### PR TITLE
core/vm: add precompiled contract to verify finality vote violation proof

### DIFF
--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/bls/blst"
+	blsCommon "github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -1724,4 +1726,244 @@ func addressesToByte(addresses []common.Address) [][]byte {
 	}
 
 	return result
+}
+
+func TestValidateFinalityVoteProof(t *testing.T) {
+	contract := consortiumValidateFinalityProof{}
+
+	contractAbi, err := abi.JSON(strings.NewReader(validateFinaltyVoteProofAbi))
+	if err != nil {
+		t.Fatalf("Failed to parse ABI, err %s", err)
+	}
+
+	var secretKey [3]blsCommon.SecretKey
+	for i := 0; i < 3; i++ {
+		secretKey[i], err = blst.RandKey()
+		if err != nil {
+			t.Fatalf("Failed to generate key, err %s", err)
+		}
+	}
+	var blockNumber uint64 = 1
+	blockHash1 := common.Hash{0x1}
+	voteData1 := types.VoteData{
+		TargetNumber: blockNumber,
+		TargetHash:   blockHash1,
+	}
+	digest1 := voteData1.Hash()
+	blockHash2 := common.Hash{0x2}
+	voteData2 := types.VoteData{
+		TargetNumber: blockNumber,
+		TargetHash:   blockHash2,
+	}
+	digest2 := voteData2.Hash()
+
+	targetBlockHashes := [2]common.Hash{blockHash1, blockHash1}
+	listOfPublicKeys := [2][][]byte{
+		{
+			secretKey[0].PublicKey().Marshal(),
+		},
+		{
+			secretKey[0].PublicKey().Marshal(),
+		},
+	}
+	voterPublicKey := secretKey[0].PublicKey().Marshal()
+	aggregatedSignature := [2][]byte{
+		secretKey[0].Sign(digest1[:]).Marshal(),
+		secretKey[0].Sign(digest1[:]).Marshal(),
+	}
+
+	input, err := contractAbi.Pack(
+		validateFinaltyVoteProof,
+		voterPublicKey,
+		new(big.Int).Add(new(big.Int).SetUint64(1<<64-1), common.Big1),
+		targetBlockHashes,
+		listOfPublicKeys,
+		aggregatedSignature,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack contract input, err: %s", err)
+	}
+
+	_, err = contract.Run(input)
+	if err == nil || err.Error() != "malformed target block number" {
+		t.Fatalf("Expect to get error %s have %s", "malformed target block number", err)
+	}
+
+	input, err = contractAbi.Pack(
+		validateFinaltyVoteProof,
+		voterPublicKey,
+		big.NewInt(int64(blockNumber)),
+		targetBlockHashes,
+		listOfPublicKeys,
+		aggregatedSignature,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack contract input, err: %s", err)
+	}
+
+	_, err = contract.Run(input)
+	if err == nil || err.Error() != "block hash is the same" {
+		t.Fatalf("Expect to get error %s have %s", "block hash is the same", err)
+	}
+
+	targetBlockHashes = [2]common.Hash{
+		blockHash1,
+		blockHash2,
+	}
+	aggregatedSignature = [2][]byte{
+		secretKey[0].Sign(digest1[:]).Marshal(),
+		secretKey[1].Sign(digest2[:]).Marshal(),
+	}
+	listOfPublicKeys = [2][][]byte{
+		{
+			secretKey[0].PublicKey().Marshal(),
+		},
+		{
+			secretKey[1].PublicKey().Marshal(),
+		},
+	}
+
+	input, err = contractAbi.Pack(
+		validateFinaltyVoteProof,
+		voterPublicKey,
+		big.NewInt(int64(blockNumber)),
+		targetBlockHashes,
+		listOfPublicKeys,
+		aggregatedSignature,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack contract input, err: %s", err)
+	}
+
+	_, err = contract.Run(input)
+	if err == nil || err.Error() != "reported voter does not in public key list" {
+		t.Fatalf("Expect to get error %s have %s", "reported voter does not in public key list", err)
+	}
+
+	aggregatedSignature = [2][]byte{
+		blst.AggregateSignatures([]blsCommon.Signature{
+			secretKey[0].Sign(digest1[:]),
+			secretKey[1].Sign(digest1[:]),
+		}).Marshal(),
+		blst.AggregateSignatures([]blsCommon.Signature{
+			secretKey[0].Sign(digest2[:]),
+			secretKey[2].Sign(digest2[:]),
+		}).Marshal(),
+	}
+
+	listOfPublicKeys = [2][][]byte{
+		{
+			secretKey[0].PublicKey().Marshal(),
+			secretKey[1].PublicKey().Marshal(),
+		},
+		{
+			secretKey[0].PublicKey().Marshal(),
+			secretKey[2].PublicKey().Marshal(),
+		},
+	}
+
+	input, err = contractAbi.Pack(
+		validateFinaltyVoteProof,
+		voterPublicKey,
+		big.NewInt(int64(blockNumber)),
+		targetBlockHashes,
+		listOfPublicKeys,
+		aggregatedSignature,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack contract input, err: %s", err)
+	}
+
+	rawReturn, err := contract.Run(input)
+	if err != nil {
+		t.Fatalf("Expect to successfully verify proof, get %s", err)
+	}
+
+	ret, err := contractAbi.Unpack(validateFinaltyVoteProof, rawReturn)
+	if err != nil {
+		t.Fatalf("Failed to unpack output, err: %s", err)
+	}
+
+	returnedBool := (ret[0]).(bool)
+	if returnedBool != true {
+		t.Fatalf("Expect the returned value to be true, get %v", returnedBool)
+	}
+}
+
+func BenchmarkPrecompiledValidateFinalityVoteProof(b *testing.B) {
+	contractAbi, err := abi.JSON(strings.NewReader(validateFinaltyVoteProofAbi))
+	if err != nil {
+		b.Fatalf("Failed to parse ABI, err %s", err)
+	}
+
+	var secretKeys []blsCommon.SecretKey
+	for i := 0; i < 200; i++ {
+		key, err := blst.RandKey()
+		if err != nil {
+			b.Fatalf("Failed to generate secret key")
+		}
+
+		secretKeys = append(secretKeys, key)
+	}
+	blockNumber := 10000
+	blockHash1 := crypto.Keccak256Hash([]byte{'t', 'e', 's', 't'})
+	vote := types.VoteData{
+		TargetNumber: uint64(blockNumber),
+		TargetHash:   blockHash1,
+	}
+	digest1 := vote.Hash()
+
+	blockHash2 := crypto.Keccak256Hash([]byte{'t', 'e', 's', 't', '2'})
+	vote = types.VoteData{
+		TargetNumber: uint64(blockNumber),
+		TargetHash:   blockHash2,
+	}
+	digest2 := vote.Hash()
+
+	var signature [100]blsCommon.Signature
+	var listOfPublicKey [2][][]byte
+	for i := 0; i < 100; i++ {
+		signature[i] = secretKeys[i].Sign(digest1[:])
+		listOfPublicKey[0] = append(listOfPublicKey[0], secretKeys[i].PublicKey().Marshal())
+	}
+	aggregatedSignature1 := blst.AggregateSignatures(signature[:])
+
+	signature[0] = secretKeys[0].Sign(digest2[:])
+	listOfPublicKey[1] = append(listOfPublicKey[1], secretKeys[0].PublicKey().Marshal())
+	for i := 101; i < 200; i++ {
+		signature[i-100] = secretKeys[i].Sign(digest2[:])
+		listOfPublicKey[1] = append(listOfPublicKey[1], secretKeys[i].PublicKey().Marshal())
+	}
+	aggregatedSignature2 := blst.AggregateSignatures(signature[:])
+
+	input, err := contractAbi.Pack(
+		validateFinaltyVoteProof,
+		secretKeys[0].PublicKey().Marshal(),
+		big.NewInt(int64(blockNumber)),
+		[2]common.Hash{
+			blockHash1,
+			blockHash2,
+		},
+		listOfPublicKey,
+		[2][]byte{
+			aggregatedSignature1.Marshal(),
+			aggregatedSignature2.Marshal(),
+		},
+	)
+	if err != nil {
+		b.Fatalf("Failed to pack contract input, err: %s", err)
+	}
+
+	output, err := contractAbi.Methods[validateFinaltyVoteProof].Outputs.Pack(true)
+	if err != nil {
+		b.Fatalf("Failed to pack contract output, err: %s", err)
+	}
+
+	test := precompiledTest{
+		Input:    common.Bytes2Hex(input),
+		Expected: common.Bytes2Hex(output),
+		Name:     "200-public-keys",
+	}
+
+	benchmarkPrecompiled("69", test, b)
 }

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/log"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -70,6 +71,7 @@ var allPrecompiles = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{17}):   &bls12381MapG1{},
 	common.BytesToAddress([]byte{18}):   &bls12381MapG2{},
 	common.BytesToAddress([]byte{101}):  &consortiumLog{},
+	common.BytesToAddress([]byte{105}):  &consortiumValidateFinalityProof{},
 }
 
 // EIP-152 test vectors

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -153,6 +153,8 @@ const (
 	Bls12381MapG1Gas          uint64 = 5500   // Gas price for BLS12-381 mapping field element to G1 operation
 	Bls12381MapG2Gas          uint64 = 110000 // Gas price for BLS12-381 mapping field element to G2 operation
 
+	ValidateFinalityProofGas uint64 = 200000 // Gas for validating finality proof
+
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529
 	RefundQuotient        uint64 = 2


### PR DESCRIPTION
This precompiled contract is called by system contract to verify signature from the provided proof of finality vote violation. It checkes if there is a validator has contributed to 2 aggregated signatures on the 2 distinct block with the same height.