### PR TITLE
Implement readiness endpoint

### DIFF
--- a/cmd/ronin/config.go
+++ b/cmd/ronin/config.go
@@ -178,7 +178,7 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 
 	// Configure health check if requested
 	if ctx.GlobalIsSet(utils.ReadinessEnabledFlag.Name) {
-	    utils.RegisterReadinessService(stack, backend, cfg.Node)
+	    utils.RegisterReadinessService(stack, ctx)
 	}
 	// Add the Ethereum Stats daemon if requested.
 	if cfg.Ethstats.URL != "" {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -630,8 +630,9 @@ var (
 	ReadinessPrometheusEndpointFlag = cli.StringFlag{
 		Name:  "readiness.prometheus",
 		Usage: "Prometheus address for collecting metric",
+		Value: "localhost:9090",
 	}
-	ReadinessBlockLagFlag = cli.IntFlag{
+	ReadinessBlockLagFlag = cli.Int64Flag{
     Name: "readiness.block.lag",
     Usage: "The block lag for deciding the readiness is success or fail",
     Value: 50,
@@ -1251,12 +1252,6 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(InsecureUnlockAllowedFlag.Name) {
 		cfg.InsecureUnlockAllowed = ctx.GlobalBool(InsecureUnlockAllowedFlag.Name)
 	}
-	if ctx.GlobalIsSet(ReadinessPrometheusEndpointFlag.Name) {
-	    cfg.ReadinessPrometheusEndpoint = ctx.GlobalString(ReadinessPrometheusEndpointFlag.Name)
-	}
-	if ctx.GlobalIsSet(ReadinessBlockLagFlag.Name) {
-	    cfg.ReadinessBlockLag = ctx.GlobalInt(ReadinessBlockLagFlag.Name)
-	}
 }
 
 func setSmartCard(ctx *cli.Context, cfg *node.Config) {
@@ -1762,8 +1757,8 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.C
 }
 
 // RegisterGraphQLService is a utility function to construct a new service and register it against a node.
-func RegisterReadinessService(stack *node.Node, backend ethapi.Backend, cfg node.Config) {
-    if err := NewReadinessHandler(stack, backend, []string{"*"}, []string{"*"}, cfg.ReadinessPrometheusEndpoint, cfg.ReadinessBlockLag); err != nil {
+func RegisterReadinessService(stack *node.Node, ctx *cli.Context) {
+    if err := NewReadinessHandler(stack, []string{"*"}, []string{"*"}, ctx.GlobalString(ReadinessPrometheusEndpointFlag.Name), ctx.GlobalInt64(ReadinessBlockLagFlag.Name)); err != nil {
         Fatalf("Failed to register the Readiness service: %v", err)
     }
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -50,7 +50,7 @@ import (
 var (
 	headBlockGauge     = metrics.NewRegisteredGauge("chain/head/block", nil)
 	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
-	HeadFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil) // need to export.
+	HeadFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)
 
 	accountReadTimer   = metrics.NewRegisteredTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredTimer("chain/account/hashes", nil)

--- a/node/config.go
+++ b/node/config.go
@@ -190,9 +190,6 @@ type Config struct {
 
 	// AllowUnprotectedTxs allows non EIP-155 protected transactions to be send over RPC.
 	AllowUnprotectedTxs bool `toml:",omitempty"`
-
-	ReadinessPrometheusEndpoint string
-	ReadinessBlockLag int
 }
 
 // IPCEndpoint resolves an IPC endpoint based on a configured value, taking into


### PR DESCRIPTION
**Description**: 
Implement a new endpoint for checking readiness based on comparing the current block lag with the threshold block lag
For enabling this, passing those params

```--readiness --readiness.prometheus 0.0.0.0:9090 --readiness.block.lag 50```

**Logic**:
It will base on the Prometheus metrics for checking the lag between the current max block number and current block number, If this lag is smaller than the configured threshold it returns 200 otherwise returns 500.

For avoiding a single failure point, we will return 200 in case the Prometheus endpoint is unreachable. We will add more mechanisms for making it more stable like using the secondary database as a backup solution for Prometheues.

**Local Test** 
High Block Lag 
```
INFO [02-15|16:00:17.329] readiness enabled                        url=http://[::]:8545/readiness
INFO [02-15|16:00:19.453] [Readiness] Current block number statics Max head=11,110,239 Current Block=105,915 current Lag=11,004,324
```
```curl -v localhost:8545/readiness
*   Trying ::1:8545...
* Connected to localhost (::1) port 8545 (#0)
> GET /readiness HTTP/1.1
> Host: localhost:8545
> User-Agent: curl/7.77.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json; charset=utf-8
< Vary: Origin
< X-Content-Type-Options: nosniff
< Date: Tue, 15 Feb 2022 09:00:19 GMT
< Content-Length: 47
<
* Connection #0 to host localhost left intact
{"error": "Block lag is larger than threshold"}```
```
Unreachable Prometheus

```curl -v localhost:8545/readiness
*   Trying ::1:8545...
* Connected to localhost (::1) port 8545 (#0)
> GET /readiness HTTP/1.1
> Host: localhost:8545
> User-Agent: curl/7.77.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Vary: Origin
< X-Content-Type-Options: nosniff
< Date: Tue, 15 Feb 2022 09:01:15 GMT
< Content-Length: 35
<
* Connection #0 to host localhost left intact
{"error": "Unreachable Prometheus"}%```
