### PR TITLE
chore: remove transfer type in internal transaction logic

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -641,7 +641,6 @@ func copyAddressPtr(a *common.Address) *common.Address {
 }
 
 const (
-	InternalTransactionTransfer         = "transfer"
 	InternalTransactionContractCall     = "call"
 	InternalTransactionContractCreation = "create"
 )


### PR DESCRIPTION
We remove the logic to create a internal transaction message with type transfer because this message type is not useful anymore. When checking for the change of token balance, we should rely on the opcode field not the message type.