### PR TITLE
chore: add error log for FinalizeAndAssemble error

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1097,6 +1097,7 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 		// As consortium does not use uncles, we don't care about copying uncles here
 		block, receipts, err := w.engine.FinalizeAndAssemble(w.chain, env.header, env.state, env.txs, uncles, env.receipts)
 		if err != nil {
+			log.Error("Failed to FinalizeAndAssemble a block", "error", err)
 			return err
 		}
 


### PR DESCRIPTION
When FinalizeAndAssemble returns error, the caller functions does not check and log anything which causes difficulty when debugging. This commit adds a simple error log.