### PR TITLE
Add reorgFeed in order to send Reorg blocks instead of using chainSideFeed

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -201,7 +201,7 @@ var (
 	subscriberFlags = []cli.Flag{
 		SubscriberFlag,
 		ChainEventFlag,
-		ChainSideEventFlag,
+		ReOrgBlockEventFlag,
 		TransactionEventFlag,
 		ReorgTransactionEventFlag,
 		KafkaPartitionFlag,

--- a/core/events.go
+++ b/core/events.go
@@ -42,3 +42,4 @@ type ChainSideEvent struct {
 }
 
 type ChainHeadEvent struct{ Block *types.Block }
+type ReorgEvent ChainHeadEvent

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -312,6 +312,10 @@ func (b *Block) SanityCheck() error {
 	return b.header.SanityCheck()
 }
 
+func (b *Block) String() string {
+	return fmt.Sprintf("{Number: %v, Hash: %v, Parent: %v, Signer: %v}", b.NumberU64(), b.Hash().Hex(), b.ParentHash().Hex(), b.Coinbase().Hex())
+}
+
 type writeCounter common.StorageSize
 
 func (c *writeCounter) Write(b []byte) (int, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -226,6 +226,10 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 	return b.eth.BlockChain().SubscribeLogsEvent(ch)
 }
 
+func (b *EthAPIBackend) SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subscription {
+	return b.eth.BlockChain().SubscribeReorgEvent(ch)
+}
+
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	return b.eth.txPool.AddLocal(signedTx)
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -85,6 +85,7 @@ type Backend interface {
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
+	SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subscription
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -232,6 +232,10 @@ func (b *LesApiBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 	return b.eth.blockchain.SubscribeLogsEvent(ch)
 }
 
+func (b *LesApiBackend) SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subscription {
+	return b.eth.blockchain.SubscribeReorgEvent(ch)
+}
+
 func (b *LesApiBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription {
 	return event.NewSubscription(func(quit <-chan struct{}) error {
 		<-quit

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -573,6 +573,12 @@ func (lc *LightChain) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
 	return lc.scope.Track(new(event.Feed).Subscribe(ch))
 }
 
+// SubscribeReorgEvent implements the interface of subscribe reorg event
+// LightChain does not do reorg, so return an empty subscription.
+func (lc *LightChain) SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subscription {
+	return lc.scope.Track(new(event.Feed).Subscribe(ch))
+}
+
 // DisableCheckFreq disables header validation. This is used for ultralight mode.
 func (lc *LightChain) DisableCheckFreq() {
 	atomic.StoreInt32(&lc.disableCheckFreq, 1)


### PR DESCRIPTION
Before, I used **ChainSideFeed** to send reorg event. However, this is not correct. **ChainSideFeed** is triggered when **Canonical chain** turns into a **Side chain** (1) or **Side Chain** failed on validating to be a **Canonical chain** (2), where (2) happens a lot. 

For example, current block has total difficulty larger than received blocks from another node, then all received blocks will be sent to **ChainSideFeed** where they are not reorg blocks.

Reorg is only happened when (1) happens and `newBlock.parentHash != currentBlock.Hash`.
Therefore, I added an addition event called **reorgFeed** which is used only when `reorg` function is triggered

This PR makes reorg events would be more correct than before
