### PR TITLE
feat: reduce block time of out of turn miner

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -43,6 +43,7 @@ const (
 
 	validatorBytesLength = common.AddressLength
 	wiggleTime           = 1000 * time.Millisecond // Random delay (per signer) to allow concurrent signers
+	unSealableValidator  = -1
 )
 
 // Consortium delegated proof-of-stake protocol constants.
@@ -478,7 +479,7 @@ func (c *Consortium) verifySeal(chain consensus.ChainHeaderReader, header *types
 	return nil
 }
 
-func backOffTime(header *types.Header, snapshot *Snapshot) uint64 {
+func backOffTime(header *types.Header, snapshot *Snapshot, chainConfig *params.ChainConfig) uint64 {
 	coinbase := header.Coinbase
 	if snapshot.inturn(coinbase) {
 		return 0
@@ -487,8 +488,17 @@ func backOffTime(header *types.Header, snapshot *Snapshot) uint64 {
 	position, numOfSealableValidators := snapshot.sealableValidators(coinbase)
 	// This block doesn't pass the recent check and will fail later, returns
 	// dummy value for delay here
-	if position == -1 {
+	if position == unSealableValidator {
 		return 0
+	}
+
+	initialDelay := time.Second
+	if chainConfig.IsOlek(new(big.Int).SetUint64(snapshot.Number + 1)) {
+		inturnValidator := snapshot.supposeValidator()
+		pos, _ := snapshot.sealableValidators(inturnValidator)
+		if pos == unSealableValidator {
+			initialDelay = 0
+		}
 	}
 
 	source := rand.NewSource(header.Number.Int64())
@@ -505,14 +515,18 @@ func backOffTime(header *types.Header, snapshot *Snapshot) uint64 {
 		delayMultiplier[i], delayMultiplier[j] = delayMultiplier[j], delayMultiplier[i]
 	})
 
-	return uint64((int(wiggleTime) + delayMultiplier[position]*int(wiggleTime)/2) / int(time.Second))
+	if chainConfig.IsOlek(new(big.Int).SetUint64(snapshot.Number + 1)) {
+		return uint64((int(initialDelay) + (delayMultiplier[position]-1)*int(wiggleTime)) / int(time.Second))
+	} else {
+		return uint64((int(initialDelay) + delayMultiplier[position]*int(wiggleTime)/2) / int(time.Second))
+	}
 }
 
 func (c *Consortium) computeHeaderTime(header, parent *types.Header, snapshot *Snapshot) uint64 {
 	headerTime := parent.Time + c.config.Period
 
 	if c.chainConfig.IsBuba(header.Number) {
-		headerTime += backOffTime(header, snapshot)
+		headerTime += backOffTime(header, snapshot, c.chainConfig)
 	}
 
 	if headerTime < uint64(time.Now().Unix()) {
@@ -527,7 +541,7 @@ func (c *Consortium) verifyHeaderTime(header, parent *types.Header, snapshot *Sn
 	}
 
 	if c.chainConfig.IsBuba(header.Number) {
-		expectedHeaderTime := parent.Time + c.config.Period + backOffTime(header, snapshot)
+		expectedHeaderTime := parent.Time + c.config.Period + backOffTime(header, snapshot, c.chainConfig)
 		if header.Time < expectedHeaderTime {
 			return consensus.ErrFutureBlock
 		}

--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -249,7 +249,7 @@ func (s *Snapshot) sealableValidators(validator common.Address) (position, numOf
 		}
 	}
 
-	return -1, numOfSealableValidators
+	return unSealableValidator, numOfSealableValidators
 }
 
 // supposeValidator returns the in-turn validator at a given block height

--- a/params/config.go
+++ b/params/config.go
@@ -462,6 +462,8 @@ type ChainConfig struct {
 	// Puffy hardfork fix the wrong order in system transactions included in a block
 	PuffyBlock *big.Int `json:"puffyBlock,omitempty"` // Puffy switch block (nil = no fork, 0 = already on activated)
 	BubaBlock  *big.Int `json:"bubaBlock,omitempty"`  // Buba switch block (nil = no fork, 0 = already on activated)
+	// Olek hardfork reduces the delay in block time of out of turn miner
+	OlekBlock *big.Int `json:"olekBlock,omitempty"` // Olek switch block (nil = no fork, 0 = already on activated)
 
 	BlacklistContractAddress      *common.Address `json:"blacklistContractAddress,omitempty"`      // Address of Blacklist Contract (nil = no blacklist)
 	FenixValidatorContractAddress *common.Address `json:"fenixValidatorContractAddress,omitempty"` // Address of Ronin Contract in the Fenix hardfork (nil = no blacklist)
@@ -556,7 +558,7 @@ func (c *ChainConfig) String() string {
 	chainConfigFmt := "{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v "
 	chainConfigFmt += "Petersburg: %v Istanbul: %v, Odysseus: %v, Fenix: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, "
 	chainConfigFmt += "Engine: %v, Blacklist Contract: %v, Fenix Validator Contract: %v, ConsortiumV2: %v, ConsortiumV2.RoninValidatorSet: %v, "
-	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v}"
+	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v, Olek: %v}"
 
 	return fmt.Sprintf(chainConfigFmt,
 		c.ChainID,
@@ -585,6 +587,7 @@ func (c *ChainConfig) String() string {
 		stakingContract.Hex(),
 		c.PuffyBlock,
 		c.BubaBlock,
+		c.OlekBlock,
 	)
 }
 
@@ -688,9 +691,14 @@ func (c *ChainConfig) IsPuffy(num *big.Int) bool {
 	return isForked(c.PuffyBlock, num)
 }
 
-// IsPuffy returns whether the num is equals to or larger than the puffy fork block.
+// IsBuba returns whether the num is equals to or larger than the buba fork block.
 func (c *ChainConfig) IsBuba(num *big.Int) bool {
 	return isForked(c.BubaBlock, num)
+}
+
+// IsOlek returns whether the num is equals to or larger than the olek fork block.
+func (c *ChainConfig) IsOlek(num *big.Int) bool {
+	return isForked(c.OlekBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported


### PR DESCRIPTION
This commit takes inspiration from section 5.3 BEP-172: Network Stability Enhancement On Slash Occur (https://github.com/bnb-chain/BEPs/pull/172)

When a validator is down, its block turn is mined by an out of turn miner. So when comes the turn of out of turn miner, it may not be able to produce block due to it is already in recently signed list. This leads to a series of out of turn blocks which increase the overall block time because currently out of turn block takes a least 4s. This commit allows out of turn block to take only 3s if the inturn validator is already in recently signed list.