### PR TITLE
fix: invalid account root traceAPI

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -537,6 +537,10 @@ func (s *stateObject) Balance() *big.Int {
 	return s.data.Balance
 }
 
+func (s *stateObject) Root() common.Hash {
+	return s.data.Root
+}
+
 func (s *stateObject) Nonce() uint64 {
 	return s.data.Nonce
 }

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -527,7 +527,7 @@ func TestTraceInternalsAndAccounts_BatchTransferAccounts(t *testing.T) {
 			t.Errorf("account %v not found", actual.Address)
 		}
 
-		if actual.Balance.Cmp(expectedBalance) != 0 {
+		if actual.Balance.ToInt().Cmp(expectedBalance) != 0 {
 			t.Errorf("account balance is not match got %v, wanted %v", actual.Balance, expectedBalance)
 		}
 	}
@@ -630,7 +630,7 @@ func TestTraceInternalsAndAccounts_CreateContract(t *testing.T) {
 			continue
 		}
 
-		if actual.Balance.Cmp(expectedBalance) != 0 {
+		if actual.Balance.ToInt().Cmp(expectedBalance) != 0 {
 			t.Errorf("account balance is not match got %v, wanted %v", actual.Balance, expectedBalance)
 		}
 	}
@@ -733,7 +733,7 @@ func TestTraceInternalsAndAccounts_Create2Contract(t *testing.T) {
 			continue
 		}
 
-		if actual.Balance.Cmp(expectedBalance) != 0 {
+		if actual.Balance.ToInt().Cmp(expectedBalance) != 0 {
 			t.Errorf("account balance is not match got %v, wanted %v", actual.Balance, expectedBalance)
 		}
 	}


### PR DESCRIPTION
## Why
Get the current StateDB instead of using the parent StateDB since the old one is not updated so it will cause the `StateRoot` to be invalid.