### PR TITLE
fix: password generation inside docker entrypoint

### DIFF
--- a/docker/chainnode/entrypoint.sh
+++ b/docker/chainnode/entrypoint.sh
@@ -70,7 +70,7 @@ if [[ ! -f $PASSWORD_FILE ]]; then
     echo "$PASSWORD" > $PASSWORD_FILE
   else
     echo "No password set (or empty), generating a new one"
-    $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32} > $PASSWORD_FILE)
+    $(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c 32 > $PASSWORD_FILE)
   fi
 fi
 


### PR DESCRIPTION
It seems that password generation is broken for some time, but pr #77 makes it impossible to use any entrypoint args. `${1}` with current password generation implementation is the first entrypoint argument. At the same time we pass all entrypoint's arguments `"$@"` as extra arguments to ronin itself, thus we cannot use password length as an argument