### PR TITLE
fix: abort if the private key is different from existed account

### DIFF
--- a/docker/chainnode/entrypoint.sh
+++ b/docker/chainnode/entrypoint.sh
@@ -91,16 +91,17 @@ if [[ $accountsCount -le 0 ]]; then
       --keystore $KEYSTORE_DIR \
       --password $PASSWORD_FILE
     rm ./private_key
-  else
-    echo "Creating new account"
-    ronin account new \
-      --datadir $datadir \
-      --keystore $KEYSTORE_DIR \
-      --password $PASSWORD_FILE
+    unset PRIVATE_KEY
   fi
 fi
 
-if [[ ! -z $KEYSTORE_DIR ]]; then
+accountsCount=$(
+  ronin account list --datadir $datadir  --keystore $KEYSTORE_DIR \
+  2> /dev/null \
+  | wc -l
+)
+
+if [[ $accountsCount -gt 0 ]]; then
   account=$(
     ronin account list --datadir $datadir  --keystore $KEYSTORE_DIR \
     2> /dev/null \


### PR DESCRIPTION
- fix: don't create account automatically

Currently, we automatically create account when no private key is provided and
there is not account in keystore. This behavior may lead to mistakes when
setting up node, so we remove this behavior in this commit.

- fix: abort if the private key is different from existed account

This commit creates a subcommand check in account command of Ronin to check if
the corresponding account of provided private key exist in the imported account.
When starting Ronin from entrypoint.sh, if the provided private key is different
from imported account, the process is aborted.