### PR TITLE
fix: improve the bloom filter calculation

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -85,7 +85,7 @@ func (v *BlockValidator) ValidateState(block *types.Block, statedb *state.StateD
 	}
 	// Validate the received block's bloom with the one derived from the generated receipts.
 	// For valid blocks this should always validate to true.
-	rbloom := types.CreateBloom(receipts)
+	rbloom := types.MergeBloom(receipts)
 	if rbloom != header.Bloom {
 		return fmt.Errorf("invalid bloom (remote: %x  local: %x)", header.Bloom, rbloom)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -103,7 +103,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), len(b.txs))
-	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+	receipt, _, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, NewReceiptBloomGenerator())
 	if err != nil {
 		panic(err)
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -205,7 +205,7 @@ func NewBlock(header *Header, txs []*Transaction, uncles []*Header, receipts []*
 		b.header.ReceiptHash = EmptyRootHash
 	} else {
 		b.header.ReceiptHash = DeriveSha(Receipts(receipts), hasher)
-		b.header.Bloom = CreateBloom(receipts)
+		b.header.Bloom = MergeBloom(receipts)
 	}
 
 	if len(uncles) == 0 {

--- a/core/types/bloom9.go
+++ b/core/types/bloom9.go
@@ -117,6 +117,23 @@ func CreateBloom(receipts Receipts) Bloom {
 	return bin
 }
 
+// MergeBloom assumes all receipts contain calculated bloom filters and
+// merge them to create the final bloom filter instead of recalculating
+// like CreateBloom
+func MergeBloom(receipts Receipts) Bloom {
+	rawBloom := make([]byte, BloomByteLength)
+	for _, receipt := range receipts {
+		if len(receipt.Logs) != 0 {
+			bl := receipt.Bloom.Bytes()
+			for i := range rawBloom {
+				rawBloom[i] = rawBloom[i] | bl[i]
+			}
+		}
+	}
+
+	return BytesToBloom(rawBloom)
+}
+
 // LogsBloom returns the bloom bytes for the given logs
 func LogsBloom(logs []*Log) []byte {
 	buf := make([]byte, 6)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -559,6 +559,10 @@ func (t *TransactionsByPriceAndNonce) Pop() {
 	heap.Pop(&t.heads)
 }
 
+func (t *TransactionsByPriceAndNonce) Size() int {
+	return t.heads.Len()
+}
+
 // Message is a fully derived transaction and implements core.Message
 //
 // NOTE: In a future PR this will be removed.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -79,7 +79,7 @@ type blockExecutionEnv struct {
 func (env *blockExecutionEnv) commitTransaction(tx *types.Transaction, coinbase common.Address) error {
 	vmconfig := *env.chain.GetVMConfig()
 	snap := env.state.Snapshot()
-	receipt, _, err := core.ApplyTransaction(env.chain.Config(), env.chain, &coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vmconfig)
+	receipt, _, err := core.ApplyTransaction(env.chain.Config(), env.chain, &coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vmconfig, core.NewReceiptBloomGenerator())
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		return err


### PR DESCRIPTION
- fix: correct the usage of AsyncReceiptBloomGenerator
AsyncReceiptBloomGenerator allows us the calculating bloom asynchronously with the caller, in this case the caller is applyTransaction. As a result, we don't need to CreateBloom in applyTransaction.
- feat: merge calculated blooms in receipts instead of recalculating
When all receipts have the calculated bloom filters, we can get the final bloom
filter by ORing them instead of looping through logs in receipts and
recalculating all things.
- test: add MergeBloom unit test and benchmark