### PR TITLE
Add reserved gas for system transactions

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -125,6 +125,7 @@ var (
 		utils.MinerNotifyFlag,
 		utils.LegacyMinerGasTargetFlag,
 		utils.MinerGasLimitFlag,
+		utils.MinerGasReserveFlag,
 		utils.MinerGasPriceFlag,
 		utils.MinerEtherbaseFlag,
 		utils.MinerExtraDataFlag,

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -187,6 +187,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerNotifyFullFlag,
 			utils.MinerGasPriceFlag,
 			utils.MinerGasLimitFlag,
+			utils.MinerGasReserveFlag,
 			utils.MinerEtherbaseFlag,
 			utils.MinerExtraDataFlag,
 			utils.MinerRecommitIntervalFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -450,6 +450,10 @@ var (
 		Usage: "Target gas ceiling for mined blocks",
 		Value: ethconfig.Defaults.Miner.GasCeil,
 	}
+	MinerGasReserveFlag = cli.Uint64Flag{
+		Name:  "miner.gasreserve",
+		Usage: "Reserved gas for system transactions",
+	}
 	MinerGasPriceFlag = BigFlag{
 		Name:  "miner.gasprice",
 		Usage: "Minimum gas price for mining a transaction",
@@ -1473,6 +1477,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.GlobalIsSet(MinerGasLimitFlag.Name) {
 		cfg.GasCeil = ctx.GlobalUint64(MinerGasLimitFlag.Name)
+	}
+	if ctx.GlobalIsSet(MinerGasReserveFlag.Name) {
+		cfg.GasReserve = ctx.GlobalUint64(MinerGasReserveFlag.Name)
 	}
 	if ctx.GlobalIsSet(MinerGasPriceFlag.Name) {
 		cfg.GasPrice = GlobalBig(ctx, MinerGasPriceFlag.Name)

--- a/eth/api.go
+++ b/eth/api.go
@@ -136,6 +136,11 @@ func (api *PrivateMinerAPI) SetGasLimit(gasLimit hexutil.Uint64) bool {
 	return true
 }
 
+func (api *PrivateMinerAPI) SetGasReserve(gasReserve hexutil.Uint64) bool {
+	api.e.Miner().SetGasReserve(uint64(gasReserve))
+	return true
+}
+
 // SetEtherbase sets the etherbase of the miner
 func (api *PrivateMinerAPI) SetEtherbase(etherbase common.Address) bool {
 	api.e.SetEtherbase(etherbase)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -49,6 +49,7 @@ type Config struct {
 	ExtraData  hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
 	GasFloor   uint64         // Target gas floor for mined blocks.
 	GasCeil    uint64         // Target gas ceiling for mined blocks.
+	GasReserve uint64         // Reserved gas for system transactions
 	GasPrice   *big.Int       // Minimum gas price for mining a transaction
 	Recommit   time.Duration  // The time interval for miner to re-create mining work.
 	Noverify   bool           // Disable remote mining solution verification(only useful in ethash).
@@ -214,6 +215,11 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 // For pre-1559 blocks, it sets the ceiling.
 func (miner *Miner) SetGasCeil(ceil uint64) {
 	miner.worker.setGasCeil(ceil)
+}
+
+// SetGasReserve sets the reserved gas for system transactions
+func (miner *Miner) SetGasReserve(reserve uint64) {
+	miner.worker.setGasReserve(reserve)
 }
 
 // EnablePreseal turns on the preseal mining feature. It's enabled by default.


### PR DESCRIPTION
Currently, when collecting transactions to commit to a block, we only check the accumulated gas with block's gas limit. Later, when finalizing the block, with system transactions included, the block's gas used may exceed the block's gas limit. As a result, that block is not mined. We want to avoid this scenario by introducing a new flag to reserve some gas in gas pool for system transactions.