### PR TITLE
ethstats: add coinbase to nodeInfo

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -260,7 +260,7 @@ func newFaucet(genesis *core.Genesis, port int, enodes []*enode.Node, network ui
 
 	// Assemble the ethstats monitoring and reporting service'
 	if stats != "" {
-		if err := ethstats.New(stack, lesBackend.ApiBackend, lesBackend.Engine(), stats); err != nil {
+		if err := ethstats.New(stack, lesBackend.ApiBackend, lesBackend.Engine(), stats, common.Address{}); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/ronin/config.go
+++ b/cmd/ronin/config.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"math/big"
 	"os"
@@ -186,7 +187,13 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 	// Add the Ethereum Stats daemon if requested.
 	if cfg.Ethstats.URL != "" {
-		utils.RegisterEthStatsService(stack, backend, cfg.Ethstats.URL)
+		coinbase, err := eth.Etherbase()
+		if err != nil {
+			log.Warn("Failed to get etherbase", "err", err)
+			utils.RegisterEthStatsService(stack, backend, cfg.Ethstats.URL, common.Address{})
+		} else {
+			utils.RegisterEthStatsService(stack, backend, cfg.Ethstats.URL, coinbase)
+		}
 	}
 	return stack, backend
 }

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1832,8 +1832,8 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config) (ethapi.Backend
 
 // RegisterEthStatsService configures the Ethereum Stats daemon and adds it to
 // the given node.
-func RegisterEthStatsService(stack *node.Node, backend ethapi.Backend, url string) {
-	if err := ethstats.New(stack, backend, backend.Engine(), url); err != nil {
+func RegisterEthStatsService(stack *node.Node, backend ethapi.Backend, url string, coinbase common.Address) {
+	if err := ethstats.New(stack, backend, backend.Engine(), url, coinbase); err != nil {
 		Fatalf("Failed to register the Ethereum Stats service: %v", err)
 	}
 }


### PR DESCRIPTION
# Purpose
In order to serve new feature of ronin-stats (knowing coinbase of connected node), I've added coinbase which is get from eth.Etherbase() function.
Empty coinbase is still allowed in case nodes run without adding any account into account manager