### PR TITLE
ci: cancel runner jobs for previous commit of pull request

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit uses github concurrency
(https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to cancel CI running in previous commit of pull request, frees the queue for CI to run on newer commit.