### PR TITLE
consortium/v2: add contract interaction to get BLS public key

### DIFF
--- a/consensus/consortium/generated_contracts/profile/profile.go
+++ b/consensus/consortium/generated_contracts/profile/profile.go
@@ -1,0 +1,222 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package profile
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IProfileCandidateProfile is an auto generated low-level Go binding around an user-defined struct.
+type IProfileCandidateProfile struct {
+	Id        common.Address
+	Consensus common.Address
+	Admin     common.Address
+	Treasury  common.Address
+	Governor  common.Address
+	Pubkey    []byte
+}
+
+// ProfileMetaData contains all meta data concerning the Profile contract.
+var ProfileMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"id\",\"type\":\"address\"}],\"name\":\"getId2Profile\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"id\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"consensus\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"admin\",\"type\":\"address\"},{\"internalType\":\"addresspayable\",\"name\":\"treasury\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"governor\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"pubkey\",\"type\":\"bytes\"}],\"internalType\":\"structIProfile.CandidateProfile\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// ProfileABI is the input ABI used to generate the binding from.
+// Deprecated: Use ProfileMetaData.ABI instead.
+var ProfileABI = ProfileMetaData.ABI
+
+// Profile is an auto generated Go binding around an Ethereum contract.
+type Profile struct {
+	ProfileCaller     // Read-only binding to the contract
+	ProfileTransactor // Write-only binding to the contract
+	ProfileFilterer   // Log filterer for contract events
+}
+
+// ProfileCaller is an auto generated read-only Go binding around an Ethereum contract.
+type ProfileCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ProfileTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type ProfileTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ProfileFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type ProfileFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// ProfileSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type ProfileSession struct {
+	Contract     *Profile          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// ProfileCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type ProfileCallerSession struct {
+	Contract *ProfileCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// ProfileTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type ProfileTransactorSession struct {
+	Contract     *ProfileTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// ProfileRaw is an auto generated low-level Go binding around an Ethereum contract.
+type ProfileRaw struct {
+	Contract *Profile // Generic contract binding to access the raw methods on
+}
+
+// ProfileCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type ProfileCallerRaw struct {
+	Contract *ProfileCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// ProfileTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type ProfileTransactorRaw struct {
+	Contract *ProfileTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewProfile creates a new instance of Profile, bound to a specific deployed contract.
+func NewProfile(address common.Address, backend bind.ContractBackend) (*Profile, error) {
+	contract, err := bindProfile(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Profile{ProfileCaller: ProfileCaller{contract: contract}, ProfileTransactor: ProfileTransactor{contract: contract}, ProfileFilterer: ProfileFilterer{contract: contract}}, nil
+}
+
+// NewProfileCaller creates a new read-only instance of Profile, bound to a specific deployed contract.
+func NewProfileCaller(address common.Address, caller bind.ContractCaller) (*ProfileCaller, error) {
+	contract, err := bindProfile(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ProfileCaller{contract: contract}, nil
+}
+
+// NewProfileTransactor creates a new write-only instance of Profile, bound to a specific deployed contract.
+func NewProfileTransactor(address common.Address, transactor bind.ContractTransactor) (*ProfileTransactor, error) {
+	contract, err := bindProfile(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &ProfileTransactor{contract: contract}, nil
+}
+
+// NewProfileFilterer creates a new log filterer instance of Profile, bound to a specific deployed contract.
+func NewProfileFilterer(address common.Address, filterer bind.ContractFilterer) (*ProfileFilterer, error) {
+	contract, err := bindProfile(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &ProfileFilterer{contract: contract}, nil
+}
+
+// bindProfile binds a generic wrapper to an already deployed contract.
+func bindProfile(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := ProfileMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Profile *ProfileRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Profile.Contract.ProfileCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Profile *ProfileRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Profile.Contract.ProfileTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Profile *ProfileRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Profile.Contract.ProfileTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Profile *ProfileCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Profile.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Profile *ProfileTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Profile.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Profile *ProfileTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Profile.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetId2Profile is a free data retrieval call binding the contract method 0xf4660940.
+//
+// Solidity: function getId2Profile(address id) view returns((address,address,address,address,address,bytes))
+func (_Profile *ProfileCaller) GetId2Profile(opts *bind.CallOpts, id common.Address) (IProfileCandidateProfile, error) {
+	var out []interface{}
+	err := _Profile.contract.Call(opts, &out, "getId2Profile", id)
+
+	if err != nil {
+		return *new(IProfileCandidateProfile), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IProfileCandidateProfile)).(*IProfileCandidateProfile)
+
+	return out0, err
+
+}
+
+// GetId2Profile is a free data retrieval call binding the contract method 0xf4660940.
+//
+// Solidity: function getId2Profile(address id) view returns((address,address,address,address,address,bytes))
+func (_Profile *ProfileSession) GetId2Profile(id common.Address) (IProfileCandidateProfile, error) {
+	return _Profile.Contract.GetId2Profile(&_Profile.CallOpts, id)
+}
+
+// GetId2Profile is a free data retrieval call binding the contract method 0xf4660940.
+//
+// Solidity: function getId2Profile(address id) view returns((address,address,address,address,address,bytes))
+func (_Profile *ProfileCallerSession) GetId2Profile(id common.Address) (IProfileCandidateProfile, error) {
+	return _Profile.Contract.GetId2Profile(&_Profile.CallOpts, id)
+}

--- a/params/config.go
+++ b/params/config.go
@@ -522,6 +522,7 @@ type ConsortiumV2Contracts struct {
 	StakingContract   common.Address `json:"stakingContract"`
 	RoninValidatorSet common.Address `json:"roninValidatorSet"`
 	SlashIndicator    common.Address `json:"slashIndicator"`
+	ProfileContract   common.Address `json:"profileContract"`
 }
 
 func (c *ConsortiumV2Contracts) IsSystemContract(address common.Address) bool {
@@ -563,10 +564,16 @@ func (c *ChainConfig) String() string {
 		stakingContract = c.ConsortiumV2Contracts.StakingContract
 	}
 
+	profileContract := common.HexToAddress("")
+	if c.ConsortiumV2Contracts != nil {
+		profileContract = c.ConsortiumV2Contracts.ProfileContract
+	}
+
 	chainConfigFmt := "{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v "
 	chainConfigFmt += "Petersburg: %v Istanbul: %v, Odysseus: %v, Fenix: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, "
 	chainConfigFmt += "Engine: %v, Blacklist Contract: %v, Fenix Validator Contract: %v, ConsortiumV2: %v, ConsortiumV2.RoninValidatorSet: %v, "
-	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v, Olek: %v, Shillin: %v}"
+	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v, Olek: %v, Shillin: %v, "
+	chainConfigFmt += "ConsortiumV2.ProfileContract: %v}"
 
 	return fmt.Sprintf(chainConfigFmt,
 		c.ChainID,
@@ -597,6 +604,7 @@ func (c *ChainConfig) String() string {
 		c.BubaBlock,
 		c.OlekBlock,
 		c.ShillinBlock,
+		profileContract.Hex(),
 	)
 }
 


### PR DESCRIPTION
This commit adds the contract interaction to get BLS public when preparing checkpoint block. This also creates a getCheckpointValidatorsFromContract function to be used in both Prepare and Finalize the checkpoint block. Besides, a new interface ContractInteraction is created for mock test contract interaction.