### PR TITLE
fix: update validators generated code

### DIFF
--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -32,10 +32,8 @@ type ContractIntegrator struct {
 	validatorSC *validators.Validators
 }
 
-func NewContractIntegrator(config *chainParams.ChainConfig, ee *ethapi.PublicBlockChainAPI) (*ContractIntegrator, error) {
-	backend := NewConsortiumBackend(ee)
-
-	validatorSC, err := validators.NewValidators(config.ConsortiumV2Contracts.ValidatorSC, &backend)
+func NewContractIntegrator(config *chainParams.ChainConfig, backend bind.ContractBackend) (*ContractIntegrator, error) {
+	validatorSC, err := validators.NewValidators(config.ConsortiumV2Contracts.ValidatorSC, backend)
 	if err != nil {
 		return nil, err
 	}
@@ -239,8 +237,8 @@ type ConsortiumBackend struct {
 	ee *ethapi.PublicBlockChainAPI
 }
 
-func NewConsortiumBackend(ee *ethapi.PublicBlockChainAPI) ConsortiumBackend {
-	return ConsortiumBackend{
+func NewConsortiumBackend(ee *ethapi.PublicBlockChainAPI) *ConsortiumBackend {
+	return &ConsortiumBackend{
 		ee,
 	}
 }

--- a/consensus/consortium/v1/consortium.go
+++ b/consensus/consortium/v1/consortium.go
@@ -716,7 +716,7 @@ func (c *Consortium) signerInTurn(signer common.Address, number uint64, validato
 }
 
 func (c *Consortium) initContract() error {
-	contract, err := consortiumCommon.NewContractIntegrator(c.chainConfig, c.ethAPI)
+	contract, err := consortiumCommon.NewContractIntegrator(c.chainConfig, consortiumCommon.NewConsortiumBackend(c.ethAPI))
 	if err != nil {
 		return err
 	}

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -715,7 +715,7 @@ func (c *Consortium) getValidatorsFromHeader(header *types.Header) []common.Addr
 }
 
 func (c *Consortium) initContract() error {
-	contract, err := consortiumCommon.NewContractIntegrator(c.chainConfig, c.ethAPI)
+	contract, err := consortiumCommon.NewContractIntegrator(c.chainConfig, consortiumCommon.NewConsortiumBackend(c.ethAPI))
 	if err != nil {
 		return err
 	}

--- a/core/systemcontracts/generated_contracts/validators/main.go
+++ b/core/systemcontracts/generated_contracts/validators/main.go
@@ -30,7 +30,7 @@ var (
 
 // ValidatorsMetaData contains all meta data concerning the Validators contract.
 var ValidatorsMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"currentValidatorSet\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"consensusAddress\",\"type\":\"address\"},{\"internalType\":\"addresspayable\",\"name\":\"feeAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"totalAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"jailTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reward\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"currentValidatorSetMap\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"valAddr\",\"type\":\"address\"}],\"name\":\"depositReward\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLastUpdated\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"updateValidators\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"consensusAddress\",\"type\":\"address\"},{\"internalType\":\"addresspayable\",\"name\":\"feeAddress\",\"type\":\"address\"}],\"name\":\"addNode\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"currentValidatorSet\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"consensusAddress\",\"type\":\"address\"},{\"internalType\":\"addresspayable\",\"name\":\"feeAddress\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"totalAmount\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"jailTime\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"reward\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"currentValidatorSetMap\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"valAddr\",\"type\":\"address\"}],\"name\":\"depositReward\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLastUpdated\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getValidators\",\"outputs\":[{\"internalType\":\"address[]\",\"name\":\"\",\"type\":\"address[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"updateValidators\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
 // ValidatorsABI is the input ABI used to generate the binding from.
@@ -330,6 +330,27 @@ func (_Validators *ValidatorsSession) GetValidators() ([]common.Address, error) 
 // Solidity: function getValidators() view returns(address[])
 func (_Validators *ValidatorsCallerSession) GetValidators() ([]common.Address, error) {
 	return _Validators.Contract.GetValidators(&_Validators.CallOpts)
+}
+
+// AddNode is a paid mutator transaction binding the contract method 0xdb8ec38c.
+//
+// Solidity: function addNode(address consensusAddress, address feeAddress) returns()
+func (_Validators *ValidatorsTransactor) AddNode(opts *bind.TransactOpts, consensusAddress common.Address, feeAddress common.Address) (*types.Transaction, error) {
+	return _Validators.contract.Transact(opts, "addNode", consensusAddress, feeAddress)
+}
+
+// AddNode is a paid mutator transaction binding the contract method 0xdb8ec38c.
+//
+// Solidity: function addNode(address consensusAddress, address feeAddress) returns()
+func (_Validators *ValidatorsSession) AddNode(consensusAddress common.Address, feeAddress common.Address) (*types.Transaction, error) {
+	return _Validators.Contract.AddNode(&_Validators.TransactOpts, consensusAddress, feeAddress)
+}
+
+// AddNode is a paid mutator transaction binding the contract method 0xdb8ec38c.
+//
+// Solidity: function addNode(address consensusAddress, address feeAddress) returns()
+func (_Validators *ValidatorsTransactorSession) AddNode(consensusAddress common.Address, feeAddress common.Address) (*types.Transaction, error) {
+	return _Validators.Contract.AddNode(&_Validators.TransactOpts, consensusAddress, feeAddress)
 }
 
 // DepositReward is a paid mutator transaction binding the contract method 0x6ffa4dc1.


### PR DESCRIPTION
- Add `addNode` function to support adding new nodes
- Change `NewContractIntegrator` param from `*ConsortiumBackend` to `bind.ContractBackend` interface to make it more flexible (we can adapt different backends lately)