### PR TITLE
fix: header's hash calculation in verifying double sign proof

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -85,10 +85,6 @@ type BlockHeader struct {
 	Nonce            uint64         `abi:"nonce"`
 }
 
-func (h *BlockHeader) Hash() common.Hash {
-	return rlpHash(h)
-}
-
 func FromHeader(header *Header, chainId *big.Int) *BlockHeader {
 	blockHeader := &BlockHeader{
 		ChainId:     chainId,

--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -405,6 +405,13 @@ func (c *consortiumVerifyHeaders) getSigner(header types.BlockHeader) (common.Ad
 	if err != nil {
 		return common.Address{}, err
 	}
+	r := new(big.Int).SetBytes(signature[:32])
+	s := new(big.Int).SetBytes(signature[32:64])
+	v := signature[64]
+	if !crypto.ValidateSignatureValues(v, r, s, true) {
+		return common.Address{}, err
+	}
+
 	var signer common.Address
 	copy(signer[:], crypto.Keccak256(pubkey[1:])[12:])
 

--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -415,6 +415,9 @@ func (c *consortiumVerifyHeaders) verify(header1, header2 types.BlockHeader) boo
 	if header1.ToHeader().ParentHash.Hex() != header2.ToHeader().ParentHash.Hex() {
 		return false
 	}
+	if len(header1.ExtraData) < crypto.SignatureLength || len(header2.ExtraData) < crypto.SignatureLength {
+		return false
+	}
 	if bytes.Equal(SealHash(header1.ToHeader(), header1.ChainId).Bytes(), SealHash(header2.ToHeader(), header2.ChainId).Bytes()) {
 		return false
 	}

--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -414,7 +415,7 @@ func (c *consortiumVerifyHeaders) verify(header1, header2 types.BlockHeader) boo
 	if header1.ToHeader().ParentHash.Hex() != header2.ToHeader().ParentHash.Hex() {
 		return false
 	}
-	if header1.Hash() == header2.Hash() {
+	if bytes.Equal(SealHash(header1.ToHeader(), header1.ChainId).Bytes(), SealHash(header2.ToHeader(), header2.ChainId).Bytes()) {
 		return false
 	}
 	signer1, err := c.getSigner(header1)

--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -683,6 +683,11 @@ func TestConsortiumVerifyHeaders_verify(t *testing.T) {
 	if c.verify(*types.FromHeader(header1, big1), *types.FromHeader(header1, big1)) {
 		t.Fatal("expected false, got true")
 	}
+
+	header1.Extra = nil
+	if c.verify(*types.FromHeader(header1, big1), *types.FromHeader(header2, big1)) {
+		t.Fatal("expected false, got true")
+	}
 }
 
 // TestConsortiumVerifyHeaders_Run init 2 headers, pack them and call `Run` function directly

--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -727,6 +727,51 @@ func TestConsortiumVerifyHeaders_Run(t *testing.T) {
 	}
 }
 
+func TestConsortiumVerifyHeaders_malleability(t *testing.T) {
+	n, _ := new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
+
+	header1, _, err := prepareHeader(big1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sig1 []byte = make([]byte, crypto.SignatureLength)
+	nbytes := copy(sig1, header1.Extra[len(header1.Extra)-crypto.SignatureLength:])
+	if nbytes != crypto.SignatureLength {
+		t.Fatal("copy signature from header1 failed")
+	}
+	var header2 *types.Header = types.CopyHeader(header1)
+
+	var sig2 []byte = make([]byte, crypto.SignatureLength)
+	copy(sig2, sig1)
+	s1 := new(big.Int).SetBytes(sig1[32:64])
+	var s2 *big.Int = new(big.Int)
+	s2.Sub(n, s1)
+	nbytes = copy(sig2[32:], s2.Bytes())
+	if nbytes != 32 {
+		t.Fatal("copy s2 to sig2 failed")
+	}
+
+	v1 := sig1[len(sig1)-1]
+	var v2 byte
+	if v1 == 0 {
+		v2 = 1
+	} else {
+		v2 = 0
+	}
+	sig2[len(sig2)-1] = v2
+
+	nbytes = copy(header2.Extra[len(header2.Extra)-crypto.SignatureLength:], sig2)
+	if nbytes != crypto.SignatureLength {
+		t.Fatal("copy sig2 to header2 failed")
+	}
+
+	c := &consortiumVerifyHeaders{evm: &EVM{chainConfig: &params.ChainConfig{ChainID: big1}}}
+	if c.verify(*types.FromHeader(header1, big1), *types.FromHeader(header2, big1)) {
+		t.Fatal("expected false, got true")
+	}
+}
+
 // TestConsortiumVerifyHeaders_Run2 deploys smart contract and call precompiled contracts via this contract
 func TestConsortiumVerifyHeaders_Run2(t *testing.T) {
 	var (


### PR DESCRIPTION
We mistakenly calculate hash on the whole header which contains the signature. This lead to signature malleability issue as the another signature can be generated on the same block data without knowing the private key. And the check for same block data is bypassed due to calculating hash on 2 different signatures. This commit fixes the hash calculation to hash on header excluding the signature field.