### PR TITLE
chore: optimize sortValidators using pdqsort in golang

### DIFF
--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"math/rand"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -146,7 +146,7 @@ func (c *consortiumPickValidatorSet) Run(input []byte) ([]byte, error) {
 	candidateMap := createCandidateMap(candidates, trustedWeights)
 
 	// Sort candidates in place
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 
 	updateIsTrustedOrganizations(candidates, trustedWeights, candidateMap)
 
@@ -245,42 +245,41 @@ func (c *consortiumValidatorSorting) Run(input []byte) ([]byte, error) {
 	if len(validators) != len(weights) {
 		return nil, errors.New("balances and validators length mismatched")
 	}
-	sortValidators(validators, weights)
+	validators, weights = sortValidators(validators, weights)
 
 	log.Debug("Precompiled sorting", "validators", validators, "weights", weights)
 
 	return method.Outputs.Pack(validators)
 }
 
-func sortValidators(validators []common.Address, weights []*big.Int) {
+type SortableValidators struct {
+	validators []common.Address
+	weights    []*big.Int
+}
+
+func (s *SortableValidators) Len() int {
+	return len(s.validators)
+}
+
+func (s *SortableValidators) Less(i, j int) bool {
+	cmp := s.weights[i].Cmp(s.weights[j])
+	addrsCmp := big.NewInt(0).SetBytes(s.validators[i].Bytes()).Cmp(big.NewInt(0).SetBytes(s.validators[j].Bytes())) > 0
+	return cmp > 0 || (cmp == 0 && addrsCmp)
+}
+
+func (s *SortableValidators) Swap(i, j int) {
+	s.validators[i], s.validators[j] = s.validators[j], s.validators[i]
+	s.weights[i], s.weights[j] = s.weights[j], s.weights[i]
+}
+
+func sortValidators(validators []common.Address, weights []*big.Int) ([]common.Address, []*big.Int) {
 	if len(validators) < 2 {
-		return
+		return validators, weights
 	}
-
-	left, right := 0, len(validators)-1
-
-	pivot := rand.Int() % len(validators)
-
-	validators[pivot], validators[right] = validators[right], validators[pivot]
-	weights[pivot], weights[right] = weights[right], weights[pivot]
-
-	for i := range validators {
-		cmp := weights[i].Cmp(weights[right])
-		addrsCmp := big.NewInt(0).SetBytes(validators[i].Bytes()).Cmp(big.NewInt(0).SetBytes(validators[right].Bytes())) > 0
-		if cmp > 0 || (cmp == 0 && addrsCmp) {
-			validators[left], validators[i] = validators[i], validators[left]
-			weights[left], weights[i] = weights[i], weights[left]
-			left++
-		}
-	}
-
-	validators[left], validators[right] = validators[right], validators[left]
-	weights[left], weights[right] = weights[right], weights[left]
-
-	sortValidators(validators[:left], weights[:left])
-	sortValidators(validators[left+1:], weights[left+1:])
-
-	return
+	// start sorting validators
+	vals := &SortableValidators{validators: validators, weights: weights}
+	sort.Sort(vals)
+	return vals.validators, vals.weights
 }
 
 type SmartContractCaller struct {

--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -146,7 +146,7 @@ func (c *consortiumPickValidatorSet) Run(input []byte) ([]byte, error) {
 	candidateMap := createCandidateMap(candidates, trustedWeights)
 
 	// Sort candidates in place
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 
 	updateIsTrustedOrganizations(candidates, trustedWeights, candidateMap)
 
@@ -245,7 +245,7 @@ func (c *consortiumValidatorSorting) Run(input []byte) ([]byte, error) {
 	if len(validators) != len(weights) {
 		return nil, errors.New("balances and validators length mismatched")
 	}
-	validators, weights = sortValidators(validators, weights)
+	sortValidators(validators, weights)
 
 	log.Debug("Precompiled sorting", "validators", validators, "weights", weights)
 
@@ -272,14 +272,14 @@ func (s *SortableValidators) Swap(i, j int) {
 	s.weights[i], s.weights[j] = s.weights[j], s.weights[i]
 }
 
-func sortValidators(validators []common.Address, weights []*big.Int) ([]common.Address, []*big.Int) {
+func sortValidators(validators []common.Address, weights []*big.Int) {
 	if len(validators) < 2 {
-		return validators, weights
+		return
 	}
 	// start sorting validators
 	vals := &SortableValidators{validators: validators, weights: weights}
 	sort.Sort(vals)
-	return vals.validators, vals.weights
+	return
 }
 
 type SmartContractCaller struct {

--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -571,7 +571,7 @@ func TestSort(t *testing.T) {
 		big.NewInt(1),
 	}
 
-	addrs, totalBalances = sortValidators(addrs, totalBalances)
+	sortValidators(addrs, totalBalances)
 	for i, val := range addrs {
 		if expectedBalances[i].Cmp(totalBalances[i]) != 0 {
 			t.Fatal(fmt.Sprintf("mismatched balance at %d, expected:%s got:%s", i, expectedBalances[i].String(), totalBalances[i].String()))
@@ -876,7 +876,7 @@ func TestArrangeValidatorCandidates(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -923,7 +923,7 @@ func TestArrangeValidatorCandidates_RandomTrustedOrganizations(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
@@ -972,7 +972,7 @@ func TestArrangeValidatorCandidates_Max5Prioritized(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -1019,7 +1019,7 @@ func TestArrangeValidatorCandidates_Miss5Nodes(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -1084,7 +1084,7 @@ func TestArrangeValidatorCandidates_Has15TrustedNodes(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -1154,7 +1154,7 @@ func TestArrangeValidatorCandidates_TrustedNodesAtBeginningArray(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	candidates, weights = sortValidators(candidates, weights)
+	sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 

--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -571,7 +571,7 @@ func TestSort(t *testing.T) {
 		big.NewInt(1),
 	}
 
-	sortValidators(addrs, totalBalances)
+	addrs, totalBalances = sortValidators(addrs, totalBalances)
 	for i, val := range addrs {
 		if expectedBalances[i].Cmp(totalBalances[i]) != 0 {
 			t.Fatal(fmt.Sprintf("mismatched balance at %d, expected:%s got:%s", i, expectedBalances[i].String(), totalBalances[i].String()))
@@ -876,7 +876,7 @@ func TestArrangeValidatorCandidates(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -923,7 +923,7 @@ func TestArrangeValidatorCandidates_RandomTrustedOrganizations(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
@@ -972,7 +972,7 @@ func TestArrangeValidatorCandidates_Max5Prioritized(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -1019,7 +1019,7 @@ func TestArrangeValidatorCandidates_Miss5Nodes(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -1084,7 +1084,7 @@ func TestArrangeValidatorCandidates_Has15TrustedNodes(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 
@@ -1154,7 +1154,7 @@ func TestArrangeValidatorCandidates_TrustedNodesAtBeginningArray(t *testing.T) {
 	maxPrioritizedValidatorNumber := big.NewInt(11)
 
 	candidateMap := createCandidateMap(candidates, isTrustedOrganizations)
-	sortValidators(candidates, weights)
+	candidates, weights = sortValidators(candidates, weights)
 	updateIsTrustedOrganizations(candidates, isTrustedOrganizations, candidateMap)
 	arrangeValidatorCandidates(candidates, newValidatorCount, isTrustedOrganizations, maxPrioritizedValidatorNumber)
 


### PR DESCRIPTION
## Purpose
Golang from v1.18 has more powerful sort algorithm call pdqsort instead of quicksort. Therefore, I change the current implement (quicksort) to built-in sort which is using pdqsort