### PR TITLE
fix: get dirty accounts from stateObjectsDirty instead of stateObjects

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1057,19 +1057,23 @@ func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addre
 
 func (s *StateDB) DirtyAccounts(hash common.Hash, number uint64) []types.DirtyStateAccount {
 	dirtyAccounts := make([]types.DirtyStateAccount, 0)
-	for addr, obj := range s.stateObjects {
-		acc := obj.data
-		dirtyAccounts = append(dirtyAccounts, types.DirtyStateAccount{
-			Address:     addr,
-			Nonce:       acc.Nonce,
-			Balance:     acc.Balance.String(),
-			Root:        acc.Root,
-			CodeHash:    common.BytesToHash(acc.CodeHash),
-			BlockNumber: number,
-			BlockHash:   hash,
-			Deleted:     obj.deleted,
-			Suicided:    obj.suicided,
-		})
+	for addr := range s.stateObjectsDirty {
+		if obj, exist := s.stateObjects[addr]; exist {
+			acc := obj.data
+			dirtyAccounts = append(dirtyAccounts, types.DirtyStateAccount{
+				Address:     addr,
+				Nonce:       acc.Nonce,
+				Balance:     acc.Balance.String(),
+				Root:        acc.Root,
+				CodeHash:    common.BytesToHash(acc.CodeHash),
+				BlockNumber: number,
+				BlockHash:   hash,
+				Deleted:     obj.deleted,
+				Suicided:    obj.suicided,
+				DirtyCode:   obj.dirtyCode,
+			})
+		}
+
 	}
 
 	return dirtyAccounts

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -32,13 +32,14 @@ type StateAccount struct {
 }
 
 type DirtyStateAccount struct {
-	Address     common.Address
-	Nonce       uint64
-	Balance     string
-	Root        common.Hash // merkle root of the storage trie
-	CodeHash    common.Hash
-	BlockNumber uint64
-	BlockHash   common.Hash
-	Deleted     bool
-	Suicided    bool
+	Address     common.Address `json:"address"`
+	Nonce       uint64         `json:"nonce"`
+	Balance     string         `json:"balance"`
+	Root        common.Hash    `json:"root"` // merkle root of the storage trie
+	CodeHash    common.Hash    `json:"codeHash"`
+	BlockNumber uint64         `json:"blockNumber"`
+	BlockHash   common.Hash    `json:"blockHash"`
+	Deleted     bool           `json:"deleted"`
+	Suicided    bool           `json:"suicided"`
+	DirtyCode   bool           `json:"dirtyCode"`
 }


### PR DESCRIPTION
Get dirty accounts from `stateObjectsDirty` instead of `stateObjects`