### PR TITLE
feat: monitor double signed block

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -159,6 +159,7 @@ var (
 		utils.MinerNotifyFullFlag,
 		configFileFlag,
 		utils.CatalystFlag,
+		utils.MonitorDoubleSign,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -55,6 +55,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LightKDFFlag,
 			utils.WhitelistFlag,
 			utils.ForceOverrideChainConfigFlag,
+			utils.MonitorDoubleSign,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -231,6 +231,10 @@ var (
 		Usage: "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)",
 		Value: ethconfig.Defaults.TxLookupLimit,
 	}
+	MonitorDoubleSign = cli.BoolFlag{
+		Name:  "monitor.doublesign",
+		Usage: "Enable double sign monitoring",
+	}
 	LightKDFFlag = cli.BoolFlag{
 		Name:  "lightkdf",
 		Usage: "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
@@ -1785,6 +1789,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if cfg.NetworkId == 1 {
 			SetDNSDiscoveryDefaults(cfg, params.MainnetGenesisHash)
 		}
+	}
+
+	if ctx.GlobalBool(MonitorDoubleSign.Name) {
+		cfg.EnableMonitorDoubleSign = true
 	}
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -20,13 +20,14 @@ package eth
 import (
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/consensus/consortium"
-	"github.com/ethereum/go-ethereum/core/state"
 	"math/big"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum/go-ethereum/consensus/consortium"
+	"github.com/ethereum/go-ethereum/core/state"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -198,6 +199,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)
 	if err != nil {
 		return nil, err
+	}
+	if config.EnableMonitorDoubleSign {
+		go eth.blockchain.StartDoubleSignMonitor()
 	}
 
 	// Rewind the chain in case of an incompatible config upgrade.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -208,6 +208,9 @@ type Config struct {
 
 	// Arrow Glacier block override (TODO: remove after the fork)
 	OverrideArrowGlacier *big.Int `toml:",omitempty"`
+
+	// Enable double sign monitoring
+	EnableMonitorDoubleSign bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/monitor/double_sign.go
+++ b/monitor/double_sign.go
@@ -1,0 +1,54 @@
+package monitor
+
+import (
+	"bytes"
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	lru "github.com/hashicorp/golang-lru"
+)
+
+const monitorBlockRange = 20
+
+type DoubleSignMonitor struct {
+	observerdBlocks *lru.Cache
+}
+
+func NewDoubleSignMonitor() (*DoubleSignMonitor, error) {
+	observerdBlocks, err := lru.New(monitorBlockRange)
+	if err != nil {
+		return nil, err
+	}
+	monitor := DoubleSignMonitor{
+		observerdBlocks: observerdBlocks,
+	}
+
+	return &monitor, nil
+}
+
+func getSignature(blockHeader *types.Header) string {
+	signature := blockHeader.Extra[len(blockHeader.Extra)-crypto.SignatureLength:]
+	return "0x" + hex.EncodeToString(signature)
+}
+
+func (monitor *DoubleSignMonitor) CheckDoubleSign(blockHeader *types.Header) {
+	if rawBlockHeader, ok := monitor.observerdBlocks.Get(blockHeader.ParentHash); ok {
+		blockHeaders, _ := rawBlockHeader.([]*types.Header)
+		for _, header := range blockHeaders {
+			// Simple check for monitoring only
+			if !bytes.Equal(header.Hash().Bytes(), blockHeader.Hash().Bytes()) &&
+				bytes.Equal(header.Coinbase[:], blockHeader.Coinbase[:]) {
+				log.Error("Double sign detected", "block number", header.Number, "signer", header.Coinbase,
+					"block 1 hash", header.Hash().Hex(), "block 1 signature", getSignature(header),
+					"block 2 hash", blockHeader.Hash().Hex(), "block 2 signature", getSignature(blockHeader),
+				)
+				break
+			}
+		}
+	} else {
+		blockHeaders := []*types.Header{blockHeader}
+		monitor.observerdBlocks.Add(blockHeader.ParentHash, blockHeaders)
+	}
+}


### PR DESCRIPTION
Add a new --monitor.doublesign parameter to Ronin node. When running node with this parameter, a goroutine is created to watch new written block to canonical and side chain to detect double signed broadcasted block.