### PR TITLE
ci: setup public pipline for master branch with nightly tag

### DIFF
--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -1,0 +1,49 @@
+name: master release
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_REPOSITORY: axieinfinity/ronin
+  DOCKER_FILE: Dockerfile
+jobs:
+  push_to_docker_registry:
+    name: Push Docker image to GHCR.IO
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: 'Checkout Repo With Submodule'
+        uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' #v3.1.0
+        with:
+          submodules: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPOSITORY }}
+          tags: |
+            type=ref,suffix=-{{sha}},event=branch
+      # Enable Registry Cache
+      - name: "Set up Docker Buildx"
+        uses: "docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325" #v2.2.1
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3 #v3.3.0
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -2,7 +2,7 @@ name: master release
 on:
   push:
     branches:
-      - main
+      - master
 
 env:
   REGISTRY: ghcr.io
@@ -45,5 +45,5 @@ jobs:
           context: .
           file: ${{ env.DOCKER_FILE }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: "nightly"
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,9 +12,6 @@ jobs:
   push_to_docker_registry:
     name: Push Docker image to GHCR.IO
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: 'Checkout Repo With Submodule'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' #v3.1.0


### PR DESCRIPTION
We need to setup the other public pipeline for main branch which supports for development phase.