### PR TITLE
Add coolDownDuration to reduce stress to jobChan

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -219,7 +219,7 @@ var (
 		BlockConfirmedEventFlag,
 		TransactionConfirmedEventFlag,
 		LogsConfirmedEventFlag,
-		ConfirmBlockAtFlag,
+		SafeBlockRangeFlag,
 		CoolDownDurationFlag,
 	}
 )


### PR DESCRIPTION
When too many data added to jobChan, it can easily reach its limit and will cause bottleneck here when many routines waiting for for each other. Therefore, it would cost memory and could make the whole system go slow or even down. Therefore, I added another flag called `coolDownDuration` to cool down jobChan a bit if it reaches its limitation.