### PR TITLE
core/vote/vote_pool: protect pool against malicious peer

### DIFF
--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -160,7 +160,8 @@ func (voteManager *VoteManager) loop() {
 				rawdb.WriteHighestFinalityVote(voteManager.db, curHead.Number.Uint64())
 
 				log.Debug("vote manager produced vote", "votedBlockNumber", voteMessage.Data.TargetNumber, "votedBlockHash", voteMessage.Data.TargetHash, "voteMessageHash", voteMessage.Hash())
-				voteManager.pool.PutVote(voteMessage)
+				// This is a local vote so just pass the dummy peer information
+				voteManager.pool.PutVote("", voteMessage)
 				votesManagerCounter.Inc(1)
 			}
 		case <-voteManager.chainHeadSub.Err():

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -297,7 +297,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		if !ok {
 			return nil, errors.New("consensus engine does not support fast finality")
 		}
-		votePool := vote.NewVotePool(chainConfig, eth.blockchain, finalityEngine, nodeConfig.MaxCurVoteAmountPerBlock)
+		votePool := vote.NewVotePool(eth.blockchain, finalityEngine, nodeConfig.MaxCurVoteAmountPerBlock)
 		if _, err := vote.NewVoteManager(
 			eth,
 			chainDb,


### PR DESCRIPTION
This commit limits the number of votes in future queue per peer as the vote in future queue is not fully verified. The check happens before the costly basicVerify which has to verify the BLS signature.