### PR TITLE
fix: avoid producing empty block when pending transactions is high

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -131,6 +131,7 @@ var (
 		utils.MinerExtraDataFlag,
 		utils.MinerRecommitIntervalFlag,
 		utils.MinerNoVerifyFlag,
+		utils.MinerBlockProduceLeftoverFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -192,6 +192,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerExtraDataFlag,
 			utils.MinerRecommitIntervalFlag,
 			utils.MinerNoVerifyFlag,
+			utils.MinerBlockProduceLeftoverFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -477,6 +477,11 @@ var (
 		Name:  "miner.noverify",
 		Usage: "Disable remote sealing verification",
 	}
+	MinerBlockProduceLeftoverFlag = cli.DurationFlag{
+		Name:  "miner.leftover",
+		Usage: "The interval block with transactions needs committing before empty block is produced",
+		Value: ethconfig.Defaults.Miner.BlockProduceLeftOver,
+	}
 	// Account settings
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
@@ -1489,6 +1494,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.GlobalIsSet(MinerNoVerifyFlag.Name) {
 		cfg.Noverify = ctx.GlobalBool(MinerNoVerifyFlag.Name)
+	}
+	if ctx.GlobalIsSet(MinerBlockProduceLeftoverFlag.Name) {
+		cfg.BlockProduceLeftOver = ctx.GlobalDuration(MinerBlockProduceLeftoverFlag.Name)
 	}
 	if ctx.GlobalIsSet(LegacyMinerGasTargetFlag.Name) {
 		log.Warn("The generic --miner.gastarget flag is deprecated and will be removed in the future!")

--- a/eth/api.go
+++ b/eth/api.go
@@ -152,6 +152,11 @@ func (api *PrivateMinerAPI) SetRecommitInterval(interval int) {
 	api.e.Miner().SetRecommitInterval(time.Duration(interval) * time.Millisecond)
 }
 
+// SetBlockProducerLeftover updates the interval for block producer leftover in milliseconds
+func (api *PrivateMinerAPI) SetBlockProducerLeftover(interval int) {
+	api.e.Miner().SetBlockProducerLeftover(time.Duration(interval) * time.Millisecond)
+}
+
 // PrivateAdminAPI is the collection of Ethereum full node-related APIs
 // exposed over the private admin endpoint.
 type PrivateAdminAPI struct {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -18,14 +18,15 @@
 package ethconfig
 
 import (
-	"github.com/ethereum/go-ethereum/consensus/consortium"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"math/big"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
 	"time"
+
+	"github.com/ethereum/go-ethereum/consensus/consortium"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -85,9 +86,10 @@ var Defaults = Config{
 	TrieTimeout:             60 * time.Minute,
 	SnapshotCache:           102,
 	Miner: miner.Config{
-		GasCeil:  8000000,
-		GasPrice: big.NewInt(params.GWei),
-		Recommit: 3 * time.Second,
+		GasCeil:              8000000,
+		GasPrice:             big.NewInt(params.GWei),
+		Recommit:             3 * time.Second,
+		BlockProduceLeftOver: 200 * time.Millisecond,
 	},
 	TxPool:        core.DefaultTxPoolConfig,
 	RPCGasCap:     50000000,

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -43,16 +43,17 @@ type Backend interface {
 
 // Config is the configuration parameters of mining.
 type Config struct {
-	Etherbase  common.Address `toml:",omitempty"` // Public address for block mining rewards (default = first account)
-	Notify     []string       `toml:",omitempty"` // HTTP URL list to be notified of new work packages (only useful in ethash).
-	NotifyFull bool           `toml:",omitempty"` // Notify with pending block headers instead of work packages
-	ExtraData  hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
-	GasFloor   uint64         // Target gas floor for mined blocks.
-	GasCeil    uint64         // Target gas ceiling for mined blocks.
-	GasReserve uint64         // Reserved gas for system transactions
-	GasPrice   *big.Int       // Minimum gas price for mining a transaction
-	Recommit   time.Duration  // The time interval for miner to re-create mining work.
-	Noverify   bool           // Disable remote mining solution verification(only useful in ethash).
+	Etherbase            common.Address `toml:",omitempty"` // Public address for block mining rewards (default = first account)
+	Notify               []string       `toml:",omitempty"` // HTTP URL list to be notified of new work packages (only useful in ethash).
+	NotifyFull           bool           `toml:",omitempty"` // Notify with pending block headers instead of work packages
+	ExtraData            hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
+	GasFloor             uint64         // Target gas floor for mined blocks.
+	GasCeil              uint64         // Target gas ceiling for mined blocks.
+	GasReserve           uint64         // Reserved gas for system transactions
+	GasPrice             *big.Int       // Minimum gas price for mining a transaction
+	Recommit             time.Duration  // The time interval for miner to re-create mining work.
+	Noverify             bool           // Disable remote mining solution verification(only useful in ethash).
+	BlockProduceLeftOver time.Duration
 }
 
 // Miner creates blocks and searches for proof-of-work values.
@@ -220,6 +221,10 @@ func (miner *Miner) SetGasCeil(ceil uint64) {
 // SetGasReserve sets the reserved gas for system transactions
 func (miner *Miner) SetGasReserve(reserve uint64) {
 	miner.worker.setGasReserve(reserve)
+}
+
+func (miner *Miner) SetBlockProducerLeftover(interval time.Duration) {
+	miner.worker.setBlockProducerLeftover(interval)
 }
 
 // EnablePreseal turns on the preseal mining feature. It's enabled by default.


### PR DESCRIPTION
This commit adapts BSC PR: https://github.com/bnb-chain/bsc/pull/112 to Ronin.

An empty block is pre-sealed by default. It's expected that a new block with
transactions is committed and abort the empty block producer if there are
pending transactions. However, with the low block time, in case there are a lot
of pending transactions, the commit transactions time exceeds the time an empty
block is produced. As a result, block with transactions is not produced but an
empty block and no real transactions is mined.