### PR TITLE
fix: handle submitBlockReward correctly when processing system transanctions

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -143,29 +143,25 @@ func New(
 	return &consortium
 }
 
-// IsSystemTransaction implements consensus.PoSA, checking whether a transaction is a system
+// IsSystemMessage implements consensus.PoSA, checking whether a transaction is a system
 // transaction or not.
 // A system transaction is a transaction that has the recipient of the contract address
 // is defined in params.ConsortiumV2Contracts
-func (c *Consortium) IsSystemTransaction(tx *types.Transaction, header *types.Header) (bool, error) {
+func (c *Consortium) IsSystemMessage(msg core.Message, header *types.Header) bool {
 	// deploy a contract
-	if tx.To() == nil {
-		return false, nil
-	}
-	sender, err := types.Sender(c.signer, tx)
-	if err != nil {
-		return false, errors.New("UnAuthorized transaction")
+	if msg.To() == nil {
+		return false
 	}
 	if c.chainConfig.IsBuba(header.Number) {
-		if sender == header.Coinbase && c.IsSystemContract(tx.To()) {
-			return true, nil
+		if msg.From() == header.Coinbase && c.IsSystemContract(msg.To()) {
+			return true
 		}
 	} else {
-		if sender == header.Coinbase && c.IsSystemContract(tx.To()) && tx.GasPrice().Cmp(big.NewInt(0)) == 0 {
-			return true, nil
+		if msg.From() == header.Coinbase && c.IsSystemContract(msg.To()) && msg.GasPrice().Cmp(big.NewInt(0)) == 0 {
+			return true
 		}
 	}
-	return false, nil
+	return false
 }
 
 // IsSystemContract implements consensus.PoSA, checking whether a contract is a system

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/consortium"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -191,6 +192,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, eth.blockchain.Config(), vm.Config{})
 		statedb.Prepare(tx.Hash(), idx)
+		consortium.HandleSubmitBlockReward(eth.engine, statedb, msg, block)
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 			return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/consensus/consortium"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -64,6 +65,7 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, leth.blockchain.Config(), vm.Config{})
+		consortium.HandleSubmitBlockReward(leth.engine, statedb, msg, block)
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
 			return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}


### PR DESCRIPTION
When getting over the DPoS hardfork, we get "insufficient funds for gas * price + value"
error when using debug API.

As the submitBlockReward is a system transaction, it's handled differently from
the normal transactions. When consensus processes submitBlockReward and there
are rewards from transaction fee in block, consensus transfers balance from
SystemAddress to miner address through the statedb.SetBalance directly. Later,
when the system transaction is created, this reward will be transfer from miner
to staking contract.

Currently, in debug API and state accessor, we treat all transactions as normal
transactions.  Without special handling, we miss the state transaction to
transfer balance from SystemAddress to miner. Consequently, when the system
transaction is processed, we get the error because there is a transfer from
miner to staking contract but we see that miner's balance is not sufficient for
the transfer.

This commit checks whether the transaction is submitBlockReward with non-zero
msg.value then adds the state transition to transfer from SystemAddress to miner
to fix the above error.

Fixes: #260 