### PR TITLE
feat/tracers: support emit trace error

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -206,20 +206,33 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	debug := evm.Config.Tracer != nil
+
 	if evm.Config.NoRecursion && evm.depth > 0 {
+		if debug && evm.Config.EmitTraceError {
+			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
+			evm.Config.Tracer.CaptureEnd(ret, 0, nil)
+		}
 		return nil, gas, nil
 	}
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
+		if debug && evm.Config.EmitTraceError {
+			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
+			evm.Config.Tracer.CaptureEnd(ret, 0, ErrDepth)
+		}
 		return nil, gas, ErrDepth
 	}
 	// Fail if we're trying to transfer more than the available balance
 	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
+		if debug && evm.Config.EmitTraceError {
+			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
+			evm.Config.Tracer.CaptureEnd(ret, 0, ErrInsufficientBalance)
+		}
 		return nil, gas, ErrInsufficientBalance
 	}
 	snapshot := evm.StateDB.Snapshot()
 	p, isPrecompile := evm.precompile(caller, addr)
-	debug := evm.Config.Tracer != nil
 
 	if !evm.StateDB.Exist(addr) {
 		if !isPrecompile && evm.chainRules.IsEIP158 && value.Sign() == 0 {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -209,7 +209,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	debug := evm.Config.Tracer != nil
 
 	if evm.Config.NoRecursion && evm.depth > 0 {
-		if debug && evm.Config.EmitTraceError {
+		if debug && evm.Config.FullCallTracing {
 			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
 			evm.Config.Tracer.CaptureEnd(ret, 0, nil)
 		}
@@ -217,7 +217,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 	// Fail if we're trying to execute above the call depth limit
 	if evm.depth > int(params.CallCreateDepth) {
-		if debug && evm.Config.EmitTraceError {
+		if debug && evm.Config.FullCallTracing {
 			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
 			evm.Config.Tracer.CaptureEnd(ret, 0, ErrDepth)
 		}
@@ -225,7 +225,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 	// Fail if we're trying to transfer more than the available balance
 	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
-		if debug && evm.Config.EmitTraceError {
+		if debug && evm.Config.FullCallTracing {
 			evm.Config.Tracer.CaptureStart(evm, caller.Address(), addr, false, input, gas, value)
 			evm.Config.Tracer.CaptureEnd(ret, 0, ErrInsufficientBalance)
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,10 +29,10 @@ import (
 type Config struct {
 	Debug                   bool      // Enables debugging
 	Tracer                  EVMLogger // Opcode logger
-	EmitTraceError          bool // Emit trace error
-	NoRecursion             bool // Disables call, callcode, delegate call and create
-	NoBaseFee               bool // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
-	EnablePreimageRecording bool // Enables recording of SHA3/keccak preimages
+	FullCallTracing         bool      // Emit trace error
+	NoRecursion             bool      // Disables call, callcode, delegate call and create
+	NoBaseFee               bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	EnablePreimageRecording bool      // Enables recording of SHA3/keccak preimages
 
 	JumpTable [256]*operation // EVM instruction table, automatically populated if unset
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,9 +29,10 @@ import (
 type Config struct {
 	Debug                   bool      // Enables debugging
 	Tracer                  EVMLogger // Opcode logger
-	NoRecursion             bool      // Disables call, callcode, delegate call and create
-	NoBaseFee               bool      // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
-	EnablePreimageRecording bool      // Enables recording of SHA3/keccak preimages
+	EmitTraceError          bool // Emit trace error
+	NoRecursion             bool // Disables call, callcode, delegate call and create
+	NoBaseFee               bool // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
+	EnablePreimageRecording bool // Enables recording of SHA3/keccak preimages
 
 	JumpTable [256]*operation // EVM instruction table, automatically populated if unset
 

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -181,9 +181,9 @@ func (api *API) blockByNumberAndHash(ctx context.Context, number rpc.BlockNumber
 // TraceConfig holds extra parameters to trace functions.
 type TraceConfig struct {
 	*logger.Config
-	Tracer         *string
-	EmitTraceError bool
-	Timeout        *string
+	Tracer          *string
+	FullCallTracing bool
+	Timeout         *string
 	Reexec         *uint64
 	// Config specific to given tracer. Note struct logger
 	// config are historically embedded in main object.
@@ -1121,7 +1121,7 @@ func (api *API) traceTx(
 	}
 
 	// Run the transaction with tracing enabled.
-	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer, NoBaseFee: true, EmitTraceError: config.EmitTraceError})
+	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer, NoBaseFee: true, FullCallTracing: config.FullCallTracing})
 
 	// Define a meaningful timeout of a single transaction trace
 	if config.Timeout != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -181,9 +181,10 @@ func (api *API) blockByNumberAndHash(ctx context.Context, number rpc.BlockNumber
 // TraceConfig holds extra parameters to trace functions.
 type TraceConfig struct {
 	*logger.Config
-	Tracer  *string
-	Timeout *string
-	Reexec  *uint64
+	Tracer         *string
+	EmitTraceError bool
+	Timeout        *string
+	Reexec         *uint64
 	// Config specific to given tracer. Note struct logger
 	// config are historically embedded in main object.
 	TracerConfig json.RawMessage
@@ -1120,7 +1121,7 @@ func (api *API) traceTx(
 	}
 
 	// Run the transaction with tracing enabled.
-	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer, NoBaseFee: true})
+	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Tracer: tracer, NoBaseFee: true, EmitTraceError: config.EmitTraceError})
 
 	// Define a meaningful timeout of a single transaction trace
 	if config.Timeout != nil {


### PR DESCRIPTION
### Problem

Sometimes we want to capture the error from the tracer. However, the default tracer does not support these errors such as `max call depth exceeded` and `insufficient balance for transfer` in internal transactions.

Currently, the default tracer in Ronin does not provide support for capturing certain errors that occur during internal transactions, such as `max call depth exceeded` and `insufficient balance for transfer`.

### Proposal

This PR aims to address this issue by introducing a new parameter, `emitTraceError: bool`, to the trace API. This addition ensures compatibility with the existing API while enabling the capture of these errors.

### Example

#### Request
```bash
curl --location 'localhost:8545' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "debug_traceInternalsAndAccountsByBlockHash",
    "params": [
        "0xe99c5951f0f4306b045d18e4f60575a1321e9dd7401702fb62c865e7d530e934",
        {
            "tracer": "callTracer2",
            "emitTraceError": true
        }
    ],
    "id": "1"
}'
```

#### Old Response
```json
{
    "jsonrpc": "2.0",
    "id": "1",
    "result": {
        "internalTxs": [
            {
                "transactionHash": "0xe9c840187b9271f5c2a104c4fbb48b975b3cf79c53396c696be5e5c524341b0c",
                "result": {
                    "type": "CALL",
                    "order": 0,
                    "from": "0x968d0cd7343f711216817e617d3f92a23dc91c07",
                    "to": "0x30800297f77fe3615e3b44ac00f8f0c5a5625281",
                    "value": "0x0",
                    "gas": "0x1f7a8",
                    "gasUsed": "0x4285",
                    "input": "0x8a4068dd",
                    "output": "0x",
                    "calls": [
                        {
                            "type": "CALL",
                            "order": 107,
                            "from": "0x30800297f77fe3615e3b44ac00f8f0c5a5625281",
                            "to": "0x2e76240d47cf6a5f319db4e681a5a0a4243297c1",
                            "value": "0xde0b6b3a7640000",
                            "gas": "0x1cf03",
                            "gasUsed": "0x20d5",
                            "input": "0x",
                            "output": "0x",
                            "error": "execution reverted"
                        }
                    ]
                }
            }
        ],
        "dirtyAccounts": []
    }
}
```

#### New Response
```json
{
    "jsonrpc": "2.0",
    "id": "1",
    "result": {
        "internalTxs": [
            {
                "transactionHash": "0xe9c840187b9271f5c2a104c4fbb48b975b3cf79c53396c696be5e5c524341b0c",
                "result": {
                    "type": "CALL",
                    "order": 0,
                    "from": "0x2e76240d47cf6a5f319db4e681a5a0a4243297c1",
                    "to": "0xeaceb97203f458211e2e8f1254308ae09a4cc2ff",
                    "value": "0x1bc16d674ec80000",
                    "gas": "0x8fc",
                    "gasUsed": "0x4285",
                    "input": "0x",
                    "output": "0x",
                    "error": "insufficient balance for transfer",
                    "calls": [
                        {
                            "type": "CALL",
                            "order": 107,
                            "from": "0x30800297f77fe3615e3b44ac00f8f0c5a5625281",
                            "to": "0x2e76240d47cf6a5f319db4e681a5a0a4243297c1",
                            "value": "0xde0b6b3a7640000",
                            "gas": "0x1cf03",
                            "gasUsed": "0x20d5",
                            "input": "0x",
                            "output": "0x",
                            "error": "execution reverted"
                        }
                    ]
                }
            }
        ],
        "dirtyAccounts": []
    }
}
```
