### PR TITLE
[RON-278] fix: failed to decode keystore key

### DIFF
--- a/docker/chainnode/entrypoint.sh
+++ b/docker/chainnode/entrypoint.sh
@@ -13,7 +13,7 @@
 # constants
 datadir="/ronin/data"
 KEYSTORE_DIR="/ronin/keystore"
-PASSWORD_FILE="$KEYSTORE_DIR/password"
+PASSWORD_FILE="/ronin/password"
 
 # variables
 genesisPath=""


### PR DESCRIPTION
https://skymavis.atlassian.net/browse/RON-278

The error occurs because the password is stored in keystore, but it is not valid
`DEBUG[10-04|04:14:12.763] Failed to decode keystore key            path=/ronin/keystore/password err="invalid character '_' looking for beginning of value"`