### PR TITLE
Disable all RPC signing methods by default (add CLI flag version)

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -35,6 +35,7 @@ const managerSubBufferSize = 50
 // is removed in favor of Clef.
 type Config struct {
 	InsecureUnlockAllowed bool // Whether account unlocking in insecure environment is allowed
+	EnableSigningMethods  bool // Enable RPC signing methods
 }
 
 // newBackendEvent lets the manager know it should

--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -179,6 +179,7 @@ var (
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
 		utils.InsecureUnlockAllowedFlag,
+		utils.EnableSigningMethodsFlag,
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalEVMTimeoutFlag,
 		utils.RPCGlobalTxFeeCapFlag,

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -128,6 +128,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.PasswordFileFlag,
 			utils.ExternalSignerFlag,
 			utils.InsecureUnlockAllowedFlag,
+			utils.EnableSigningMethodsFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -497,6 +497,10 @@ var (
 		Name:  "allow-insecure-unlock",
 		Usage: "Allow insecure account unlocking when account-related RPCs are exposed by http",
 	}
+	EnableSigningMethodsFlag = cli.BoolFlag{
+		Name:  "enable-signing-methods",
+		Usage: "Enable RPC signing methods",
+	}
 	RPCGlobalGasCapFlag = cli.Uint64Flag{
 		Name:  "rpc.gascap",
 		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)",
@@ -1312,6 +1316,9 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(InsecureUnlockAllowedFlag.Name) {
 		cfg.InsecureUnlockAllowed = ctx.GlobalBool(InsecureUnlockAllowedFlag.Name)
+	}
+	if ctx.GlobalIsSet(EnableSigningMethodsFlag.Name) {
+		cfg.EnableSigningMethods = ctx.GlobalBool(EnableSigningMethodsFlag.Name)
 	}
 }
 

--- a/node/config.go
+++ b/node/config.go
@@ -87,6 +87,9 @@ type Config struct {
 	// InsecureUnlockAllowed allows user to unlock accounts in unsafe http environment.
 	InsecureUnlockAllowed bool `toml:",omitempty"`
 
+	// Enable RPC signing methods.
+	EnableSigningMethods bool `toml:",omitempty"`
+
 	// NoUSB disables hardware wallet monitoring and connectivity.
 	// Deprecated: USB monitoring is disabled by default and must be enabled explicitly.
 	NoUSB bool `toml:",omitempty"`

--- a/node/node.go
+++ b/node/node.go
@@ -121,7 +121,12 @@ func New(conf *Config) (*Node, error) {
 	node.keyDirTemp = isEphem
 	// Creates an empty AccountManager with no backends. Callers (e.g. cmd/geth)
 	// are required to add the backends later on.
-	node.accman = accounts.NewManager(&accounts.Config{InsecureUnlockAllowed: conf.InsecureUnlockAllowed})
+	node.accman = accounts.NewManager(
+		&accounts.Config{
+			InsecureUnlockAllowed: conf.InsecureUnlockAllowed,
+			EnableSigningMethods:  conf.EnableSigningMethods,
+		},
+	)
 
 	// Initialize the p2p server. This creates the node key and discovery databases.
 	node.server.Config.PrivateKey = node.config.NodeKey()


### PR DESCRIPTION
We disable all signing methods that use node's private key by default. Also, we
introduce an cli flag for enabling those methods again when needed,
--enable-signing-methods.

These methods are not supported by default

	eth_signTransaction
	eth_resend
	eth_sendTransaction
	eth_sign
	personal_sendTransaction
	personal_signTransaction
	personal_sign
	personal_signAndSendTransaction
	debug_testSignCliqueBlock