### PR TITLE
fix: add hardfork logic to system transaction check

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -150,8 +150,14 @@ func (c *Consortium) IsSystemTransaction(tx *types.Transaction, header *types.He
 	if err != nil {
 		return false, errors.New("UnAuthorized transaction")
 	}
-	if sender == header.Coinbase && c.IsSystemContract(tx.To()) {
-		return true, nil
+	if c.chainConfig.IsBuba(header.Number) {
+		if sender == header.Coinbase && c.IsSystemContract(tx.To()) {
+			return true, nil
+		}
+	} else {
+		if sender == header.Coinbase && c.IsSystemContract(tx.To()) && tx.GasPrice().Cmp(big.NewInt(0)) == 0 {
+			return true, nil
+		}
 	}
 	return false, nil
 }


### PR DESCRIPTION
We only restrict the system transaction check when buba hardfork happens.