### PR TITLE
feat: verify the block delay on broadcasted blocks

### DIFF
--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -220,6 +220,32 @@ func (s *Snapshot) inturn(validator common.Address) bool {
 	return validators[offset] == validator
 }
 
+// distanceToInturn returns the distance until the validator gets its turn
+// This function is only used to calculate delay time in backOffTime
+func (s *Snapshot) distanceToInturn(validator common.Address) int {
+	validators := s.validators()
+
+	validatorIndex := -1
+	for i, val := range validators {
+		if val == validator {
+			validatorIndex = i
+			break
+		}
+	}
+	// This address is not in validator list, the block is discarded later.
+	// Therefore, we return a dummy value here as the result is useless
+	if validatorIndex == -1 {
+		return 0
+	}
+
+	offset := (s.Number + 1) % uint64(len(validators))
+	if validatorIndex > int(offset) {
+		return validatorIndex - int(offset)
+	} else {
+		return len(validators) + validatorIndex - int(offset)
+	}
+}
+
 // supposeValidator returns the in-turn validator at a given block height
 func (s *Snapshot) supposeValidator() common.Address {
 	validators := s.validators()

--- a/params/config.go
+++ b/params/config.go
@@ -461,6 +461,7 @@ type ChainConfig struct {
 
 	// Puffy hardfork fix the wrong order in system transactions included in a block
 	PuffyBlock *big.Int `json:"puffyBlock,omitempty"` // Puffy switch block (nil = no fork, 0 = already on activated)
+	BubaBlock  *big.Int `json:"bubaBlock,omitempty"`  // Buba switch block (nil = no fork, 0 = already on activated)
 
 	BlacklistContractAddress      *common.Address `json:"blacklistContractAddress,omitempty"`      // Address of Blacklist Contract (nil = no blacklist)
 	FenixValidatorContractAddress *common.Address `json:"fenixValidatorContractAddress,omitempty"` // Address of Ronin Contract in the Fenix hardfork (nil = no blacklist)
@@ -552,7 +553,12 @@ func (c *ChainConfig) String() string {
 		stakingContract = c.ConsortiumV2Contracts.StakingContract
 	}
 
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Odysseus: %v, Fenix: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Engine: %v, Blacklist Contract: %v, Fenix Validator Contract: %v, ConsortiumV2: %v, ConsortiumV2.RoninValidatorSet: %v, ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v}",
+	chainConfigFmt := "{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v "
+	chainConfigFmt += "Petersburg: %v Istanbul: %v, Odysseus: %v, Fenix: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, "
+	chainConfigFmt += "Engine: %v, Blacklist Contract: %v, Fenix Validator Contract: %v, ConsortiumV2: %v, ConsortiumV2.RoninValidatorSet: %v, "
+	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v}"
+
+	return fmt.Sprintf(chainConfigFmt,
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -577,6 +583,8 @@ func (c *ChainConfig) String() string {
 		roninValidatorSetSC.Hex(),
 		slashIndicatorSC.Hex(),
 		stakingContract.Hex(),
+		c.PuffyBlock,
+		c.BubaBlock,
 	)
 }
 
@@ -678,6 +686,11 @@ func (c *ChainConfig) IsOnConsortiumV2(num *big.Int) bool {
 // IsPuffy returns whether the num is equals to or larger than the puffy fork block.
 func (c *ChainConfig) IsPuffy(num *big.Int) bool {
 	return isForked(c.PuffyBlock, num)
+}
+
+// IsPuffy returns whether the num is equals to or larger than the puffy fork block.
+func (c *ChainConfig) IsBuba(num *big.Int) bool {
+	return isForked(c.BubaBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported


### PR DESCRIPTION
This commit follows the approach of Ramanujan in BSC which includes the block
delay in block timestamp for verification on the recipients.

The block timestamp is calculated by the formula
- block timestamp = max(parent timestamp + block duration + backoff time,
  current timestamp)

The block duration is 3s in the current configuration. When the validator is
inturn, the backoff time is 0, otherwise, each out of turn validator has a
different delay.

The delay equals to
- delay = wiggle + (random multiplier * wiggle/2)

The random multiplier is in range [1, len(current validators)]. The random seed
is the block number, the recipient can use the same seed to get the same random
result for verification.