### PR TITLE
Add eventFeed that publish start, done and failed event in downloader…

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -234,6 +234,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
+	// Subscribe all downloading events for txPool
+	eth.handler.downloader.SubscribeStartEvent(eth.txPool.StartDownloadCh)
+	eth.handler.downloader.SubscribeFailedEvent(eth.txPool.DownloadFailedCh)
+	eth.handler.downloader.SubscribeDoneEvent(eth.txPool.DoneCh)
+
 	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")


### PR DESCRIPTION
**Background**
Sometimes, a validator is out-dated and it needs time to sync blocks. However, it still receives transactions from bridge and start mining. This will lead to invalid blocks and some transactions might be dropped or be out-dated or wait a lot of time to be executed.

**Solution**
Add eventFeed that publish start, done and failed event in downloader and subscribe them on txPool to identify whether node is downloading and vice versa. If it's downloading, then transaction is dropped