### PR TITLE
Run FinalizeAndAssemble only on validator node

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1031,13 +1031,15 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 // commit runs any post-transaction state modifications, assembles the final block
 // and commits new work if consensus engine is running.
 func (w *worker) commit(uncles []*types.Header, interval func(), update bool, start time.Time) error {
-	// Deep copy receipts here to avoid interaction between different tasks.
-	s := w.current.state.Copy()
-	block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, w.current.header, s, w.current.txs, uncles, w.current.receipts)
-	if err != nil {
-		return err
-	}
 	if w.isRunning() {
+		// Deep copy receipts here to avoid interaction between different tasks.
+		receiptsCpy := copyReceipts(w.current.receipts)
+		s := w.current.state.Copy()
+		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, w.current.header, s, w.current.txs, uncles, receiptsCpy)
+		if err != nil {
+			return err
+		}
+
 		if interval != nil {
 			interval()
 		}


### PR DESCRIPTION
We accept that the system transactions will not be in the pending state so it is unnecessary to call FinalizeAndAssemble in non-validator node. Move this call to be called only on validator node