### PR TITLE
feat: implement optimized archive GC mode

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -20,6 +20,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"
@@ -35,12 +42,6 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/pyroscope-io/client/pyroscope"
-	"os"
-	"runtime"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 
 	// Force-load the tracer engines to trigger registration
 	_ "github.com/ethereum/go-ethereum/eth/tracers/js"
@@ -166,6 +167,9 @@ var (
 		utils.CatalystFlag,
 		utils.MonitorDoubleSign,
 		utils.StoreInternalTransactions,
+		utils.TrieSnapshotGasUsed,
+		utils.TrieSnapshotCheckpoint,
+		utils.TrieSnapshotBlockRange,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -57,6 +57,9 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.ForceOverrideChainConfigFlag,
 			utils.MonitorDoubleSign,
 			utils.StoreInternalTransactions,
+			utils.TrieSnapshotGasUsed,
+			utils.TrieSnapshotCheckpoint,
+			utils.TrieSnapshotBlockRange,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -219,8 +219,23 @@ var (
 	}
 	GCModeFlag = cli.StringFlag{
 		Name:  "gcmode",
-		Usage: `Blockchain garbage collection mode ("full", "archive")`,
+		Usage: `Blockchain garbage collection mode ("full", "archive", "optimized")`,
 		Value: "full",
+	}
+	TrieSnapshotGasUsed = cli.Uint64Flag{
+		Name:  "triesnapshot.gasused",
+		Usage: "The accumulated gas used threshold before creating a new snapshot",
+		Value: 150000000,
+	}
+	TrieSnapshotCheckpoint = cli.Uint64Flag{
+		Name:  "triesnapshot.checkpoint",
+		Usage: "The checkpoint block interval that stores the list of snapshot",
+		Value: 300,
+	}
+	TrieSnapshotBlockRange = cli.Uint64Flag{
+		Name:  "triesnapshot.blockrange",
+		Usage: "The maximum blocks before next trie snapshot",
+		Value: 20000,
 	}
 	SnapshotFlag = cli.BoolTFlag{
 		Name:  "snapshot",
@@ -1608,11 +1623,17 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.DatabaseFreezer = ctx.GlobalString(AncientFlag.Name)
 	}
 
-	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
-		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
+	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" && gcmode != "optimized" {
+		Fatalf("--%s must be either 'full' or 'archive' or 'optimized'", GCModeFlag.Name)
 	}
 	if ctx.GlobalIsSet(GCModeFlag.Name) {
 		cfg.NoPruning = ctx.GlobalString(GCModeFlag.Name) == "archive"
+		cfg.OptimizedMode = ctx.GlobalString(GCModeFlag.Name) == "optimized"
+	}
+	if cfg.OptimizedMode {
+		cfg.TrieSnapshotGasUsed = ctx.GlobalUint64(TrieSnapshotGasUsed.Name)
+		cfg.TrieSnapshotCheckpoint = ctx.GlobalUint64(TrieSnapshotCheckpoint.Name)
+		cfg.TrieSnapshotBlockRange = ctx.GlobalUint64(TrieSnapshotBlockRange.Name)
 	}
 	if ctx.GlobalIsSet(CacheNoPrefetchFlag.Name) {
 		cfg.NoPrefetch = ctx.GlobalBool(CacheNoPrefetchFlag.Name)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -83,6 +83,8 @@ var (
 	blockTxsGauge     = metrics.NewRegisteredGauge("chain/block/txs", nil)
 	blockGasUsedGauge = metrics.NewRegisteredGauge("chain/block/gasUsed", nil)
 
+	stateByHeaderTimer = metrics.NewRegisteredTimer("chain/reader/stateByHeader", nil)
+
 	errInsertionInterrupted = errors.New("insertion is interrupted")
 	errChainStopped         = errors.New("blockchain is stopped")
 )
@@ -437,6 +439,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	}
 
 	return bc, nil
+}
+
+func (bc *BlockChain) IsOptimizedMode() bool {
+	return bc.cacheConfig.OptimizedMode
 }
 
 func (bc *BlockChain) loadLatestDirtyAccounts() {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -17,16 +17,21 @@
 package core
 
 import (
+	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -3335,5 +3340,294 @@ func TestEIP1559Transition(t *testing.T) {
 	expected = new(big.Int).SetUint64(block.GasUsed() * (effectiveTip + block.BaseFee().Uint64()))
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("sender balance incorrect: expected %d, got %d", expected, actual)
+	}
+}
+
+func TestTrieSnapshotSave(t *testing.T) {
+	// Configure and generate a sample block chain
+	var (
+		gendb   = rawdb.NewMemoryDatabase()
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(100000000000000000)
+		gspec   = &Genesis{Config: params.TestChainConfig, Alloc: GenesisAlloc{address: {Balance: funds}}}
+		genesis = gspec.MustCommit(gendb)
+		signer  = types.LatestSigner(gspec.Config)
+	)
+	blocks, _ := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, 50+128, func(i int, block *BlockGen) {
+		tx, err := types.SignTx(
+			types.NewTransaction(block.TxNonce(address), common.Address{0x01}, big.NewInt(1000), params.TxGas, block.header.BaseFee, nil),
+			signer,
+			key,
+		)
+		if err != nil {
+			panic(err)
+		}
+
+		blockNumber := i + 1
+		if blockNumber == 7 {
+			// Insert 1 transaction in the second snapshot interval
+			block.AddTx(tx)
+		} else if blockNumber == 15 {
+			// Insert 1 transaction in the third snapshot interval
+			block.AddTx(tx)
+		} else if blockNumber == 18 || blockNumber == 19 {
+			// Insert 2 transactions in the fourth snapshot interval
+			block.AddTx(tx)
+		} else if blockNumber == 21 || blockNumber == 22 || blockNumber == 23 || blockNumber == 24 {
+			// Insert 4 transactions in the fifth snapshot interval
+			block.AddTx(tx)
+		}
+	}, false)
+
+	cacheConfig := *defaultCacheConfig
+	cacheConfig.OptimizedMode = true
+	cacheConfig.TrieSnapshotGasUsed = 40000
+	cacheConfig.TrieSnapshotCheckpoint = 5
+	cacheConfig.TrieSnapshotBlockRange = 20
+	blockchain, err := NewBlockChain(gendb, &cacheConfig, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer blockchain.Stop()
+
+	if _, err := blockchain.InsertChain(blocks); err != nil {
+		t.Fatal(err)
+	}
+
+	if snapshotLen := len(rawdb.ReadTrieSnapshotList(gendb, 5)); snapshotLen != 0 {
+		t.Fatalf("First interval is expected to have %d, found %d snapshots", 0, snapshotLen)
+	}
+
+	if snapshotLen := len(rawdb.ReadTrieSnapshotList(gendb, 10)); snapshotLen != 0 {
+		t.Fatalf("Second interval is expected to have %d, found %d snapshots", 0, snapshotLen)
+	}
+
+	if snapshotLen := len(rawdb.ReadTrieSnapshotList(gendb, 15)); snapshotLen != 1 {
+		t.Fatalf("Third interval is expected to have %d, found %d snapshots", 1, snapshotLen)
+	}
+
+	if snapshotLen := len(rawdb.ReadTrieSnapshotList(gendb, 20)); snapshotLen != 1 {
+		t.Fatalf("Fourth interval is expected to have %d, found %d snapshots", 1, snapshotLen)
+	}
+
+	if snapshotLen := len(rawdb.ReadTrieSnapshotList(gendb, 19)); snapshotLen != 0 {
+		t.Fatalf("Non chekpoint block is expected to have %d, found %d snapshots", 0, snapshotLen)
+	}
+
+	if snapshotLen := len(rawdb.ReadTrieSnapshotList(gendb, 25)); snapshotLen != 2 {
+		t.Fatalf("Fifth interval is expected to have %d, found %d snapshots", 2, snapshotLen)
+	}
+
+	if number := blockchain.findNearestSnapshot(0); number != 0 {
+		t.Fatalf("Nearest snapshot of %d is %d, found %d", 0, 0, number)
+	}
+
+	if number := blockchain.findNearestSnapshot(7); number != 0 {
+		t.Fatalf("Nearest snapshot of %d is %d, found %d", 7, 0, number)
+	}
+
+	if number := blockchain.findNearestSnapshot(18); number != 15 {
+		t.Fatalf("Nearest snapshot of %d is %d, found %d", 18, 15, number)
+	}
+
+	if number := blockchain.findNearestSnapshot(20); number != 19 {
+		t.Fatalf("Nearest snapshot of %d is %d, found %d", 20, 19, number)
+	}
+
+	if number := blockchain.findNearestSnapshot(28); number != 24 {
+		t.Fatalf("Nearest snapshot of %d is %d, found %d", 28, 24, number)
+	}
+
+	if number := blockchain.findNearestSnapshot(50); number != 45 {
+		t.Fatalf("Nearest snapshot of %d is %d, found %d", 50, 45, number)
+	}
+
+	header := blockchain.GetHeaderByNumber(4)
+	_, err = blockchain.StateAt(header.Root)
+	if err == nil {
+		t.Fatalf("Expect state at block %d to be garbage collected", 4)
+	}
+
+	statedb, err := blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 4, err)
+	}
+	balance := statedb.GetBalance(common.Address{0x01})
+	if balance.Cmp(common.Big0) != 0 {
+		t.Fatalf("Balance of address %s is %d, expect: %d", common.Address{0x01}, balance.Uint64(), 0)
+	}
+
+	header = blockchain.GetHeaderByNumber(12)
+	statedb, err = blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 12, err)
+	}
+	balance = statedb.GetBalance(common.Address{0x01})
+	if balance.Cmp(big.NewInt(1000)) != 0 {
+		t.Fatalf("Balance of address %s is %d, expect: %d", common.Address{0x01}, balance.Uint64(), 1000)
+	}
+
+	header = blockchain.GetHeaderByNumber(21)
+	statedb, err = blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 21, err)
+	}
+	balance = statedb.GetBalance(common.Address{0x01})
+	if balance.Cmp(big.NewInt(5000)) != 0 {
+		t.Fatalf("Balance of address %s is %d, expect: %d", common.Address{0x01}, balance.Uint64(), 5000)
+	}
+
+	header = blockchain.GetHeaderByNumber(25)
+	statedb, err = blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 25, err)
+	}
+	balance = statedb.GetBalance(common.Address{0x01})
+	if balance.Cmp(big.NewInt(8000)) != 0 {
+		t.Fatalf("Balance of address %s is %d, expect: %d", common.Address{0x01}, balance.Uint64(), 8000)
+	}
+}
+
+func TestOptimizedModeAccessStorageTrie(t *testing.T) {
+	// Configure and generate a sample block chain
+	var (
+		gendb   = rawdb.NewMemoryDatabase()
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(100000000000000000)
+		gspec   = &Genesis{Config: params.TestChainConfig, Alloc: GenesisAlloc{address: {Balance: funds}}}
+		genesis = gspec.MustCommit(gendb)
+		signer  = types.LatestSigner(gspec.Config)
+	)
+
+	/*
+		// SPDX-License-Identifier: GPL-3.0
+
+		pragma solidity >=0.7.0 <0.9.0;
+
+		contract Contract {
+			uint256 public number;
+
+			function setNumber(uint256 num) public {
+				number = num;
+			}
+		}
+	*/
+	contractBytecode, _ := hex.DecodeString("608060405234801561001057600080fd5b50610133806100206000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80633fb5c1cb1460375780638381f58a14604f575b600080fd5b604d60048036038101906049919060af565b6069565b005b60556073565b6040516060919060e4565b60405180910390f35b8060008190555050565b60005481565b600080fd5b6000819050919050565b608f81607e565b8114609957600080fd5b50565b60008135905060a9816088565b92915050565b60006020828403121560c25760c16079565b5b600060ce84828501609c565b91505092915050565b60de81607e565b82525050565b600060208201905060f7600083018460d7565b9291505056fea26469706673582212204e4a4bfb6fdec0309f3a115a8dd9014a9a7cfcac3ef78e2cd42d2f485837541964736f6c63430008120033")
+	contractABI, _ := abi.JSON(strings.NewReader(`[{"inputs":[],"name":"number","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"num","type":"uint256"}],"name":"setNumber","outputs":[],"stateMutability":"nonpayable","type":"function"}]`))
+	contractAddr := common.HexToAddress("0x3A220f351252089D385b29beca14e27F204c296A")
+
+	blocks, _ := GenerateChain(gspec.Config, genesis, ethash.NewFaker(), gendb, 15+128, func(i int, block *BlockGen) {
+		blockNumber := i + 1
+		if blockNumber == 3 {
+			// Deploy contract in the first snapshot interval
+			tx, err := types.SignTx(
+				types.NewTx(&types.LegacyTx{Nonce: block.TxNonce(address), To: nil, Gas: 1000000, GasPrice: block.header.BaseFee, Data: contractBytecode}),
+				signer,
+				key,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			block.AddTx(tx)
+		} else if blockNumber == 7 {
+			// Insert 1 transaction in the third snapshot interval
+			input, _ := contractABI.Pack("setNumber", big.NewInt(100))
+			tx, err := types.SignTx(
+				types.NewTx(&types.LegacyTx{Nonce: block.TxNonce(address), To: &contractAddr, Gas: 1000000, GasPrice: block.header.BaseFee, Data: input}),
+				signer,
+				key,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			block.AddTx(tx)
+		} else if blockNumber == 9 {
+			// Insert 2 transactions in the fourth snapshot interval
+			input, _ := contractABI.Pack("setNumber", big.NewInt(200))
+			tx, err := types.SignTx(
+				types.NewTx(&types.LegacyTx{Nonce: block.TxNonce(address), To: &contractAddr, Gas: 1000000, GasPrice: block.header.BaseFee, Data: input}),
+				signer,
+				key,
+			)
+			if err != nil {
+				panic(err)
+			}
+			block.AddTx(tx)
+
+			input, _ = contractABI.Pack("setNumber", big.NewInt(300))
+			tx, err = types.SignTx(
+				types.NewTx(&types.LegacyTx{Nonce: block.TxNonce(address), To: &contractAddr, Gas: 1000000, GasPrice: block.header.BaseFee, Data: input}),
+				signer,
+				key,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			block.AddTx(tx)
+		}
+	}, false)
+
+	cacheConfig := *defaultCacheConfig
+	cacheConfig.OptimizedMode = true
+	cacheConfig.TrieSnapshotGasUsed = 40000
+	cacheConfig.TrieSnapshotCheckpoint = 5
+	cacheConfig.TrieSnapshotBlockRange = 1000
+	blockchain, err := NewBlockChain(gendb, &cacheConfig, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer blockchain.Stop()
+
+	if _, err := blockchain.InsertChain(blocks); err != nil {
+		t.Fatal(err)
+	}
+
+	header := blockchain.GetHeaderByNumber(2)
+	statedb, err := blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 2, err)
+	}
+	code := statedb.GetCode(contractAddr)
+	if len(code) != 0 {
+		t.Fatalf("Expect address %s to have empty code, found: %d code length", contractAddr, len(code))
+	}
+
+	header = blockchain.GetHeaderByNumber(5)
+	statedb, err = blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 5, err)
+	}
+	code = statedb.GetCode(contractAddr)
+	if bytes.Equal(code, contractBytecode) {
+		t.Fatalf("Mismatch code of contract address %s", contractAddr)
+	}
+	number := statedb.GetState(contractAddr, common.HexToHash("0x00")).Big().Uint64()
+	if number != 0 {
+		t.Fatalf("Expect number at block %d to be %d, found %d", 5, 0, number)
+	}
+
+	header = blockchain.GetHeaderByNumber(8)
+	statedb, err = blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 8, err)
+	}
+	number = statedb.GetState(contractAddr, common.HexToHash("0x00")).Big().Uint64()
+	if number != 100 {
+		t.Fatalf("Expect number at block %d to be %d, found %d", 8, 100, number)
+	}
+
+	header = blockchain.GetHeaderByNumber(12)
+	statedb, err = blockchain.StateByHeader(header)
+	if err != nil {
+		t.Fatalf("Failed to get state at block %d, err: %s", 12, err)
+	}
+	number = statedb.GetState(contractAddr, common.HexToHash("0x00")).Big().Uint64()
+	if number != 300 {
+		t.Fatalf("Expect number at block %d to be %d, found %d", 12, 300, number)
 	}
 }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -1018,3 +1018,32 @@ func ReadDirtyAccounts(db ethdb.KeyValueReader) []*types.DirtyStateAccountsAndBl
 	}
 	return dirtyStateAccounts
 }
+
+func WriteTrieSnapshotList(db ethdb.KeyValueWriter, blockNumber uint64, unsavedTrieSnapshot []uint64) {
+	data, err := rlp.EncodeToBytes(unsavedTrieSnapshot)
+	if err != nil {
+		log.Crit("Failed to encode trie snapshot list", "err", err)
+	}
+	if err = db.Put(trieSnapshotKey(blockNumber), data); err != nil {
+		log.Crit("Failed to write trie snapshot list", "err", err)
+	}
+}
+
+func DeleteTrieSnapshotList(db ethdb.KeyValueWriter, blockNumber uint64) {
+	if err := db.Delete(trieSnapshotKey(blockNumber)); err != nil {
+		log.Crit("Failed to delete trie snapshot list", "err", err)
+	}
+}
+
+func ReadTrieSnapshotList(db ethdb.KeyValueReader, blockNumber uint64) []uint64 {
+	data, _ := db.Get(trieSnapshotKey(blockNumber))
+	if len(data) == 0 {
+		return []uint64{}
+	}
+
+	var trieSnapshot []uint64
+	if err := rlp.Decode(bytes.NewReader(data), &trieSnapshot); err != nil {
+		log.Crit("Failed to decode trie snapshot list", "err", err)
+	}
+	return trieSnapshot
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -467,3 +467,30 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 
 	return nil
 }
+
+func GetTrieSnapshot(db ethdb.Database, interval uint64) ([]uint64, error) {
+	head := ReadHeadBlockHash(db)
+	currentNumber := ReadHeaderNumber(db, head)
+	if currentNumber == nil {
+		return nil, errors.New("current header number not found")
+	}
+
+	var (
+		i                uint64
+		trieSnapshotMap  = make(map[uint64]struct{})
+		trieSnapshotList []uint64
+	)
+
+	for i = 0; i < *currentNumber; i += interval {
+		snapshots := ReadTrieSnapshotList(db, i)
+		for _, snapshot := range snapshots {
+			trieSnapshotMap[snapshot] = struct{}{}
+		}
+	}
+
+	for snapshot := range trieSnapshotMap {
+		trieSnapshotList = append(trieSnapshotList, snapshot)
+	}
+
+	return trieSnapshotList, nil
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -308,20 +308,21 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		logged = time.Now()
 
 		// Key-value store statistics
-		headers         stat
-		bodies          stat
-		receipts        stat
-		tds             stat
-		numHashPairings stat
-		hashNumPairings stat
-		tries           stat
-		codes           stat
-		txLookups       stat
-		accountSnaps    stat
-		storageSnaps    stat
-		preimages       stat
-		bloomBits       stat
-		cliqueSnaps     stat
+		headers          stat
+		bodies           stat
+		receipts         stat
+		tds              stat
+		numHashPairings  stat
+		hashNumPairings  stat
+		tries            stat
+		codes            stat
+		txLookups        stat
+		accountSnaps     stat
+		storageSnaps     stat
+		preimages        stat
+		bloomBits        stat
+		cliqueSnaps      stat
+		trieSnapshotList stat
 
 		// Ancient store statistics
 		ancientHeadersSize  common.StorageSize
@@ -381,6 +382,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			bloomBits.Add(size)
 		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
 			cliqueSnaps.Add(size)
+		case bytes.HasPrefix(key, trieSnapshotPrefix) && len(key) == (len(trieSnapshotPrefix)+8):
+			trieSnapshotList.Add(size)
 		case bytes.HasPrefix(key, []byte("cht-")) ||
 			bytes.HasPrefix(key, []byte("chtIndexV2-")) ||
 			bytes.HasPrefix(key, []byte("chtRootV2-")): // Canonical hash trie
@@ -442,6 +445,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Account snapshot", accountSnaps.Size(), accountSnaps.Count()},
 		{"Key-Value store", "Storage snapshot", storageSnaps.Size(), storageSnaps.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
+		{"Key-Value store", "Trie snapshots list", trieSnapshotList.Size(), trieSnapshotList.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -96,6 +96,8 @@ var (
 	internalTxsPrefix = []byte("itxs") // internalTxsPrefix + block hash -> internal transactions
 	dirtyAccountsKey  = []byte("dacc") // dirtyAccountsPrefix + block hash -> dirty accounts
 
+	trieSnapshotPrefix = []byte("S") // trieSnapshotPrefix + block number (uint64 big endian) -> trie snapshot list
+
 	PreimagePrefix = []byte("secure-key-")      // PreimagePrefix + hash -> preimage
 	configPrefix   = []byte("ethereum-config-") // config prefix for the db
 
@@ -240,4 +242,8 @@ func IsCodeKey(key []byte) (bool, []byte) {
 // configKey = configPrefix + hash
 func configKey(hash common.Hash) []byte {
 	return append(configPrefix, hash.Bytes()...)
+}
+
+func trieSnapshotKey(blockNumber uint64) []byte {
+	return binary.BigEndian.AppendUint64(trieSnapshotPrefix, blockNumber)
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -301,7 +301,7 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 	if block == nil {
 		return state.Dump{}, fmt.Errorf("block #%d not found", blockNr)
 	}
-	stateDb, err := api.eth.BlockChain().StateAt(block.Root())
+	stateDb, err := api.eth.BlockChain().StateByHeader(block.Header())
 	if err != nil {
 		return state.Dump{}, err
 	}
@@ -389,7 +389,7 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 			if block == nil {
 				return state.IteratorDump{}, fmt.Errorf("block #%d not found", number)
 			}
-			stateDb, err = api.eth.BlockChain().StateAt(block.Root())
+			stateDb, err = api.eth.BlockChain().StateByHeader(block.Header())
 			if err != nil {
 				return state.IteratorDump{}, err
 			}
@@ -399,7 +399,7 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 		if block == nil {
 			return state.IteratorDump{}, fmt.Errorf("block %s not found", hash.Hex())
 		}
-		stateDb, err = api.eth.BlockChain().StateAt(block.Root())
+		stateDb, err = api.eth.BlockChain().StateByHeader(block.Header())
 		if err != nil {
 			return state.IteratorDump{}, err
 		}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,9 +19,10 @@ package eth
 import (
 	"context"
 	"errors"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum/eth/tracers"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -153,7 +154,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumber(ctx context.Context, number rpc.B
 	if header == nil {
 		return nil, nil, errors.New("header not found")
 	}
-	stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+	stateDb, err := b.eth.BlockChain().StateByHeader(header)
 	return stateDb, header, err
 }
 
@@ -172,7 +173,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 		if blockNrOrHash.RequireCanonical && b.eth.blockchain.GetCanonicalHash(header.Number.Uint64()) != hash {
 			return nil, nil, errors.New("hash is not currently canonical")
 		}
-		stateDb, err := b.eth.BlockChain().StateAt(header.Root)
+		stateDb, err := b.eth.BlockChain().StateByHeader(header)
 		return stateDb, header, err
 	}
 	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -185,15 +185,19 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnablePreimageRecording: config.EnablePreimageRecording,
 		}
 		cacheConfig = &core.CacheConfig{
-			TrieCleanLimit:      config.TrieCleanCache,
-			TrieCleanJournal:    stack.ResolvePath(config.TrieCleanCacheJournal),
-			TrieCleanRejournal:  config.TrieCleanCacheRejournal,
-			TrieCleanNoPrefetch: config.NoPrefetch,
-			TrieDirtyLimit:      config.TrieDirtyCache,
-			TrieDirtyDisabled:   config.NoPruning,
-			TrieTimeLimit:       config.TrieTimeout,
-			SnapshotLimit:       config.SnapshotCache,
-			Preimages:           config.Preimages,
+			TrieCleanLimit:         config.TrieCleanCache,
+			TrieCleanJournal:       stack.ResolvePath(config.TrieCleanCacheJournal),
+			TrieCleanRejournal:     config.TrieCleanCacheRejournal,
+			TrieCleanNoPrefetch:    config.NoPrefetch,
+			TrieDirtyLimit:         config.TrieDirtyCache,
+			TrieDirtyDisabled:      config.NoPruning,
+			TrieTimeLimit:          config.TrieTimeout,
+			SnapshotLimit:          config.SnapshotCache,
+			Preimages:              config.Preimages,
+			OptimizedMode:          config.OptimizedMode,
+			TrieSnapshotGasUsed:    config.TrieSnapshotGasUsed,
+			TrieSnapshotCheckpoint: config.TrieSnapshotCheckpoint,
+			TrieSnapshotBlockRange: config.TrieSnapshotBlockRange,
 		}
 	)
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -212,6 +212,12 @@ type Config struct {
 
 	// Enable double sign monitoring
 	EnableMonitorDoubleSign bool
+
+	// Optimized GC mode flags
+	OptimizedMode          bool
+	TrieSnapshotGasUsed    uint64 // The accumulated gas used threshold before creating a new snapshot
+	TrieSnapshotCheckpoint uint64 // The checkpoint block interval that stores the list of snapshot
+	TrieSnapshotBlockRange uint64 // The maximum blocks before next trie snapshot
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"time"
+
+	"github.com/ethereum/go-ethereum/eth/tracers"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/consortium"
@@ -72,6 +73,12 @@ func (eth *Ethereum) StateAtBlock(ctx context.Context, block *types.Block, reexe
 			}, nil
 		}
 	}
+
+	if eth.blockchain.IsOptimizedMode() {
+		statedb, err := eth.blockchain.StateByHeader(block.Header())
+		return statedb, noopReleaser, err
+	}
+
 	// The state is both for reading and writing, or it's unavailable in disk,
 	// try to construct/recover the state over an ephemeral trie.Database for
 	// isolating the live one.


### PR DESCRIPTION
- feat: implement optimized archive GC mode

This commit introduces new optimized mode in gcmode, and 3 new flags:
triesnapshot.gasused, triesnapshot.checkpoint, triesnapshot.blockrange.  Instead
of flushing the trie in every block like archive mode, we only flush the trie
(create a trie snapshot) when accumulated gas used of block range is higher than
triesnapshot.gasused or the block range is longer than triesnapshot.blockrange.
To lookup the trie snapshot, the list of trie snapshots between 2 checkpoints is
stored at the higher checkpoint block. The interval between 2 checkpoints is
configured by triesnapshot.checkpoint.

- feat: re-execute blocks from nearest snapshot to get missing state

When trying the get a state that is not stored in database, we look up the
nearest snapshot before requested block. Then, re-execute all the blocks from
snapshot to requested block based on the snapshot state to get the requested
state.

Currently, debug_getModifiedAccountsByNumber/debug_getModifiedAccountsByHash
does not work the same as archive node because the above logic applies to get
state only while these APIs work on triedb directly.