### PR TITLE
fix: duplicate logs returned by StateProcessor.Process

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -109,7 +109,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		if err != nil {
 			return nil, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
-		allLogs = append(allLogs, receipt.Logs...)
 
 		commonTxs = append(commonTxs, tx)
 		receipts = append(receipts, receipt)


### PR DESCRIPTION
As we will collect all logs from the receipts after finalizing the block, we must remove the log appending in each transaction to avoid duplication.