### PR TITLE
fix: use slots to check queued, pending transactions limit

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -146,22 +146,26 @@ func (m *txSortedMap) filter(filter func(*types.Transaction) bool) types.Transac
 	return removed
 }
 
-// Cap places a hard limit on the number of items, returning all transactions
+// Cap places a hard limit on the total slots of items, returning all transactions
 // exceeding that limit.
 func (m *txSortedMap) Cap(threshold int) types.Transactions {
 	// Short circuit if the number of items is under the limit
-	if len(m.items) <= threshold {
+	if m.totalslots <= threshold {
 		return nil
 	}
 	// Otherwise gather and drop the highest nonce'd transactions
-	var drops types.Transactions
+	var (
+		drops types.Transactions
+		size  int
+	)
 
 	sort.Sort(*m.index)
-	for size := len(m.items); size > threshold; size-- {
+	for size = len(m.items); m.totalslots > threshold; size-- {
 		drops = append(drops, m.items[(*m.index)[size-1]])
+		m.totalslots -= numSlots(m.items[(*m.index)[size-1]])
 		delete(m.items, (*m.index)[size-1])
 	}
-	*m.index = (*m.index)[:threshold]
+	*m.index = (*m.index)[:size]
 	heap.Init(m.index)
 
 	// If we had a cache, shift the back

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1414,25 +1414,48 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 	return promoted
 }
 
+// removeLastPendingTransaction removes the highest nonce transaction of the sender from
+// the pending transactions, returns the number of transaction slot of that transaction
+func (pool *TxPool) removeLastPendingTransaction(sender common.Address) uint64 {
+	list := pool.pending[sender]
+
+	// Remove the transaction with highest nonce
+	lastTx := list.LastElement()
+	list.Remove(lastTx)
+
+	// Drop the transaction from the global pools too
+	pool.all.Remove(lastTx.Hash())
+	// Update the account nonce to the dropped transaction
+	pool.pendingNonces.setIfLower(sender, lastTx.Nonce())
+	log.Trace("Removed fairness-exceeding pending transaction", "hash", lastTx.Hash())
+
+	pool.priced.Removed(1)
+	pendingGauge.Dec(1)
+	if pool.locals.contains(sender) {
+		localGauge.Dec(1)
+	}
+	return uint64(numSlots(lastTx))
+}
+
 // truncatePending removes transactions from the pending queue if the pool is above the
 // pending limit. The algorithm tries to reduce transaction counts by an approximately
 // equal number for all for accounts with many pending transactions.
 func (pool *TxPool) truncatePending() {
 	pending := uint64(0)
+	droppedTxs := 0
 	for _, list := range pool.pending {
-		pending += uint64(list.Len())
+		pending += uint64(list.TotalSlots())
 	}
 	if pending <= pool.config.GlobalSlots {
 		return
 	}
 
-	pendingBeforeCap := pending
 	// Assemble a spam order to penalize large transactors first
 	spammers := prque.New(nil)
 	for addr, list := range pool.pending {
 		// Only evict transactions from high rollers
-		if !pool.locals.contains(addr) && uint64(list.Len()) > pool.config.AccountSlots {
-			spammers.Push(addr, int64(list.Len()))
+		if !pool.locals.contains(addr) && uint64(list.TotalSlots()) > pool.config.AccountSlots {
+			spammers.Push(addr, int64(list.TotalSlots()))
 		}
 	}
 	// Gradually drop transactions from offenders
@@ -1445,29 +1468,23 @@ func (pool *TxPool) truncatePending() {
 		// Equalize balances until all the same or below threshold
 		if len(offenders) > 1 {
 			// Calculate the equalization threshold for all current offenders
-			threshold := pool.pending[offender.(common.Address)].Len()
+			threshold := pool.pending[offender.(common.Address)].TotalSlots()
 
 			// Iteratively reduce all offenders until below limit or threshold reached
-			for pending > pool.config.GlobalSlots && pool.pending[offenders[len(offenders)-2]].Len() > threshold {
+			for pending > pool.config.GlobalSlots {
+				lowerThanThreshold := 0
 				for i := 0; i < len(offenders)-1; i++ {
-					list := pool.pending[offenders[i]]
-
-					caps := list.Cap(list.Len() - 1)
-					for _, tx := range caps {
-						// Drop the transaction from the global pools too
-						hash := tx.Hash()
-						pool.all.Remove(hash)
-
-						// Update the account nonce to the dropped transaction
-						pool.pendingNonces.setIfLower(offenders[i], tx.Nonce())
-						log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
+					if pool.pending[offenders[i]].TotalSlots() <= threshold {
+						lowerThanThreshold++
+						continue
 					}
-					pool.priced.Removed(len(caps))
-					pendingGauge.Dec(int64(len(caps)))
-					if pool.locals.contains(offenders[i]) {
-						localGauge.Dec(int64(len(caps)))
-					}
-					pending--
+
+					pending -= pool.removeLastPendingTransaction(offenders[i])
+					droppedTxs++
+				}
+
+				if lowerThanThreshold == len(offenders)-1 {
+					break
 				}
 			}
 		}
@@ -1475,37 +1492,30 @@ func (pool *TxPool) truncatePending() {
 
 	// If still above threshold, reduce to limit or min allowance
 	if pending > pool.config.GlobalSlots && len(offenders) > 0 {
-		for pending > pool.config.GlobalSlots && uint64(pool.pending[offenders[len(offenders)-1]].Len()) > pool.config.AccountSlots {
+		for pending > pool.config.GlobalSlots {
+			lowerThanThreshold := 0
 			for _, addr := range offenders {
-				list := pool.pending[addr]
-
-				caps := list.Cap(list.Len() - 1)
-				for _, tx := range caps {
-					// Drop the transaction from the global pools too
-					hash := tx.Hash()
-					pool.all.Remove(hash)
-
-					// Update the account nonce to the dropped transaction
-					pool.pendingNonces.setIfLower(addr, tx.Nonce())
-					log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
+				if uint64(pool.pending[addr].TotalSlots()) <= pool.config.AccountSlots {
+					lowerThanThreshold++
+					continue
 				}
-				pool.priced.Removed(len(caps))
-				pendingGauge.Dec(int64(len(caps)))
-				if pool.locals.contains(addr) {
-					localGauge.Dec(int64(len(caps)))
-				}
-				pending--
+				pending -= pool.removeLastPendingTransaction(addr)
+				droppedTxs++
+			}
+
+			if lowerThanThreshold == len(offenders) {
+				break
 			}
 		}
 	}
-	pendingRateLimitMeter.Mark(int64(pendingBeforeCap - pending))
+	pendingRateLimitMeter.Mark(int64(droppedTxs))
 }
 
 // truncateQueue drops the oldes transactions in the queue if the pool is above the global queue limit.
 func (pool *TxPool) truncateQueue() {
 	queued := uint64(0)
 	for _, list := range pool.queue {
-		queued += uint64(list.Len())
+		queued += uint64(list.TotalSlots())
 	}
 	if queued <= pool.config.GlobalQueue {
 		return
@@ -1521,26 +1531,26 @@ func (pool *TxPool) truncateQueue() {
 	sort.Sort(sort.Reverse(addresses))
 
 	// Drop transactions until the total is below the limit or only locals remain
-	for drop := queued - pool.config.GlobalQueue; drop > 0 && len(addresses) > 0; {
+	for drop := int(queued - pool.config.GlobalQueue); drop > 0 && len(addresses) > 0; {
 		addr := addresses[len(addresses)-1]
 		list := pool.queue[addr.address]
 
 		addresses = addresses[:len(addresses)-1]
 
 		// Drop all transactions if they are less than the overflow
-		if size := uint64(list.Len()); size <= drop {
+		if list.TotalSlots() <= drop {
 			for _, tx := range list.Flatten() {
 				pool.removeTx(tx.Hash(), true)
 			}
-			drop -= size
-			queuedRateLimitMeter.Mark(int64(size))
+			drop -= list.TotalSlots()
+			queuedRateLimitMeter.Mark(int64(list.Len()))
 			continue
 		}
 		// Otherwise drop only last few transactions
 		txs := list.Flatten()
 		for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
 			pool.removeTx(txs[i].Hash(), true)
-			drop--
+			drop -= numSlots(txs[i])
 			queuedRateLimitMeter.Mark(1)
 		}
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -376,12 +376,17 @@ func (pool *TxPool) loop() {
 		// Handle stats reporting ticks
 		case <-report.C:
 			pool.mu.RLock()
-			pending, queued := pool.stats()
+			pending, queued, pendingSlots, queuedSlots := pool.stats()
 			pool.mu.RUnlock()
 			stales := int(atomic.LoadInt64(&pool.priced.stales))
 
 			if pending != prevPending || queued != prevQueued || stales != prevStales {
-				log.Debug("Transaction pool status report", "executable", pending, "queued", queued, "stales", stales)
+				log.Debug(
+					"Transaction pool status report",
+					"executable", pending, "executable slots", pendingSlots,
+					"queued", queued, "queued slots", queuedSlots,
+					"stales", stales,
+				)
 				prevPending, prevQueued, prevStales = pending, queued, stales
 			}
 
@@ -476,27 +481,35 @@ func (pool *TxPool) Nonce(addr common.Address) uint64 {
 	return pool.pendingNonces.get(addr)
 }
 
-// Stats retrieves the current pool stats, namely the number of pending and the
-// number of queued (non-executable) transactions.
-func (pool *TxPool) Stats() (int, int) {
+// Stats retrieves the current pool stats, namely the number of pending transations,
+// slots, and the number of queued (non-executable) transactions, slots.
+func (pool *TxPool) Stats() (int, int, int, int) {
 	pool.mu.RLock()
 	defer pool.mu.RUnlock()
 
 	return pool.stats()
 }
 
-// stats retrieves the current pool stats, namely the number of pending and the
-// number of queued (non-executable) transactions.
-func (pool *TxPool) stats() (int, int) {
+// stats retrieves the current pool stats, namely the number of pending transactions,
+// slots and the number of queued (non-executable) transactions, slots.
+func (pool *TxPool) stats() (int, int, int, int) {
 	pending := 0
 	for _, list := range pool.pending {
 		pending += list.Len()
+	}
+	pendingSlots := 0
+	for _, list := range pool.pending {
+		pendingSlots += list.TotalSlots()
 	}
 	queued := 0
 	for _, list := range pool.queue {
 		queued += list.Len()
 	}
-	return pending, queued
+	queuedSlots := 0
+	for _, list := range pool.queue {
+		queuedSlots += list.TotalSlots()
+	}
+	return pending, queued, pendingSlots, queuedSlots
 }
 
 // Content retrieves the data content of the transaction pool, returning all the

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1182,6 +1182,93 @@ func TestTransactionPendingGlobalLimiting(t *testing.T) {
 	}
 }
 
+// Test if the queued transaction slots per account or by total
+// go beyond the threshold, then transactions are dropped to prevent
+// DOS.
+func TestSlotsLimit(t *testing.T) {
+	t.Parallel()
+
+	pool, _ := setupTxPool()
+	defer pool.Stop()
+
+	pool.config.GlobalQueue = uint64(6)
+	pool.config.AccountQueue = uint64(4)
+
+	// Create a number of test accounts and fund them
+	keys := make([]*ecdsa.PrivateKey, 2)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000000))
+	}
+
+	// Compute maximal data size for transactions (lower bound).
+	//
+	// It is assumed the fields in the transaction (except of the data) are:
+	//   - nonce     <= 32 bytes
+	//   - gasPrice  <= 32 bytes
+	//   - gasLimit  <= 32 bytes
+	//   - recipient == 20 bytes
+	//   - value     <= 32 bytes
+	//   - signature == 65 bytes
+	// All those fields are summed up to at most 213 bytes.
+	baseSize := uint64(213)
+	dataSize := txMaxSize - baseSize
+	maxGas := pool.currentMaxGas
+
+	tx := pricedDataTransaction(1, maxGas, big.NewInt(1), keys[0], baseSize)
+	if err := pool.addRemoteSync(tx); err != nil {
+		t.Fatalf("failed to add transaction: %v ", err)
+	}
+	_, queued, _, queuedSlots := pool.Stats()
+	if queued != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+	if queuedSlots != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+
+	// 4-slot transaction makes total number of queued slots per account is
+	// higher than AccountQueue, drop this higher nonce transaction
+	tx = pricedDataTransaction(2, maxGas, big.NewInt(1), keys[0], dataSize)
+	if err := pool.addRemoteSync(tx); err != nil {
+		t.Fatalf("failed to add transaction: %v ", err)
+	}
+	_, queued, _, queuedSlots = pool.Stats()
+	if queued != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+	if queuedSlots != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+
+	// 2-slot transaction is acceptable
+	tx = pricedDataTransaction(2, maxGas, big.NewInt(1), keys[0], dataSize/2)
+	if err := pool.addRemoteSync(tx); err != nil {
+		t.Fatalf("failed to add transaction: %v ", err)
+	}
+	_, queued, _, queuedSlots = pool.Stats()
+	if queued != 2 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 2)
+	}
+	if queuedSlots != 3 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 3)
+	}
+
+	// 4-slot transaction from account 2 makes global queued slots is higher
+	// than GlobalQueue, the 2-slot nonce 2 is dropped
+	tx = pricedDataTransaction(1, maxGas, big.NewInt(1), keys[1], dataSize)
+	if err := pool.addRemoteSync(tx); err != nil {
+		t.Fatalf("failed to add transaction: %v ", err)
+	}
+	_, queued, _, queuedSlots = pool.Stats()
+	if queued != 2 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 2)
+	}
+	if queuedSlots != 5 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 5)
+	}
+}
+
 // Test the limit on transaction size is enforced correctly.
 // This test verifies every transaction having allowed size
 // is added to the pool, and longer transactions are rejected.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -274,7 +274,7 @@ func (b *EthAPIBackend) GetPoolNonce(ctx context.Context, addr common.Address) (
 	return b.eth.txPool.Nonce(addr), nil
 }
 
-func (b *EthAPIBackend) Stats() (pending int, queued int) {
+func (b *EthAPIBackend) Stats() (pending, queued, pendingSlots, queuedSlots int) {
 	return b.eth.txPool.Stats()
 }
 

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -66,7 +66,7 @@ type backend interface {
 	CurrentHeader() *types.Header
 	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	GetTd(ctx context.Context, hash common.Hash) *big.Int
-	Stats() (pending int, queued int)
+	Stats() (pending, queued, pendingSlots, pendingQueued int)
 	SyncProgress() ethereum.SyncProgress
 }
 
@@ -734,7 +734,7 @@ type pendStats struct {
 // it to the stats server.
 func (s *Service) reportPending(conn *connWrapper) error {
 	// Retrieve the pending count from the local blockchain
-	pending, _ := s.backend.Stats()
+	pending, _, _, _ := s.backend.Stats()
 	// Assemble the transaction stats and send it to the server
 	log.Trace("Sending pending transactions to ethstats", "count", pending)
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"math/big"
 	"strings"
 	"time"
+
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -203,10 +204,12 @@ func (s *PublicTxPoolAPI) ContentFrom(addr common.Address) map[string]map[string
 
 // Status returns the number of pending and queued transaction in the pool.
 func (s *PublicTxPoolAPI) Status() map[string]hexutil.Uint {
-	pending, queue := s.b.Stats()
+	pending, queue, pendingSlots, queuedSlots := s.b.Stats()
 	return map[string]hexutil.Uint{
-		"pending": hexutil.Uint(pending),
-		"queued":  hexutil.Uint(queue),
+		"pending":       hexutil.Uint(pending),
+		"queued":        hexutil.Uint(queue),
+		"pending slots": hexutil.Uint(pendingSlots),
+		"queued slots":  hexutil.Uint(queuedSlots),
 	}
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -78,7 +78,7 @@ type Backend interface {
 	GetPoolTransactions() (types.Transactions, error)
 	GetPoolTransaction(txHash common.Hash) *types.Transaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
-	Stats() (pending int, queued int)
+	Stats() (pending, queued, pendingSlots, queuedSlots int)
 	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -216,8 +216,13 @@ func (b *LesApiBackend) GetPoolNonce(ctx context.Context, addr common.Address) (
 	return b.eth.txPool.GetNonce(ctx, addr)
 }
 
-func (b *LesApiBackend) Stats() (pending int, queued int) {
-	return b.eth.txPool.Stats(), 0
+func (b *LesApiBackend) Stats() (pending, queued, pendingSlots, queuedSlots int) {
+	pending = b.eth.txPool.Stats()
+
+	// For simplicity, just return number of pending transactions in pending slots
+	// without calculating the exact number of slots here
+	pendingSlots = pending
+	return pending, 0, pendingSlots, 0
 }
 
 func (b *LesApiBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -649,12 +649,12 @@ func testTransactionStatus(t *testing.T, protocol int) {
 	}
 	// wait until TxPool processes the inserted block
 	for i := 0; i < 10; i++ {
-		if pending, _ := server.handler.txpool.Stats(); pending == 1 {
+		if pending, _, _, _ := server.handler.txpool.Stats(); pending == 1 {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if pending, _ := server.handler.txpool.Stats(); pending != 1 {
+	if pending, _, _, _ := server.handler.txpool.Stats(); pending != 1 {
 		t.Fatalf("pending count mismatch: have %d, want 1", pending)
 	}
 	// Discard new block announcement
@@ -674,12 +674,12 @@ func testTransactionStatus(t *testing.T, protocol int) {
 	}
 	// wait until TxPool processes the reorg
 	for i := 0; i < 10; i++ {
-		if pending, _ := server.handler.txpool.Stats(); pending == 3 {
+		if pending, _, _, _ := server.handler.txpool.Stats(); pending == 3 {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	if pending, _ := server.handler.txpool.Stats(); pending != 3 {
+	if pending, _, _, _ := server.handler.txpool.Stats(); pending != 3 {
 		t.Fatalf("pending count mismatch: have %d, want 3", pending)
 	}
 	// Discard new block announcement

--- a/miner/stress/1559/main.go
+++ b/miner/stress/1559/main.go
@@ -136,7 +136,7 @@ func main() {
 		nonces[index]++
 
 		// Wait if we're too saturated
-		if pend, _ := backend.TxPool().Stats(); pend > 4192 {
+		if pend, _, _, _ := backend.TxPool().Stats(); pend > 4192 {
 			time.Sleep(100 * time.Millisecond)
 		}
 

--- a/miner/stress/clique/main.go
+++ b/miner/stress/clique/main.go
@@ -138,7 +138,7 @@ func main() {
 		nonces[index]++
 
 		// Wait if we're too saturated
-		if pend, _ := backend.TxPool().Stats(); pend > 2048 {
+		if pend, _, _, _ := backend.TxPool().Stats(); pend > 2048 {
 			time.Sleep(100 * time.Millisecond)
 		}
 	}

--- a/miner/stress/ethash/main.go
+++ b/miner/stress/ethash/main.go
@@ -125,7 +125,7 @@ func main() {
 		nonces[index]++
 
 		// Wait if we're too saturated
-		if pend, _ := backend.TxPool().Stats(); pend > 2048 {
+		if pend, _, _, _ := backend.TxPool().Stats(); pend > 2048 {
 			time.Sleep(100 * time.Millisecond)
 		}
 	}


### PR DESCRIPTION
Since commit https://github.com/axieinfinity/ronin/commit/8bd37a1d919194d9a488d1cee823eaecfeb5ed9a (core: count tx size in slots, bump max size ot
4x32KB), txpool uses transaction slot for transaction accounting. However, when
truncating queued and pending transactions, we still use number of transactions.
This commit change all the places to consistently use transaction slot.