### PR TITLE
fix: wrong balance update in HandleSubmitBlockReward

### DIFF
--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -213,7 +213,7 @@ func HandleSubmitBlockReward(engine consensus.Engine, statedb *state.StateDB, ms
 		if isSystemMsg && msg.Value().Cmp(common.Big0) > 0 {
 			balance := statedb.GetBalance(consensus.SystemAddress)
 			statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-			statedb.SetBalance(block.Coinbase(), balance)
+			statedb.AddBalance(block.Coinbase(), balance)
 		}
 	}
 }


### PR DESCRIPTION
We mistakenly use SetBalance instead of AddBalance to update the balance of miner when transfer the token from SystemAddress to miner. This commit corrects the balance update.