### PR TITLE
batch all internal transactions into 1 slices before sending to internalTxFeed

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -563,7 +563,7 @@ func (c *Clique) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 // Finalize implements consensus.Engine, ensuring no uncles are set, nor block
 // rewards given.
 func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs *[]*types.Transaction,
-	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, usedGas *uint64) error {
+	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, internalTxs *[]*types.InternalTransaction, usedGas *uint64) error {
 	// No block rewards in PoA, so the state remains as is and uncles are dropped
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 	header.UncleHash = types.CalcUncleHash(nil)
@@ -576,7 +576,7 @@ func (c *Clique) Finalize(chain consensus.ChainHeaderReader, header *types.Heade
 func (c *Clique) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
 	uncles []*types.Header, receipts []*types.Receipt) (*types.Block, []*types.Receipt, error) {
 	// Finalize block
-	c.Finalize(chain, header, state, &txs, uncles, nil, nil, nil)
+	c.Finalize(chain, header, state, &txs, uncles, nil, nil, nil, nil)
 
 	// Assemble and return the final block for sealing
 	return types.NewBlock(header, txs, nil, receipts, trie.NewStackTrie(nil)), receipts, nil

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -18,6 +18,7 @@
 package consensus
 
 import (
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"math/big"
 
@@ -55,6 +56,9 @@ type ChainHeaderReader interface {
 
 	// StateCache returns currently using stateCache
 	StateCache() state.Database
+
+	// OpEvents returns list of opcode's events
+	OpEvents() []*vm.PublishEvent
 }
 
 // ChainReader defines a small collection of methods needed to access the local
@@ -98,7 +102,7 @@ type Engine interface {
 	// Note: The block header and state database might be updated to reflect any
 	// consensus rules that happen at finalization (e.g. block rewards).
 	Finalize(chain ChainHeaderReader, header *types.Header, state *state.StateDB, txs *[]*types.Transaction,
-		uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, usedGas *uint64) error
+		uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, internalTxs *[]*types.InternalTransaction, usedGas *uint64) error
 
 	// FinalizeAndAssemble runs any post-transaction state modifications (e.g. block
 	// rewards) and assembles the final block.

--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -103,12 +103,12 @@ func (c *Consortium) Prepare(chain consensus.ChainHeaderReader, header *types.He
 
 // Finalize implements consensus.Engine as a proxy
 func (c *Consortium) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs *[]*types.Transaction,
-	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, usedGas *uint64) error {
+	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, internalTxs *[]*types.InternalTransaction, usedGas *uint64) error {
 	if c.chainConfig.IsConsortiumV2(header.Number) {
-		return c.v2.Finalize(chain, header, state, txs, uncles, receipts, systemTxs, usedGas)
+		return c.v2.Finalize(chain, header, state, txs, uncles, receipts, systemTxs, internalTxs, usedGas)
 	}
 
-	return c.v1.Finalize(chain, header, state, txs, uncles, receipts, systemTxs, usedGas)
+	return c.v1.Finalize(chain, header, state, txs, uncles, receipts, systemTxs, internalTxs, usedGas)
 }
 
 // FinalizeAndAssemble implements consensus.Engine as a proxy

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -592,7 +592,7 @@ func (ethash *Ethash) Prepare(chain consensus.ChainHeaderReader, header *types.H
 // Finalize implements consensus.Engine, accumulating the block and uncle rewards,
 // setting the final state on the header
 func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs *[]*types.Transaction,
-	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, usedGas *uint64) error {
+	uncles []*types.Header, receipts *[]*types.Receipt, systemTxs *[]*types.Transaction, internalTxs *[]*types.InternalTransaction, usedGas *uint64) error {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
@@ -604,7 +604,7 @@ func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.
 func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB,
 	txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, []*types.Receipt, error) {
 	// Finalize block
-	ethash.Finalize(chain, header, state, &txs, uncles, nil, nil, nil)
+	ethash.Finalize(chain, header, state, &txs, uncles, nil, nil, nil, nil)
 
 	// Header seems complete, assemble into a block and return
 	return types.NewBlock(header, txs, uncles, receipts, trie.NewStackTrie(nil)), receipts, nil

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1624,11 +1624,16 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 
 		// Process block using the parent state as reference point
 		substart := time.Now()
-		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig, bc.OpEvents()...)
+		receipts, logs, internalTxs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig, bc.OpEvents()...)
 		if err != nil {
 			bc.reportBlock(block, receipts, err)
 			atomic.StoreUint32(&followupInterrupt, 1)
 			return it.index, err
+		}
+
+		// send internalTxs events
+		if len(internalTxs) > 0 {
+			bc.internalTxFeed.Send(internalTxs)
 		}
 
 		// Update the metrics touched during block processing

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -157,7 +157,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 		if err != nil {
 			return err
 		}
-		receipts, _, usedGas, err := blockchain.processor.Process(block, statedb, vm.Config{})
+		receipts, _, _, usedGas, err := blockchain.processor.Process(block, statedb, vm.Config{})
 		if err != nil {
 			blockchain.reportBlock(block, receipts, err)
 			return err

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -316,3 +316,4 @@ func (cr *fakeChainReader) GetHeader(hash common.Hash, number uint64) *types.Hea
 func (cr *fakeChainReader) GetBlock(hash common.Hash, number uint64) *types.Block   { return nil }
 func (cr *fakeChainReader) DB() ethdb.Database                                      { return nil }
 func (cr *fakeChainReader) StateCache() state.Database                              { return nil }
+func (cr *fakeChainReader) OpEvents() []*vm.PublishEvent                            { return nil }

--- a/core/evm.go
+++ b/core/evm.go
@@ -51,18 +51,20 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	if header.BaseFee != nil {
 		baseFee = new(big.Int).Set(header.BaseFee)
 	}
+	internalTransactions := make([]*types.InternalTransaction, 0)
 	ctx := vm.BlockContext{
-		CanTransfer:   CanTransfer,
-		Transfer:      Transfer,
-		GetHash:       GetHashFn(header, chain),
-		PublishEvents: make(map[vm.OpCode]vm.OpEvent),
-		Coinbase:      beneficiary,
-		BlockNumber:   new(big.Int).Set(header.Number),
-		Time:          new(big.Int).SetUint64(header.Time),
-		Difficulty:    new(big.Int).Set(header.Difficulty),
-		BaseFee:       baseFee,
-		GasLimit:      header.GasLimit,
-		BlockHash:     header.Hash(),
+		CanTransfer:          CanTransfer,
+		Transfer:             Transfer,
+		GetHash:              GetHashFn(header, chain),
+		PublishEvents:        make(map[vm.OpCode]vm.OpEvent),
+		Coinbase:             beneficiary,
+		BlockNumber:          new(big.Int).Set(header.Number),
+		Time:                 new(big.Int).SetUint64(header.Time),
+		Difficulty:           new(big.Int).Set(header.Difficulty),
+		BaseFee:              baseFee,
+		GasLimit:             header.GasLimit,
+		BlockHash:            header.Hash(),
+		InternalTransactions: &internalTransactions,
 	}
 	// update publishEvents if `events` is not empty
 	if len(events) > 0 {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"math"
 	"math/big"
 	mrand "math/rand"
@@ -630,5 +631,9 @@ func (hc *HeaderChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 }
 
 func (hc *HeaderChain) StateCache() state.Database {
+	return nil
+}
+
+func (hc *HeaderChain) OpEvents() []*vm.PublishEvent {
 	return nil
 }

--- a/core/types.go
+++ b/core/types.go
@@ -47,5 +47,5 @@ type Processor interface {
 	// Process processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb and applying any rewards to both
 	// the processor (coinbase) and any included uncles.
-	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, publishEvents ...*vm.PublishEvent) (types.Receipts, []*types.Log, uint64, error)
+	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, publishEvents ...*vm.PublishEvent) (types.Receipts, []*types.Log, []*types.InternalTransaction, uint64, error)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -642,6 +642,11 @@ const (
 	InternalTransactionContractCreation = "create"
 )
 
+type InternalTransactions struct {
+	BlockNumber  uint64
+	Transactions []*InternalTransaction
+}
+
 type InternalTransaction struct {
 	Opcode  string `rlp:"-"`
 	Type    string `rlp:"-"`
@@ -656,9 +661,9 @@ type InternalTransaction struct {
 	To              common.Address
 
 	// block info
-	Height          uint64
-	BlockHash       common.Hash
-	BlockTime       uint64
+	Height    uint64
+	BlockHash common.Hash
+	BlockTime uint64
 }
 
 func (internal *InternalTransaction) Hash() common.Hash {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -642,11 +642,6 @@ const (
 	InternalTransactionContractCreation = "create"
 )
 
-type InternalTransactions struct {
-	BlockNumber  uint64
-	Transactions []*InternalTransaction
-}
-
 type InternalTransaction struct {
 	Opcode  string `rlp:"-"`
 	Type    string `rlp:"-"`

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -239,7 +239,7 @@ func (b *EthAPIBackend) SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Sub
 	return b.eth.BlockChain().SubscribeReorgEvent(ch)
 }
 
-func (b *EthAPIBackend) SubscribeInternalTransactionEvent(ch chan<- types.InternalTransaction) event.Subscription {
+func (b *EthAPIBackend) SubscribeInternalTransactionEvent(ch chan<- []*types.InternalTransaction) event.Subscription {
 	return b.eth.blockchain.SubscribeInternalTransactionEvent(ch)
 }
 

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -131,7 +131,7 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 		if current = eth.blockchain.GetBlockByNumber(next); current == nil {
 			return nil, fmt.Errorf("block #%d not found", next)
 		}
-		_, _, _, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{})
+		_, _, _, _, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{})
 		if err != nil {
 			return nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -91,7 +91,7 @@ type Backend interface {
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subscription
-	SubscribeInternalTransactionEvent(ch chan<- types.InternalTransaction) event.Subscription
+	SubscribeInternalTransactionEvent(ch chan<- []*types.InternalTransaction) event.Subscription
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -262,7 +262,7 @@ func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEven
 	return b.eth.blockchain.SubscribeRemovedLogsEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeInternalTransactionEvent(ch chan<- types.InternalTransaction) event.Subscription {
+func (b *LesApiBackend) SubscribeInternalTransactionEvent(ch chan<- []*types.InternalTransaction) event.Subscription {
 	return b.eth.blockchain.SubscribeInternalTransactionEvent(ch)
 }
 

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -21,6 +21,7 @@ package light
 import (
 	"context"
 	"errors"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -223,6 +224,10 @@ func (lc *LightChain) Genesis() *types.Block {
 }
 
 func (lc *LightChain) StateCache() state.Database {
+	panic("not implemented")
+}
+
+func (lc *LightChain) OpEvents() []*vm.PublishEvent {
 	panic("not implemented")
 }
 
@@ -572,7 +577,7 @@ func (lc *LightChain) SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subsc
 	return lc.scope.Track(new(event.Feed).Subscribe(ch))
 }
 
-func (lc *LightChain) SubscribeInternalTransactionEvent(ch chan<- types.InternalTransaction) event.Subscription {
+func (lc *LightChain) SubscribeInternalTransactionEvent(ch chan<- []*types.InternalTransaction) event.Subscription {
 	return lc.scope.Track(new(event.Feed).Subscribe(ch))
 }
 


### PR DESCRIPTION
### batch all internal transactions into 1 slices before sending to internalTxFeed
- Also returns system internal transactions from consortium