### PR TITLE
build: add cflags to build portable blst library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ generate-contract:
 	abigen --abi $(RONIN_CONTRACTS_OUTPUT_PATH)/slashing/SlashIndicator.abi --bin $(RONIN_CONTRACTS_OUTPUT_PATH)/slashing/SlashIndicator.bin --pkg slashIndicator --out $(GEN_CONTRACTS_OUTPUT_PATH)/slash_indicator/slash_indicator.go
 
 ronin:
-	$(GORUN) build/ci.go install ./cmd/ronin
+	CGO_CFLAGS="-O -D__BLST_PORTABLE__" $(GORUN) build/ci.go install ./cmd/ronin
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/ronin\" to launch ronin."
 


### PR DESCRIPTION
We randomly get error in CI

	Caught SIGILL in blst_cgo_init, consult <blst>/bindinds/go/README.md.

As in blst documentation, we need to provide CGO_CFLAGS="-O -D__BLST_PORTABLE__" to make the compiled blst portable across different CPU. This commit adds this CGO_CFLAGS to the build process.