### PR TITLE
refactor: change dirty account balance from string to big.Int

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1063,7 +1063,7 @@ func (s *StateDB) DirtyAccounts(hash common.Hash, number uint64) []types.DirtySt
 			dirtyAccounts = append(dirtyAccounts, types.DirtyStateAccount{
 				Address:     addr,
 				Nonce:       acc.Nonce,
-				Balance:     acc.Balance.String(),
+				Balance:     acc.Balance,
 				Root:        acc.Root,
 				CodeHash:    common.BytesToHash(acc.CodeHash),
 				BlockNumber: number,
@@ -1073,7 +1073,6 @@ func (s *StateDB) DirtyAccounts(hash common.Hash, number uint64) []types.DirtySt
 				DirtyCode:   obj.dirtyCode,
 			})
 		}
-
 	}
 
 	return dirtyAccounts

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -34,7 +34,7 @@ type StateAccount struct {
 type DirtyStateAccount struct {
 	Address     common.Address `json:"address"`
 	Nonce       uint64         `json:"nonce"`
-	Balance     string         `json:"balance"`
+	Balance     *big.Int       `json:"balance"`
 	Root        common.Hash    `json:"root"` // merkle root of the storage trie
 	CodeHash    common.Hash    `json:"codeHash"`
 	BlockNumber uint64         `json:"blockNumber"`


### PR DESCRIPTION
## Why
Change the DirtyAccount balance type from `string` to `*big.Int` to make it more transparent.