### PR TITLE
ci: checkout repository without submodule when building image

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -16,10 +16,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: 'Checkout Repo With Submodule'
+      - name: 'Checkout Repo'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' #v3.1.0
-        with:
-          submodules: true
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: 'Checkout Repo With Submodule'
+      - name: 'Checkout Repo'
         uses: 'actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c' #v3.1.0
-        with:
-          submodules: true
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
Currently, the only submodule in Ronin is tests/testdata, this submodule is not necessary for building image. This commit removes submodule fetch when checkout repository for building image to reduce the build time.