### PR TITLE
fix: apply GetBestParentBlock only after Olek hardfork

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1019,10 +1019,12 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		parent     *types.Block
 		fastCommit bool
 	)
+
+	parent = w.chain.CurrentBlock()
 	if consortiumEngine, ok := w.engine.(*consortium.Consortium); ok {
-		parent, fastCommit = consortiumEngine.GetBestParentBlock(w.chain)
-	} else {
-		parent = w.chain.CurrentBlock()
+		if w.chainConfig.IsOlek(parent.Number()) {
+			parent, fastCommit = consortiumEngine.GetBestParentBlock(w.chain)
+		}
 	}
 
 	if parent.Time() >= uint64(timestamp) {


### PR DESCRIPTION
Strictly speaking, this logic can apply after some blocks passing the Consortium v2 hardfork so that when going backward the chain we are still on Consortium v2. This helps to avoid division by 0 error because of not being able to get validator list when not passing the Consortium v2. We intend to release this logic together with Olek hardfork so just check with Olek hardfork here for symplification.