### PR TITLE
Exit when there is an error in entrypoint.sh

### DIFF
--- a/docker/chainnode/entrypoint.sh
+++ b/docker/chainnode/entrypoint.sh
@@ -21,6 +21,8 @@ params=""
 syncmode="snap"
 mine="true"
 
+set -e
+
 if [[ ! -z $DATA_DIR ]]; then
   datadir="$DATA_DIR"
 fi


### PR DESCRIPTION
Add `set -e` in bash script so that when there is an error in bash command, the
entrypoint.sh exits immediately.