### PR TITLE
Change the length of epoch in consortium version 2

### DIFF
--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -205,7 +205,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 		}
 		snap.Recents[number] = validator
 		// Change the validator set base on the size of the validators set
-		if number > 0 && number%s.config.Epoch == uint64(len(snap.Validators)/2) {
+		if number > 0 && number%s.config.EpochV2 == uint64(len(snap.Validators)/2) {
 			// Get the most recent checkpoint header
 			checkpointHeader := FindAncientHeader(header, uint64(len(snap.Validators)/2), chain, parents)
 			if checkpointHeader == nil {

--- a/params/config.go
+++ b/params/config.go
@@ -410,8 +410,9 @@ func (c *CliqueConfig) String() string {
 
 // ConsortiumConfig is the consensus engine configs for proof-of-authority based sealing.
 type ConsortiumConfig struct {
-	Period uint64 `json:"period"` // Number of seconds between blocks to enforce
-	Epoch  uint64 `json:"epoch"`  // Epoch length to reset votes and checkpoint
+	Period  uint64 `json:"period"` // Number of seconds between blocks to enforce
+	Epoch   uint64 `json:"epoch"`  // Epoch length to reset votes and checkpoint
+	EpochV2 uint64 `json:"epochV2"`
 }
 
 // String implements the stringer interface, returning the consensus engine details.


### PR DESCRIPTION
The hardfork block number is assumed to be divisible to both old epoch and new epoch