### PR TITLE
fix: miner does not mine its inturn block

### DIFF
--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -198,6 +198,10 @@ func (c *Consortium) IsSystemContract(to *common.Address) bool {
 	return c.v2.IsSystemContract(to)
 }
 
+func (c *Consortium) GetBestParentBlock(chain *core.BlockChain) (*types.Block, bool) {
+	return c.v2.GetBestParentBlock(chain)
+}
+
 // HandleSubmitBlockReward determines if the transaction is submitBlockReward
 // transaction with non-zero msg.value and fixes up the statedb.
 // This function bases on the fact that submitBlockReward is the only system

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -462,6 +462,9 @@ func (s *Ethereum) shouldPreserve(block *types.Block) bool {
 	if _, ok := s.engine.(*clique.Clique); ok {
 		return false
 	}
+	if _, ok := s.engine.(*consortium.Consortium); ok {
+		return false
+	}
 	return s.isLocalBlock(block)
 }
 


### PR DESCRIPTION
We have an issue that a miner A is inturn for block 10. At block 9, due to a
node is down, miner A mines the out of turn block 9 and broadcast to the
network. As a result, miner A cannot mine block 10 due to recently signed rule.
However, at block 9, there is another miner B that mines block 9' and this block
is accepted by most of nodes in the network. Then based on block 9', block 10 is
mined by miner C and there is a slash transaction for miner A because on network
view block 9 is mined by miner B not miner A. Miner A receives the chain 9' -
10 and reorgs to that chain. In theory, miner can mine the block 10' which
creates a canonical has greater difficulty. This drops the block 10 and the
slash transaction. However, currently, miner tries to mine block 11 instead of
reproducing new block 10. This leads to miner is slashed even though the node is
running well.

To fix this issue, when mining, we try to go backward on the canonical chain to
find whether we can produce a better chain. If we cannot find way to create a
better chain, we start mining based on the current head block same as current
implementation.

Fixes: https://github.com/axieinfinity/ronin/issues/266