### PR TITLE
chore: reduce log level of snapshot registration failure

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -346,7 +346,7 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 	defer h.peerWG.Done()
 
 	if err := h.peers.registerSnapExtension(peer); err != nil {
-		peer.Log().Error("Snapshot extension registration failed", "err", err)
+		peer.Log().Info("Snapshot extension registration failed", "err", err)
 		return err
 	}
 	return handler(peer)


### PR DESCRIPTION
This failure happens when a peer connects with snap protocol but does not support eth protocol. This is not so critical so we reduce the log level from error to info.