### PR TITLE
Make copy of block header when passing it to FinalizeAndAssemble

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1035,7 +1035,7 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 		// Deep copy receipts here to avoid interaction between different tasks.
 		receiptsCpy := copyReceipts(w.current.receipts)
 		s := w.current.state.Copy()
-		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, w.current.header, s, w.current.txs, uncles, receiptsCpy)
+		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, types.CopyHeader(w.current.header), s, w.current.txs, uncles, receiptsCpy)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As default, an empty block without applying any transactions in transaction pool is committed for sealing. Later, if there is no pending transactions in pool, that empty block is inserted. Otherwise, another block is committed.

As we currently pass block header as a pointer to FinalizeAndAssemble, that block header can be edited twice because it goes through FinalizeAndAssemble twice. This leads to system transactions' gas used is accumulated twice, later results in the mismatch between local and remote block's gas used calculation. We fix this issue by make a copy of block header before passing it to FinalizeAndAssemble.