### PR TITLE
fix: try to load snapshot from disk at forked block before calculating

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -320,6 +320,12 @@ func (c *Consortium) snapshot(chain consensus.ChainHeaderReader, number uint64, 
 				err        error
 				validators []common.Address
 			)
+			snap, err = loadSnapshot(c.config, c.signatures, c.db, hash, c.ethAPI, c.chainConfig)
+			if err == nil {
+				log.Trace("Loaded snapshot from disk", "number", number, "hash", hash.Hex())
+				break
+			}
+
 			// get validators set from number
 			validators, err = c.contract.GetValidators(big.NewInt(0).SetUint64(number))
 			if err != nil {


### PR DESCRIPTION
When trying get snapshot at forked block - 1, we call to contract to get state at that block which may not be available when chain head is ahead of that block. When that snapshot is calculated the first time (chain head is at that block, so the calculation always succeeds), we store that snapshot persistently to the disk. So, later query to that snapshot, we only need to load it from disk without re-calculating.