### PR TITLE
fix: use block hash instead of parent hash in dirty account

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1198,7 +1198,7 @@ func (bc *BlockChain) writeKnownBlock(block *types.Block) error {
 }
 
 // WriteBlockWithState writes the block and all associated state to the database.
-func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, dirtyAccounts []types.DirtyStateAccount, err error) {
+func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, dirtyAccounts []*types.DirtyStateAccount, err error) {
 	if !bc.chainmu.TryLock() {
 		return NonStatTy, nil, errInsertionInterrupted
 	}
@@ -1208,7 +1208,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 
 // writeBlockWithState writes the block and all associated state to the database,
 // but is expects the chain mutex to be held.
-func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, dirtyAccounts []types.DirtyStateAccount, err error) {
+func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, dirtyAccounts []*types.DirtyStateAccount, err error) {
 	if bc.insertStopped() {
 		return NonStatTy, nil, errInsertionInterrupted
 	}
@@ -1236,7 +1236,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		log.Crit("Failed to write block into disk", "err", err)
 	}
 	// Commit all cached state changes into underlying memory database.
-	dirtyAccounts = state.DirtyAccounts(block.ParentHash(), block.NumberU64())
+	dirtyAccounts = state.DirtyAccounts(block.Hash(), block.NumberU64())
 	root, err := state.Commit(bc.chainConfig.IsEIP158(block.Number()))
 	if err != nil {
 		return NonStatTy, nil, err

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -396,7 +396,7 @@ func (bc *BlockChain) SubscribeInternalTransactionEvent(ch chan<- []*types.Inter
 	return bc.scope.Track(bc.internalTxFeed.Subscribe(ch))
 }
 
-func (bc *BlockChain) SubscribeDirtyAccountEvent(ch chan<- []types.DirtyStateAccount) event.Subscription {
+func (bc *BlockChain) SubscribeDirtyAccountEvent(ch chan<- []*types.DirtyStateAccount) event.Subscription {
 	return bc.scope.Track(bc.dirtyAccountFeed.Subscribe(ch))
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1055,12 +1055,12 @@ func (s *StateDB) SlotInAccessList(addr common.Address, slot common.Hash) (addre
 	return s.accessList.Contains(addr, slot)
 }
 
-func (s *StateDB) DirtyAccounts(hash common.Hash, number uint64) []types.DirtyStateAccount {
-	dirtyAccounts := make([]types.DirtyStateAccount, 0)
+func (s *StateDB) DirtyAccounts(hash common.Hash, number uint64) []*types.DirtyStateAccount {
+	dirtyAccounts := make([]*types.DirtyStateAccount, 0)
 	for addr := range s.stateObjectsDirty {
 		if obj, exist := s.stateObjects[addr]; exist {
 			acc := obj.data
-			dirtyAccounts = append(dirtyAccounts, types.DirtyStateAccount{
+			dirtyAccounts = append(dirtyAccounts, &types.DirtyStateAccount{
 				Address:     addr,
 				Nonce:       acc.Nonce,
 				Balance:     acc.Balance,

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -243,7 +243,7 @@ func (b *EthAPIBackend) SubscribeInternalTransactionEvent(ch chan<- []*types.Int
 	return b.eth.blockchain.SubscribeInternalTransactionEvent(ch)
 }
 
-func (b *EthAPIBackend) SubscribeDirtyAccountEvent(ch chan<- []types.DirtyStateAccount) event.Subscription {
+func (b *EthAPIBackend) SubscribeDirtyAccountEvent(ch chan<- []*types.DirtyStateAccount) event.Subscription {
 	return b.eth.blockchain.SubscribeDirtyAccountEvent(ch)
 }
 

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -196,9 +196,9 @@ type txTraceResult struct {
 
 // txTraceResult2 is the result of a single transaction trace.
 type internalAndAccountResult struct {
-	InternalTxs   []*txTraceResult          `json:"internalTxs,omitempty"` // Trace results produced by the tracer
-	DirtyAccounts []types.DirtyStateAccount `json:"dirtyAccounts,omitempty"`
-	Error         string                    `json:"error,omitempty"` // Trace failure produced by the tracer
+	InternalTxs   []*txTraceResult           `json:"internalTxs,omitempty"` // Trace results produced by the tracer
+	DirtyAccounts []*types.DirtyStateAccount `json:"dirtyAccounts,omitempty"`
+	Error         string                     `json:"error,omitempty"` // Trace failure produced by the tracer
 }
 
 // blockTraceTask represents a single block trace task when an entire chain is
@@ -684,7 +684,7 @@ func (api *API) traceInternalsAndAccounts(ctx context.Context, block *types.Bloc
 		txs     = block.Transactions()
 		results = &internalAndAccountResult{
 			InternalTxs:   make([]*txTraceResult, len(txs)),
-			DirtyAccounts: make([]types.DirtyStateAccount, 0),
+			DirtyAccounts: make([]*types.DirtyStateAccount, 0),
 		}
 
 		pend = new(sync.WaitGroup)

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -92,7 +92,7 @@ type Backend interface {
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeReorgEvent(ch chan<- core.ReorgEvent) event.Subscription
 	SubscribeInternalTransactionEvent(ch chan<- []*types.InternalTransaction) event.Subscription
-	SubscribeDirtyAccountEvent(ch chan<- []types.DirtyStateAccount) event.Subscription
+	SubscribeDirtyAccountEvent(ch chan<- []*types.DirtyStateAccount) event.Subscription
 
 	ChainConfig() *params.ChainConfig
 	Engine() consensus.Engine

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -266,7 +266,7 @@ func (b *LesApiBackend) SubscribeInternalTransactionEvent(ch chan<- []*types.Int
 	return b.eth.blockchain.SubscribeInternalTransactionEvent(ch)
 }
 
-func (b *LesApiBackend) SubscribeDirtyAccountEvent(ch chan<- []types.DirtyStateAccount) event.Subscription {
+func (b *LesApiBackend) SubscribeDirtyAccountEvent(ch chan<- []*types.DirtyStateAccount) event.Subscription {
 	return b.eth.blockchain.SubscribeDirtyAccountEvent(ch)
 }
 

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -581,7 +581,7 @@ func (lc *LightChain) SubscribeInternalTransactionEvent(ch chan<- []*types.Inter
 	return lc.scope.Track(new(event.Feed).Subscribe(ch))
 }
 
-func (lc *LightChain) SubscribeDirtyAccountEvent(ch chan<- []types.DirtyStateAccount) event.Subscription {
+func (lc *LightChain) SubscribeDirtyAccountEvent(ch chan<- []*types.DirtyStateAccount) event.Subscription {
 	return lc.scope.Track(new(event.Feed).Subscribe(ch))
 }
 


### PR DESCRIPTION
- Use BlockHash instead of ParentHash in DirtyAccount
- Convert []DirtyStateAccount to []*DirtyStateAccount