### PR TITLE
consortium/v2: add finality vote to consensus layer

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -161,6 +161,8 @@ type FastFinalityPoSA interface {
 	// VerifyVote check if the finality voter is in the validator set, it assumes the signature is
 	// already verified
 	VerifyVote(chain ChainHeaderReader, vote *types.VoteEnvelope) error
+
+	SetVotePool(votePool VotePool)
 }
 
 type VotePool interface {

--- a/consensus/consortium/common/constants.go
+++ b/consensus/consortium/common/constants.go
@@ -2,11 +2,13 @@ package common
 
 import (
 	"errors"
+
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const (
-	ExtraSeal = crypto.SignatureLength // Fixed number of extra-data suffix bytes reserved for signer seal
+	ExtraSeal   = crypto.SignatureLength
+	ExtraVanity = 32
 )
 
 var (

--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -192,6 +192,35 @@ func (c *ContractIntegrator) Slash(opts *ApplyTransactOpts, spoiledValidator com
 	return nil
 }
 
+func (c *ContractIntegrator) FinalityReward(opts *ApplyTransactOpts, votedValidators []common.Address) error {
+	nonce := opts.State.GetNonce(c.coinbase)
+	// FIXME: Change this
+	tx, err := c.slashIndicatorSC.SlashUnavailability(getTransactionOpts(c.coinbase, nonce, c.chainId, c.signTxFn), common.Address{})
+	if err != nil {
+		return err
+	}
+
+	msg := types.NewMessage(
+		opts.Header.Coinbase,
+		tx.To(),
+		opts.State.GetNonce(opts.Header.Coinbase),
+		tx.Value(),
+		tx.Gas(),
+		big.NewInt(0),
+		big.NewInt(0),
+		big.NewInt(0),
+		tx.Data(),
+		tx.AccessList(),
+		false,
+	)
+
+	if err = ApplyTransaction(msg, opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ApplyMessageOpts is the collection of options to fine tune a contract call request.
 type ApplyMessageOpts struct {
 	State       *state.StateDB

--- a/consensus/consortium/common/types.go
+++ b/consensus/consortium/common/types.go
@@ -1,11 +1,12 @@
 package common
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
-	"math/big"
 )
 
 // SignerFn is a signer callback function to request the wallet to sign the hash of the given data

--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -202,6 +202,41 @@ func (c *Consortium) GetBestParentBlock(chain *core.BlockChain) (*types.Block, b
 	return c.v2.GetBestParentBlock(chain)
 }
 
+func (c *Consortium) GetJustifiedBlock(
+	chain consensus.ChainHeaderReader,
+	blockNumber uint64,
+	blockHash common.Hash,
+) (uint64, common.Hash) {
+	if c.chainConfig.IsShillin(new(big.Int).SetUint64(blockNumber)) {
+		return c.v2.GetJustifiedBlock(chain, blockNumber, blockHash)
+	}
+	return 0, common.Hash{}
+}
+
+func (c *Consortium) GetFinalizedBlock(
+	chain consensus.ChainHeaderReader,
+	headNumber uint64,
+	headHash common.Hash,
+) (uint64, common.Hash) {
+	if c.chainConfig.IsShillin(new(big.Int).SetUint64(headNumber)) {
+		return c.v2.GetFinalizedBlock(chain, headNumber, headHash)
+	}
+	return 0, common.Hash{}
+}
+
+func (c *Consortium) SetVotePool(votePool consensus.VotePool) {
+	c.v2.SetVotePool(votePool)
+}
+
+// IsActiveValidatorAt always returns false before Shillin
+func (c *Consortium) IsActiveValidatorAt(chain consensus.ChainHeaderReader, header *types.Header) bool {
+	if c.chainConfig.IsShillin(header.Number) {
+		return c.v2.IsActiveValidatorAt(chain, header)
+	}
+
+	return false
+}
+
 // HandleSystemTransaction fixes up the statedb when system transaction
 // goes through ApplyMessage when tracing/debugging
 func HandleSystemTransaction(engine consensus.Engine, statedb *state.StateDB, msg core.Message, block *types.Block) bool {

--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -1,0 +1,247 @@
+package finality
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/bls/blst"
+	blsCommon "github.com/ethereum/go-ethereum/crypto/bls/common"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const (
+	ExtraSeal   = crypto.SignatureLength
+	ExtraVanity = 32
+)
+
+var (
+	// ErrInvalidHasFinalityVote is returned if a block's extra-data contains invalid
+	// has finality vote byte
+	ErrInvalidHasFinalityVote = errors.New("invalid has finality vote byte")
+
+	// ErrMissingHasFinalityVote is returned if a block's extra-data section does not seem
+	// to include 1 byte to determine if the extra data has the finality votes
+	ErrMissingHasFinalityVote = errors.New("extra-data 1 byte has finality votes missing")
+
+	// ErrMissingFinalityVoteBitSet is returned if a block's extra-data section does not seem
+	// to include 8 bytes of finality vote bitset
+	ErrMissingFinalityVoteBitSet = errors.New("extra-data 8 bytes finality votes bitset missing")
+
+	// ErrMissingFinalitySignature is returned if a block's extra-data section does not seem
+	// to include finality signature
+	ErrMissingFinalitySignature = errors.New("extra-data finality signature missing")
+
+	// ErrMissingFinalitySignature is returned if the number of finality votes is under
+	// the threshold
+	ErrNotEnoughFinalityVote = errors.New("not enough finality vote")
+
+	// ErrFinalitySignatureVerificationFailed is returned if the finality signature verification
+	// failed
+	ErrFinalitySignatureVerificationFailed = errors.New("failed to verify finality signature")
+
+	// ErrInvalidFinalityVotedBitSet is returned if the voted validator in bit set is not in
+	// snapshot validator set
+	ErrInvalidFinalityVotedBitSet = errors.New("invalid finality voted bit set")
+
+	// ErrUnauthorizedFinalityVoter is returned if finality voter is not in validator set
+	ErrUnauthorizedFinalityVoter = errors.New("unauthorized finality voter")
+
+	// ErrMissingVanity is returned if a block's extra-data section is shorter than
+	// 32 bytes, which is required to store the signer vanity.
+	ErrMissingVanity = errors.New("extra-data 32 byte vanity prefix missing")
+
+	// ErrMissingSignature is returned if a block's extra-data section doesn't seem
+	// to contain a 65 byte secp256k1 signature.
+	ErrMissingSignature = errors.New("extra-data 65 byte signature suffix missing")
+
+	// ErrInvalidSpanValidators is returned if a block contains an
+	// invalid list of validators (i.e. non divisible by 20 bytes).
+	ErrInvalidSpanValidators = errors.New("invalid validator list on sprint end block")
+)
+
+type ValidatorWithBlsPub struct {
+	Address      common.Address      `json:"address"`
+	BlsPublicKey blsCommon.PublicKey `json:"blsPublicKey"`
+}
+
+// CheckpointValidatorAscending implements the sort interface to allow sorting a list
+// of checkpoint validator
+type CheckpointValidatorAscending []ValidatorWithBlsPub
+
+func (validator CheckpointValidatorAscending) Len() int { return len(validator) }
+func (validator CheckpointValidatorAscending) Less(i, j int) bool {
+	return bytes.Compare(validator[i].Address[:], validator[j].Address[:]) < 0
+}
+func (validator CheckpointValidatorAscending) Swap(i, j int) {
+	validator[i], validator[j] = validator[j], validator[i]
+}
+
+type FinalityVoteBitSet uint64
+
+const finalityVoteBitSetByteLength int = 8
+
+func (bitSet *FinalityVoteBitSet) Indices() []int {
+	var votedValidatorPositions []int
+
+	for i := 0; i < finalityVoteBitSetByteLength*8; i++ {
+		if uint64(*bitSet)&(1<<i) != 0 {
+			votedValidatorPositions = append(votedValidatorPositions, i)
+		}
+	}
+	return votedValidatorPositions
+}
+
+func (bitSet *FinalityVoteBitSet) SetBit(index int) {
+	if index >= finalityVoteBitSetByteLength*8 {
+		return
+	}
+
+	*bitSet = FinalityVoteBitSet(uint64(*bitSet) | (1 << index))
+}
+
+// HeaderExtraData represents the information in the extra data of header,
+// this helps to make the code more readable
+type HeaderExtraData struct {
+	Vanity                  [ExtraVanity]byte     // unused in Consortium, filled with zero
+	HasFinalityVote         uint8                 // determine if the header extra has the finality vote
+	FinalityVotedValidators FinalityVoteBitSet    // the bit set of validators that vote for finality
+	AggregatedFinalityVotes blsCommon.Signature   // aggregated BLS signatures for finality vote
+	CheckpointValidators    []ValidatorWithBlsPub // validator addresses and BLS public key appended at checkpoint block
+	Seal                    [ExtraSeal]byte       // the sealing block signature
+}
+
+func (extraData *HeaderExtraData) Encode(isShillin bool) []byte {
+	var rawBytes []byte
+
+	rawBytes = append(rawBytes, extraData.Vanity[:]...)
+	if isShillin {
+		rawBytes = append(rawBytes, extraData.HasFinalityVote)
+		if extraData.HasFinalityVote == 1 {
+			rawBytes = binary.LittleEndian.AppendUint64(rawBytes, uint64(extraData.FinalityVotedValidators))
+			rawBytes = append(rawBytes, extraData.AggregatedFinalityVotes.Marshal()...)
+		}
+	}
+	for _, validator := range extraData.CheckpointValidators {
+		rawBytes = append(rawBytes, validator.Address.Bytes()...)
+		if isShillin {
+			rawBytes = append(rawBytes, validator.BlsPublicKey.Marshal()...)
+		}
+	}
+	rawBytes = append(rawBytes, extraData.Seal[:]...)
+
+	return rawBytes
+}
+
+func DecodeExtra(rawBytes []byte, isShillin bool) (*HeaderExtraData, error) {
+	var (
+		extraData       HeaderExtraData
+		currentPosition int
+		err             error
+	)
+
+	rawBytesLength := len(rawBytes)
+	if rawBytesLength < ExtraVanity {
+		return nil, ErrMissingVanity
+	}
+
+	copy(extraData.Vanity[:], rawBytes[:ExtraVanity])
+	currentPosition += ExtraVanity
+
+	if isShillin {
+		if rawBytesLength-currentPosition < 1 {
+			return nil, ErrMissingHasFinalityVote
+		}
+
+		extraData.HasFinalityVote = rawBytes[currentPosition]
+		currentPosition += 1
+
+		if extraData.HasFinalityVote != 1 && extraData.HasFinalityVote != 0 {
+			return nil, ErrInvalidHasFinalityVote
+		}
+
+		if extraData.HasFinalityVote == 1 {
+			if rawBytesLength-currentPosition < finalityVoteBitSetByteLength {
+				return nil, ErrMissingFinalityVoteBitSet
+			}
+			extraData.FinalityVotedValidators = FinalityVoteBitSet(
+				binary.LittleEndian.Uint64(rawBytes[currentPosition : currentPosition+finalityVoteBitSetByteLength]),
+			)
+			currentPosition += finalityVoteBitSetByteLength
+
+			if rawBytesLength-currentPosition < params.BLSSignatureLength {
+				return nil, ErrMissingFinalitySignature
+			}
+			extraData.AggregatedFinalityVotes, err = blst.SignatureFromBytes(
+				rawBytes[currentPosition : currentPosition+params.BLSSignatureLength],
+			)
+			if err != nil {
+				return nil, err
+			}
+			currentPosition += params.BLSSignatureLength
+		}
+	}
+
+	if rawBytesLength-currentPosition < ExtraSeal {
+		return nil, ErrMissingSignature
+	}
+
+	checkpointValidatorsLength := rawBytesLength - currentPosition - ExtraSeal
+	extraData.CheckpointValidators, err = ParseCheckpointData(
+		rawBytes[currentPosition:currentPosition+checkpointValidatorsLength],
+		isShillin,
+	)
+	if err != nil {
+		return nil, err
+	}
+	currentPosition += checkpointValidatorsLength
+
+	copy(extraData.Seal[:], rawBytes[currentPosition:])
+
+	return &extraData, nil
+}
+
+// ParseCheckpointData retrieves the list of validator addresses and finality voter's public keys
+// at the checkpoint block
+func ParseCheckpointData(checkpointData []byte, isShillin bool) ([]ValidatorWithBlsPub, error) {
+	var (
+		lengthPerValidator int
+		extraData          []ValidatorWithBlsPub
+		currentPosition    int
+		err                error
+	)
+
+	if isShillin {
+		lengthPerValidator = common.AddressLength + params.BLSPubkeyLength
+	} else {
+		lengthPerValidator = common.AddressLength
+	}
+
+	if len(checkpointData)%lengthPerValidator != 0 {
+		return nil, ErrInvalidSpanValidators
+	}
+
+	numValidators := len(checkpointData) / lengthPerValidator
+	extraData = make([]ValidatorWithBlsPub, numValidators)
+	for i := 0; i < numValidators; i++ {
+		copy(
+			extraData[i].Address[:],
+			checkpointData[currentPosition:currentPosition+common.AddressLength],
+		)
+		currentPosition += common.AddressLength
+
+		if isShillin {
+			extraData[i].BlsPublicKey, err = blst.PublicKeyFromBytes(
+				checkpointData[currentPosition : currentPosition+params.BLSPubkeyLength],
+			)
+			if err != nil {
+				return nil, err
+			}
+			currentPosition += params.BLSPubkeyLength
+		}
+	}
+
+	return extraData, nil
+}

--- a/params/config.go
+++ b/params/config.go
@@ -470,6 +470,8 @@ type ChainConfig struct {
 	BubaBlock  *big.Int `json:"bubaBlock,omitempty"`  // Buba switch block (nil = no fork, 0 = already on activated)
 	// Olek hardfork reduces the delay in block time of out of turn miner
 	OlekBlock *big.Int `json:"olekBlock,omitempty"` // Olek switch block (nil = no fork, 0 = already on activated)
+	// Shillin hardfork introduces fast finality
+	ShillinBlock *big.Int `json:"shillinBlock,omitempty"` // Shillin switch block (nil = no fork, 0 = already on activated)
 
 	BlacklistContractAddress      *common.Address `json:"blacklistContractAddress,omitempty"`      // Address of Blacklist Contract (nil = no blacklist)
 	FenixValidatorContractAddress *common.Address `json:"fenixValidatorContractAddress,omitempty"` // Address of Ronin Contract in the Fenix hardfork (nil = no blacklist)
@@ -564,7 +566,7 @@ func (c *ChainConfig) String() string {
 	chainConfigFmt := "{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v "
 	chainConfigFmt += "Petersburg: %v Istanbul: %v, Odysseus: %v, Fenix: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, "
 	chainConfigFmt += "Engine: %v, Blacklist Contract: %v, Fenix Validator Contract: %v, ConsortiumV2: %v, ConsortiumV2.RoninValidatorSet: %v, "
-	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v, Olek: %v}"
+	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v, Olek: %v, Shillin: %v}"
 
 	return fmt.Sprintf(chainConfigFmt,
 		c.ChainID,
@@ -594,6 +596,7 @@ func (c *ChainConfig) String() string {
 		c.PuffyBlock,
 		c.BubaBlock,
 		c.OlekBlock,
+		c.ShillinBlock,
 	)
 }
 
@@ -705,6 +708,11 @@ func (c *ChainConfig) IsBuba(num *big.Int) bool {
 // IsOlek returns whether the num is equals to or larger than the olek fork block.
 func (c *ChainConfig) IsOlek(num *big.Int) bool {
 	return isForked(c.OlekBlock, num)
+}
+
+// IsShillin returns whether the num is equals to or larger than the shillin fork block.
+func (c *ChainConfig) IsShillin(num *big.Int) bool {
+	return isForked(c.ShillinBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -825,6 +833,21 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.FenixBlock, newcfg.FenixBlock, head) {
 		return newCompatError("Fenix fork block", c.FenixBlock, newcfg.FenixBlock)
+	}
+	if isForkIncompatible(c.ConsortiumV2Block, newcfg.ConsortiumV2Block, head) {
+		return newCompatError("Consortium v2 fork block", c.ConsortiumV2Block, newcfg.ConsortiumV2Block)
+	}
+	if isForkIncompatible(c.PuffyBlock, newcfg.PuffyBlock, head) {
+		return newCompatError("Puffy fork block", c.PuffyBlock, newcfg.PuffyBlock)
+	}
+	if isForkIncompatible(c.BubaBlock, newcfg.BubaBlock, head) {
+		return newCompatError("Buba fork block", c.BubaBlock, newcfg.BubaBlock)
+	}
+	if isForkIncompatible(c.OlekBlock, newcfg.OlekBlock, head) {
+		return newCompatError("Olek fork block", c.OlekBlock, newcfg.OlekBlock)
+	}
+	if isForkIncompatible(c.ShillinBlock, newcfg.ShillinBlock, head) {
+		return newCompatError("Shillin fork block", c.ShillinBlock, newcfg.ShillinBlock)
 	}
 	return nil
 }


### PR DESCRIPTION
This commit extends the snapshot to contains additional BLS public key of the
validators. The new information is also added to header's extra data like
aggregated BLS signature and voted validator information. A new system
transaction is created to reward the finality voted validators.