### PR TITLE
blockchain: check total difficulty only when having same justified block number

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1331,6 +1331,8 @@ func (bc *BlockChain) reorgNeeded(localBlock *types.Block, localTd *big.Int, ext
 
 		if externJustifiedBlockNumber > localJustifiedBlockNumber {
 			return true
+		} else if externJustifiedBlockNumber < localJustifiedBlockNumber {
+			return false
 		}
 	}
 


### PR DESCRIPTION
In fork choice, we only need to compare the difficulty of forks when the justified block numbers are the same in those forks. Otherwise, we choose the fork with higher justified block number. This commit fixes a bug in current fork choice to make it follow the correct behavior.