### PR TITLE
chore: Remove processed transactions in `demoteUnexecutables` function

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1555,6 +1555,9 @@ func (pool *TxPool) demoteUnexecutables() {
 		}
 		pendingNofundsMeter.Mark(int64(len(drops)))
 
+		// remove `olds` and `drops` out of priced list
+		pool.priced.Removed(len(olds) + len(drops))
+
 		for _, tx := range invalids {
 			hash := tx.Hash()
 			log.Trace("Demoting pending transaction", "hash", hash)


### PR DESCRIPTION
I don't think forcing reheap txPriced list everytime is a good idea, in fact, function `demoveUnexecutables` does not call `remove` priced function with `olds` and `drops` list. It could lead on missing a number of stales which lead to `Reheap` function is not triggered correctly