### PR TITLE
eth/backend: add vote pool to consortium engine

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -287,6 +287,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			}
 			return state.GetFenixValidators(stateDb, eth.blockchain.Config().FenixValidatorContractAddress), nil
 		})
+		if votePool != nil {
+			c.SetVotePool(votePool)
+		}
 	}
 	// The first thing the node will do is reconstruct the verification data for
 	// the head block (ethash cache or clique voting snapshot). Might as well do


### PR DESCRIPTION
When the vote pool is enabled, make the consortium consensus engine use it.