### PR TITLE
fix: prevent malicious miners from bypassing system transaction check

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -150,7 +150,7 @@ func (c *Consortium) IsSystemTransaction(tx *types.Transaction, header *types.He
 	if err != nil {
 		return false, errors.New("UnAuthorized transaction")
 	}
-	if sender == header.Coinbase && c.IsSystemContract(tx.To()) && tx.GasPrice().Cmp(big.NewInt(0)) == 0 {
+	if sender == header.Coinbase && c.IsSystemContract(tx.To()) {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
Remove the condition that checks the transaction's gas price is 0 in system transaction check. This makes all transactions created by miners to core DPoS contracts system transactions and must go through verification on receiving nodes.