### PR TITLE
eth/protocols: implement finality vote communication via ronin protocol

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -171,6 +171,7 @@ var (
 		utils.EnableFastFinality,
 		utils.BlsPasswordPath,
 		utils.BlsWalletPath,
+		utils.DisableRoninProtocol,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -57,6 +57,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.ForceOverrideChainConfigFlag,
 			utils.MonitorDoubleSign,
 			utils.StoreInternalTransactions,
+			utils.DisableRoninProtocol,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -894,6 +894,11 @@ var (
 		Usage: "The path to bls wallet secret key",
 		Value: "bls_key",
 	}
+
+	DisableRoninProtocol = cli.BoolFlag{
+		Name:  "ronin.disable",
+		Usage: "Disable ronin p2p protocol",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1728,6 +1733,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		} else {
 			cfg.EthDiscoveryURLs = SplitAndTrim(urls)
 		}
+	}
+	if ctx.GlobalIsSet(DisableRoninProtocol.Name) {
+		cfg.DisableRoninProtocol = ctx.GlobalBool(DisableRoninProtocol.Name)
 	}
 	// Override any default configs for hard coded networks.
 	switch {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -212,6 +212,9 @@ type Config struct {
 
 	// Enable double sign monitoring
 	EnableMonitorDoubleSign bool
+
+	// Disable ronin p2p protocol
+	DisableRoninProtocol bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -574,7 +574,7 @@ func (h *handler) txBroadcastLoop() {
 }
 
 func (h *handler) broadcastVote(voteEnvelop *types.VoteEnvelope) {
-	roninPeers := h.peers.peerWithRonin()
+	roninPeers := h.peers.roninPeerWithoutVote(voteEnvelop.Hash())
 	for _, peer := range roninPeers {
 		peer.AsyncSendNewVote(voteEnvelop)
 	}

--- a/eth/handler_ronin.go
+++ b/eth/handler_ronin.go
@@ -1,0 +1,40 @@
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/protocols/ronin"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+type roninHandler handler
+
+func (r *roninHandler) RunPeer(peer *ronin.Peer, hand ronin.Handler) error {
+	return (*handler)(r).runRoninExtension(peer, hand)
+}
+
+func (r *roninHandler) PeerInfo(id enode.ID) interface{} {
+	ethPeer := r.peers.peer(id.String())
+	if ethPeer.roninExt != nil {
+		return ethPeer.roninExt.Version()
+	} else {
+		return nil
+	}
+}
+
+func (r *roninHandler) Handle(peer *ronin.Peer, packet ronin.Packet) error {
+	switch packet.Kind() {
+	case ronin.NewVoteMsg:
+		if r.votePool != nil {
+			votePacket := packet.(*ronin.NewVotePacket)
+			for _, rawVote := range votePacket.Vote {
+				vote := &types.VoteEnvelope{
+					RawVoteEnvelope: *rawVote,
+				}
+				r.votePool.PutVote(peer.ID(), vote)
+			}
+		} else {
+			peer.Log().Debug("Local node does not enable fast finality, drop new vote msg")
+		}
+	}
+	return nil
+}

--- a/eth/handler_ronin_test.go
+++ b/eth/handler_ronin_test.go
@@ -1,0 +1,185 @@
+package eth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/eth/protocols/ronin"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// testRoninHandler is a mock event handler to listen for inbound network requests
+// on the `eth` protocol and convert them into a more easily testable form.
+type testRoninHandler struct {
+	voteBroadcasts event.Feed
+}
+
+func (h *testRoninHandler) RunPeer(*ronin.Peer, ronin.Handler) error { panic("not used in tests") }
+func (h *testRoninHandler) PeerInfo(enode.ID) interface{}            { panic("not used in tests") }
+
+func (h *testRoninHandler) Handle(peer *ronin.Peer, packet ronin.Packet) error {
+	switch packet.Kind() {
+	case ronin.NewVoteMsg:
+		h.voteBroadcasts.Send(packet.Name())
+		return nil
+
+	default:
+		panic(fmt.Sprintf("unexpected eth packet type in tests: %T", packet))
+	}
+}
+
+func TestVoteBroadcast(t *testing.T) {
+	const peers = 10
+	protocols := []p2p.Protocol{
+		{
+			Name:    eth.ProtocolName,
+			Version: eth.ETH66,
+		},
+		{
+			Name:    ronin.ProtocolName,
+			Version: ronin.Ronin1,
+		},
+	}
+	caps := []p2p.Cap{
+		{
+			Name:    eth.ProtocolName,
+			Version: eth.ETH66,
+		},
+		{
+			Name:    ronin.ProtocolName,
+			Version: ronin.Ronin1,
+		},
+	}
+
+	// Create a source eth handler
+	source := newTestHandler()
+	defer source.close()
+
+	sinksEth := make([]*testEthHandler, peers)
+	for i := 0; i < len(sinksEth); i++ {
+		sinksEth[i] = new(testEthHandler)
+	}
+	sinksRonin := make([]*testRoninHandler, peers)
+	for i := 0; i < len(sinksRonin); i++ {
+		sinksRonin[i] = new(testRoninHandler)
+	}
+
+	// Interconnect all the sink handlers with the source handler
+	var (
+		genesis = source.chain.Genesis()
+		td      = source.chain.GetTd(genesis.Hash(), genesis.NumberU64())
+	)
+	for i := range sinksEth {
+		sinkEth := sinksEth[i]
+		sinkRonin := sinksRonin[i]
+
+		sourceEthPipe, sinkEthPipe := p2p.MsgPipe()
+		defer sourceEthPipe.Close()
+		defer sinkEthPipe.Close()
+
+		sourceEthPeer := eth.NewPeer(
+			eth.ETH66,
+			p2p.NewPeerPipeWithProtocol(enode.ID{byte(i + 1)}, "", caps, sourceEthPipe, protocols),
+			sourceEthPipe,
+			nil,
+		)
+		sinkEthPeer := eth.NewPeer(
+			eth.ETH66,
+			p2p.NewPeerPipeWithProtocol(enode.ID{0}, "", caps, sinkEthPipe, protocols),
+			sinkEthPipe,
+			nil,
+		)
+		defer sourceEthPeer.Close()
+		defer sinkEthPeer.Close()
+
+		sourceRoninPipe, sinkRoninPipe := p2p.MsgPipe()
+		defer sourceRoninPipe.Close()
+		defer sinkRoninPipe.Close()
+
+		sourceRoninPeer := ronin.NewPeer(
+			ronin.Ronin1,
+			p2p.NewPeerPipeWithProtocol(enode.ID{byte(i + 1)}, "", caps, sourceRoninPipe, protocols),
+			sourceRoninPipe,
+		)
+		sinkRoninPeer := ronin.NewPeer(
+			ronin.Ronin1,
+			p2p.NewPeerPipeWithProtocol(enode.ID{0}, "", caps, sinkRoninPipe, protocols),
+			sinkRoninPipe,
+		)
+		defer sourceRoninPeer.Close()
+		defer sinkRoninPeer.Close()
+
+		go source.handler.runRoninExtension(sourceRoninPeer, func(peer *ronin.Peer) error {
+			return ronin.Handle((*roninHandler)(source.handler), peer)
+		})
+		go ronin.Handle(sinkRonin, sinkRoninPeer)
+
+		go source.handler.runEthPeer(sourceEthPeer, func(peer *eth.Peer) error {
+			return eth.Handle((*ethHandler)(source.handler), peer)
+		})
+
+		if err := sinkEthPeer.Handshake(
+			1,
+			td,
+			genesis.Hash(),
+			genesis.Hash(),
+			forkid.NewIDWithChain(source.chain),
+			forkid.NewFilter(source.chain),
+		); err != nil {
+			t.Fatalf("failed to run protocol handshake, err %s", err)
+		}
+
+		go eth.Handle(sinkEth, sinkEthPeer)
+	}
+
+	// Subscribe to all the vote sinks
+	voteChs := make([]chan string, len(sinksRonin))
+	for i := 0; i < len(sinksRonin); i++ {
+		voteChs[i] = make(chan string, 1)
+		defer close(voteChs[i])
+
+		sub := sinksRonin[i].voteBroadcasts.Subscribe(voteChs[i])
+		defer sub.Unsubscribe()
+	}
+
+	// Initiate a vote propagation across the peers
+	time.Sleep(100 * time.Millisecond)
+	source.handler.broadcastVote(&types.VoteEnvelope{
+		RawVoteEnvelope: types.RawVoteEnvelope{
+			Data: &types.VoteData{
+				TargetNumber: 0,
+				TargetHash:   common.Hash{},
+			},
+		},
+	})
+
+	// Iterate through all the sinks and ensure the correct number of the votes
+	done := make(chan struct{}, peers)
+	for _, ch := range voteChs {
+		ch := ch
+		go func() {
+			<-ch
+			done <- struct{}{}
+		}()
+	}
+	var received int
+	for {
+		select {
+		case <-done:
+			received++
+
+		case <-time.After(200 * time.Millisecond):
+			if received != peers {
+				t.Errorf("broadcast count mismatch: have %d, want %d", received, peers)
+			}
+			return
+		}
+	}
+}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/eth/protocols/ronin"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 )
 
@@ -36,7 +37,8 @@ type ethPeerInfo struct {
 // ethPeer is a wrapper around eth.Peer to maintain a few extra metadata.
 type ethPeer struct {
 	*eth.Peer
-	snapExt *snapPeer // Satellite `snap` connection
+	snapExt  *snapPeer   // Satellite `snap` connection
+	roninExt *ronin.Peer // Satellite `ronin` connection
 
 	syncDrop *time.Timer   // Connection dropper if `eth` sync progress isn't validated in time
 	snapWait chan struct{} // Notification channel for snap connections

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -317,13 +317,13 @@ func (ps *peerSet) peerWithHighestTD() *eth.Peer {
 	return bestPeer
 }
 
-func (ps *peerSet) peerWithRonin() []*ronin.Peer {
+func (ps *peerSet) roninPeerWithoutVote(hash common.Hash) []*ronin.Peer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	var roninPeers []*ronin.Peer
 	for _, peer := range ps.peers {
-		if peer.roninExt != nil {
+		if peer.roninExt != nil && !peer.roninExt.KnownFinalityVote(hash) {
 			roninPeers = append(roninPeers, peer.roninExt)
 		}
 	}

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
+	"github.com/ethereum/go-ethereum/eth/protocols/ronin"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/p2p"
 )
@@ -43,6 +44,10 @@ var (
 	// errSnapWithoutEth is returned if a peer attempts to connect only on the
 	// snap protocol without advertizing the eth main protocol.
 	errSnapWithoutEth = errors.New("peer connected on snap without compatible eth support")
+
+	// errRoninWithoutEth is returned if a peer attempts to connect only on the
+	// ronin protocol without advertizing the eth main protocol.
+	errRoninWithoutEth = errors.New("peer connected on ronin without compatible eth support")
 )
 
 // peerSet represents the collection of active peers currently participating in
@@ -54,6 +59,9 @@ type peerSet struct {
 	snapWait map[string]chan *snap.Peer // Peers connected on `eth` waiting for their snap extension
 	snapPend map[string]*snap.Peer      // Peers connected on the `snap` protocol, but not yet on `eth`
 
+	roninWait map[string]chan *ronin.Peer // Peers connected on `eth` waiting for their ronin extension
+	roninPend map[string]*ronin.Peer      // Peers connected on the `ronin` protocol, but not yet on `eth`
+
 	lock   sync.RWMutex
 	closed bool
 }
@@ -61,9 +69,11 @@ type peerSet struct {
 // newPeerSet creates a new peer set to track the active participants.
 func newPeerSet() *peerSet {
 	return &peerSet{
-		peers:    make(map[string]*ethPeer),
-		snapWait: make(map[string]chan *snap.Peer),
-		snapPend: make(map[string]*snap.Peer),
+		peers:     make(map[string]*ethPeer),
+		snapWait:  make(map[string]chan *snap.Peer),
+		snapPend:  make(map[string]*snap.Peer),
+		roninWait: make(map[string]chan *ronin.Peer),
+		roninPend: make(map[string]*ronin.Peer),
 	}
 }
 
@@ -131,9 +141,66 @@ func (ps *peerSet) waitSnapExtension(peer *eth.Peer) (*snap.Peer, error) {
 	return <-wait, nil
 }
 
+// registerRoninExtension unblocks an already connected `eth` peer waiting for its
+// `ronin` extension, or if no such peer exists, tracks the extension for the time
+// being until the `eth` main protocol starts looking for it.
+func (ps *peerSet) registerRoninExtension(peer *ronin.Peer) error {
+	if !peer.RunningCap(eth.ProtocolName, eth.ProtocolVersions) {
+		return errRoninWithoutEth
+	}
+
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+
+	id := peer.ID()
+	if _, ok := ps.peers[id]; ok {
+		return errPeerAlreadyRegistered // avoid connections with the same id as existing ones
+	}
+	if _, ok := ps.roninPend[id]; ok {
+		return errPeerAlreadyRegistered // avoid connections with the same id as pending ones
+	}
+	if wait, ok := ps.roninWait[id]; ok {
+		delete(ps.roninWait, id)
+		wait <- peer
+		return nil
+	}
+	ps.roninPend[id] = peer
+	return nil
+}
+
+// waitRoninExtensions blocks until `ronin` satellite protocols are connected and tracked
+// by the peerset.
+func (ps *peerSet) waitRoninExtension(peer *eth.Peer) (*ronin.Peer, error) {
+	// If the peer does not support a compatible `ronin`, don't wait
+	if !peer.RunningCap(ronin.ProtocolName, ronin.ProtocolVersions) {
+		return nil, nil
+	}
+	ps.lock.Lock()
+
+	id := peer.ID()
+	if _, ok := ps.peers[id]; ok {
+		ps.lock.Unlock()
+		return nil, errPeerAlreadyRegistered // avoid connections with the same id as existing ones
+	}
+	if _, ok := ps.roninWait[id]; ok {
+		ps.lock.Unlock()
+		return nil, errPeerAlreadyRegistered // avoid connections with the same id as pending ones
+	}
+	if peer, ok := ps.roninPend[id]; ok {
+		delete(ps.roninPend, id)
+		ps.lock.Unlock()
+		return peer, nil
+	}
+	wait := make(chan *ronin.Peer)
+	ps.roninWait[id] = wait
+	ps.lock.Unlock()
+
+	return <-wait, nil
+}
+
 // registerPeer injects a new `eth` peer into the working set, or returns an error
 // if the peer is already known.
-func (ps *peerSet) registerPeer(peer *eth.Peer, ext *snap.Peer) error {
+func (ps *peerSet) registerPeer(peer *eth.Peer, ext *snap.Peer, roninExt *ronin.Peer) error {
 	// Start tracking the new peer
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
@@ -151,6 +218,9 @@ func (ps *peerSet) registerPeer(peer *eth.Peer, ext *snap.Peer) error {
 	if ext != nil {
 		eth.snapExt = &snapPeer{ext}
 		ps.snapPeers++
+	}
+	if roninExt != nil {
+		eth.roninExt = roninExt
 	}
 	ps.peers[id] = eth
 	return nil
@@ -245,6 +315,20 @@ func (ps *peerSet) peerWithHighestTD() *eth.Peer {
 		}
 	}
 	return bestPeer
+}
+
+func (ps *peerSet) peerWithRonin() []*ronin.Peer {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	var roninPeers []*ronin.Peer
+	for _, peer := range ps.peers {
+		if peer.roninExt != nil {
+			roninPeers = append(roninPeers, peer.roninExt)
+		}
+	}
+
+	return roninPeers
 }
 
 // close disconnects all peers.

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth/protocols"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -64,7 +65,7 @@ func (p *testPeer) close() {
 
 func TestPeerSet(t *testing.T) {
 	size := 5
-	s := newKnownCache(size)
+	s := protocols.NewKnownCache(size)
 
 	// add 10 items
 	for i := 0; i < size*2; i++ {

--- a/eth/protocols/known_cache.go
+++ b/eth/protocols/known_cache.go
@@ -1,0 +1,48 @@
+package protocols
+
+import (
+	mapset "github.com/deckarep/golang-set"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// max is a helper function which returns the larger of the two given integers.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// KnownCache is a cache for known hashes.
+type KnownCache struct {
+	hashes mapset.Set
+	max    int
+}
+
+// NewKnownCache creates a new knownCache with a max capacity.
+func NewKnownCache(max int) *KnownCache {
+	return &KnownCache{
+		max:    max,
+		hashes: mapset.NewSet(),
+	}
+}
+
+// Add adds a list of elements to the set.
+func (k *KnownCache) Add(hashes ...common.Hash) {
+	for k.hashes.Cardinality() > max(0, k.max-len(hashes)) {
+		k.hashes.Pop()
+	}
+	for _, hash := range hashes {
+		k.hashes.Add(hash)
+	}
+}
+
+// Contains returns whether the given item is in the set.
+func (k *KnownCache) Contains(hash common.Hash) bool {
+	return k.hashes.Contains(hash)
+}
+
+// Cardinality returns the number of elements in the set.
+func (k *KnownCache) Cardinality() int {
+	return k.hashes.Cardinality()
+}

--- a/eth/protocols/ronin/handler.go
+++ b/eth/protocols/ronin/handler.go
@@ -1,0 +1,118 @@
+package ronin
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// Handler is a callback to invoke from an outside runner after the boilerplate
+// exchanges have passed.
+type Handler func(peer *Peer) error
+
+type Backend interface {
+	// RunPeer is invoked when a peer joins on the `ronin` protocol. The handler
+	// should do any peer maintenance work, handshakes and validations. If all
+	// is passed, control should be given back to the `handler` to process the
+	// inbound messages going forward.
+	RunPeer(peer *Peer, handler Handler) error
+
+	// PeerInfo retrieves all known `ronin` information about a peer.
+	PeerInfo(id enode.ID) interface{}
+
+	// Handle is a callback to be invoked when a data packet is received from
+	// the remote peer. Only packets not consumed by the protocol handler will
+	// be forwarded to the backend.
+	Handle(peer *Peer, packet Packet) error
+}
+
+func MakeProtocols(backend Backend) []p2p.Protocol {
+	protocol := make([]p2p.Protocol, len(ProtocolVersions))
+	for i, version := range ProtocolVersions {
+		protocol[i] = p2p.Protocol{
+			Name:    ProtocolName,
+			Version: version,
+			Length:  protocolLengths[version],
+			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+				roninPeer := NewPeer(version, peer, rw)
+				defer roninPeer.Close()
+
+				return backend.RunPeer(roninPeer, func(peer *Peer) error {
+					return Handle(backend, peer)
+				})
+			},
+			NodeInfo: func() interface{} {
+				return nodeInfo()
+			},
+			PeerInfo: func(id enode.ID) interface{} {
+				return backend.PeerInfo(id)
+			},
+		}
+	}
+
+	return protocol
+}
+
+// Handle is the callback invoked to manage the life cycle of a `ronin` peer.
+// When this function terminates, the peer is disconnected.
+func Handle(backend Backend, peer *Peer) error {
+	for {
+		err := handleMessage(backend, peer)
+		if err != nil {
+			peer.Log().Debug("Failed to handle `ronin` message", "err", err)
+			return err
+		}
+	}
+}
+
+// handleMessage is invoked whenever an inbound message is received from a
+// remote peer on the `ronin` protocol. The remote connection is torn down upon
+// returning any error.
+func handleMessage(backend Backend, peer *Peer) error {
+	msg, err := peer.rw.ReadMsg()
+	if err != nil {
+		return err
+	}
+
+	if msg.Size > maxMessageSize {
+		return fmt.Errorf("%w: %v > %v", errMsgTooLarge, msg.Size, maxMessageSize)
+	}
+
+	defer msg.Discard()
+	start := time.Now()
+	// Track the emount of time it takes to serve the request and run the handler
+	if metrics.Enabled {
+		h := fmt.Sprintf("%s/%s/%d/%#02x", p2p.HandleHistName, ProtocolName, peer.Version(), msg.Code)
+		defer func(start time.Time) {
+			sampler := func() metrics.Sample {
+				return metrics.ResettingSample(
+					metrics.NewExpDecaySample(1028, 0.015),
+				)
+			}
+			metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(time.Since(start).Microseconds())
+		}(start)
+	}
+
+	switch msg.Code {
+	case NewVoteMsg:
+		var votePacket NewVotePacket
+		if err := msg.Decode(&votePacket); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		return backend.Handle(peer, &votePacket)
+	default:
+		return fmt.Errorf("%w: %v", errInvalidMsgCode, msg.Code)
+	}
+}
+
+// NodeInfo represents a short summary of the `ronin` sub-protocol metadata
+// known about the host peer.
+type NodeInfo struct{}
+
+// nodeInfo retrieves some `ronin` protocol metadata about the running host node.
+func nodeInfo() *NodeInfo {
+	return &NodeInfo{}
+}

--- a/eth/protocols/ronin/handler.go
+++ b/eth/protocols/ronin/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -102,6 +103,14 @@ func handleMessage(backend Backend, peer *Peer) error {
 		if err := msg.Decode(&votePacket); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 		}
+		for _, packet := range votePacket.Vote {
+			vote := types.VoteEnvelope{
+				RawVoteEnvelope: *packet,
+			}
+
+			peer.markFinalityVote(vote.Hash())
+		}
+
 		return backend.Handle(peer, &votePacket)
 	default:
 		return fmt.Errorf("%w: %v", errInvalidMsgCode, msg.Code)

--- a/eth/protocols/ronin/peer.go
+++ b/eth/protocols/ronin/peer.go
@@ -1,0 +1,105 @@
+package ronin
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+const (
+	voteChannelSize = 50
+	batchInterval   = 100 * time.Millisecond
+)
+
+// Peer is a collection of relevant information we have about a `ronin` peer.
+type Peer struct {
+	id string // Unique ID for the peer, cached
+
+	*p2p.Peer                          // The embedded P2P package peer
+	rw        p2p.MsgReadWriter        // Input/output streams for snap
+	version   uint                     // Protocol version negotiated
+	term      chan struct{}            // Terminate the batch vote loop
+	voteCh    chan *types.VoteEnvelope // Put vote into pool for batching
+
+	logger log.Logger // Contextual logger with the peer id injected
+}
+
+// NewPeer create a wrapper for a network connection and negotiated  protocol
+// version.
+func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
+	id := p.ID().String()
+	peer := &Peer{
+		id:      id,
+		Peer:    p,
+		rw:      rw,
+		version: version,
+		voteCh:  make(chan *types.VoteEnvelope, voteChannelSize),
+		term:    make(chan struct{}),
+		logger:  log.New("peer", id[:8]),
+	}
+	go peer.batchVote()
+
+	return peer
+}
+
+// Close terminates the vote batch goroutine.
+func (p *Peer) Close() {
+	close(p.term)
+}
+
+// ID retrieves the peer's unique identifier.
+func (p *Peer) ID() string {
+	return p.id
+}
+
+// Version retrieves the peer's negoatiated `ronin` protocol version.
+func (p *Peer) Version() uint {
+	return p.version
+}
+
+// Log overrides the P2P logget with the higher level one containing only the id.
+func (p *Peer) Log() log.Logger {
+	return p.logger
+}
+
+// sendNewVote sends votes to the peer.
+func (p *Peer) sendNewVote(votes []*types.VoteEnvelope) error {
+	var rawVote []*types.RawVoteEnvelope
+	for _, vote := range votes {
+		rawVote = append(rawVote, vote.Raw())
+	}
+	return p2p.Send(p.rw, NewVoteMsg, NewVotePacket{
+		Vote: rawVote,
+	})
+}
+
+// AsyncSendNewVote puts the vote into the batch vote goroutine.
+func (p *Peer) AsyncSendNewVote(vote *types.VoteEnvelope) {
+	p.voteCh <- vote
+}
+
+// batchVote batches multiple votes and sends to the peer.
+func (p *Peer) batchVote() {
+	var pendingVote []*types.VoteEnvelope
+	ticker := time.NewTicker(batchInterval)
+
+	for {
+		select {
+		case vote := <-p.voteCh:
+			pendingVote = append(pendingVote, vote)
+		case <-ticker.C:
+			if len(pendingVote) > 0 {
+				if err := p.sendNewVote(pendingVote); err != nil {
+					p.Log().Debug("Failed to send vote", "err", err)
+					return
+				}
+				pendingVote = nil
+			}
+		case <-p.term:
+			ticker.Stop()
+			return
+		}
+	}
+}

--- a/eth/protocols/ronin/protocol.go
+++ b/eth/protocols/ronin/protocol.go
@@ -1,0 +1,49 @@
+package ronin
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Constants to match up protocol versions and messages
+const (
+	Ronin1 = 1
+)
+
+// ProtocolName is the official short name of the `ronin` protocol used during
+// devp2p capability negotiation.
+const ProtocolName = "ronin"
+
+// ProtocolVersions are the supported versions of the `ronin` protocol
+var ProtocolVersions = []uint{Ronin1}
+
+// protocolLengths are the number of implemented message corresponding to
+// different protocol versions.
+var protocolLengths = map[uint]uint64{Ronin1: 1}
+
+// maxMessageSize is the maximum cap on the size of a protocol message.
+const maxMessageSize = 10 * 1024 * 1024
+
+const (
+	NewVoteMsg = 0x00
+)
+
+var (
+	errMsgTooLarge    = errors.New("message too long")
+	errDecode         = errors.New("invalid message")
+	errInvalidMsgCode = errors.New("invalid message code")
+)
+
+// Packet represents a p2p message in the `ronin` protocol.
+type Packet interface {
+	Name() string // Name returns a string corresponding to the message type.
+	Kind() byte   // Kind returns the message type.
+}
+
+type NewVotePacket struct {
+	Vote []*types.RawVoteEnvelope
+}
+
+func (*NewVotePacket) Name() string { return "NewVote" }
+func (*NewVotePacket) Kind() byte   { return NewVoteMsg }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -129,11 +129,30 @@ func NewPeer(id enode.ID, name string, caps []Cap) *Peer {
 	return peer
 }
 
+// NewPeerWithProtocol returns a peer for testing purposes.
+func NewPeerWithProtocol(id enode.ID, name string, caps []Cap, protocols []Protocol) *Peer {
+	pipe, _ := net.Pipe()
+	node := enode.SignNull(new(enr.Record), id)
+	conn := &conn{fd: pipe, transport: nil, node: node, caps: caps, name: name}
+	peer := newPeer(log.Root(), conn, protocols)
+	close(peer.closed) // ensures Disconnect doesn't block
+	return peer
+}
+
 // NewPeerPipe creates a peer for testing purposes.
 // The message pipe given as the last parameter is closed when
 // Disconnect is called on the peer.
 func NewPeerPipe(id enode.ID, name string, caps []Cap, pipe *MsgPipeRW) *Peer {
 	p := NewPeer(id, name, caps)
+	p.testPipe = pipe
+	return p
+}
+
+// NewPeerPipeWithProtocol creates a peer for testing purposes.
+// The message pipe given as the last parameter is closed when
+// Disconnect is called on the peer.
+func NewPeerPipeWithProtocol(id enode.ID, name string, caps []Cap, pipe *MsgPipeRW, protocols []Protocol) *Peer {
+	p := NewPeerWithProtocol(id, name, caps, protocols)
 	p.testPipe = pipe
 	return p
 }


### PR DESCRIPTION
ronin protocol is an extension protocol of eth, a peer is required to support eth protocol to run ronin protocol. ronin protocol currently only supports NewVotePacket which contains a list of finality votes.