### PR TITLE
consortium/v2: edit the finality vote threshold

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -245,7 +245,7 @@ func (c *Consortium) verifyFinalitySignatures(
 	}
 
 	votedValidatorPositions := finalityVotedValidators.Indices()
-	if len(votedValidatorPositions) <= int(math.Floor(finalityRatio*float64(len(snap.ValidatorsWithBlsPub))))+1 {
+	if len(votedValidatorPositions) < int(math.Floor(finalityRatio*float64(len(snap.ValidatorsWithBlsPub))))+1 {
 		return finality.ErrNotEnoughFinalityVote
 	}
 
@@ -1131,7 +1131,7 @@ func (c *Consortium) assembleFinalityVote(header *types.Header, snap *Snapshot) 
 		// so we do not verify signature here
 		if c.votePool != nil {
 			votes := c.votePool.FetchVoteByBlockHash(header.ParentHash)
-			if len(votes) > finalityThreshold {
+			if len(votes) >= finalityThreshold {
 				for _, vote := range votes {
 					publicKey, err := blst.PublicKeyFromBytes(vote.PublicKey[:])
 					if err != nil {
@@ -1161,7 +1161,7 @@ func (c *Consortium) assembleFinalityVote(header *types.Header, snap *Snapshot) 
 				}
 
 				bitSetCount := len(finalityVotedValidators.Indices())
-				if bitSetCount > finalityThreshold {
+				if bitSetCount >= finalityThreshold {
 					extraData, err := finality.DecodeExtra(header.Extra, true)
 					if err != nil {
 						// This should not happen

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -525,7 +525,7 @@ func TestExtraDataDecode(t *testing.T) {
 }
 
 func TestVerifyFinalitySignature(t *testing.T) {
-	const numValidator = 4
+	const numValidator = 3
 	var err error
 
 	secretKey := make([]blsCommon.SecretKey, numValidator+1)
@@ -581,8 +581,7 @@ func TestVerifyFinalitySignature(t *testing.T) {
 	votedBitSet = finality.FinalityVoteBitSet(0)
 	votedBitSet.SetBit(0)
 	votedBitSet.SetBit(1)
-	votedBitSet.SetBit(2)
-	votedBitSet.SetBit(4)
+	votedBitSet.SetBit(3)
 	err = c.verifyFinalitySignatures(nil, votedBitSet, nil, 0, snap.Hash, nil)
 	if !errors.Is(err, finality.ErrInvalidFinalityVotedBitSet) {
 		t.Errorf("Expect error %v have %v", finality.ErrInvalidFinalityVotedBitSet, err)
@@ -592,12 +591,10 @@ func TestVerifyFinalitySignature(t *testing.T) {
 	votedBitSet.SetBit(0)
 	votedBitSet.SetBit(1)
 	votedBitSet.SetBit(2)
-	votedBitSet.SetBit(3)
 	aggregatedSignature := blst.AggregateSignatures([]blsCommon.Signature{
 		signature[0],
 		signature[1],
-		signature[2],
-		signature[4],
+		signature[3],
 	})
 	err = c.verifyFinalitySignatures(nil, votedBitSet, aggregatedSignature, 0, snap.Hash, nil)
 	if !errors.Is(err, finality.ErrFinalitySignatureVerificationFailed) {
@@ -608,13 +605,11 @@ func TestVerifyFinalitySignature(t *testing.T) {
 	votedBitSet.SetBit(0)
 	votedBitSet.SetBit(1)
 	votedBitSet.SetBit(2)
-	votedBitSet.SetBit(3)
 	aggregatedSignature = blst.AggregateSignatures([]blsCommon.Signature{
 		signature[0],
 		signature[1],
 		signature[2],
 		signature[3],
-		signature[4],
 	})
 	err = c.verifyFinalitySignatures(nil, votedBitSet, aggregatedSignature, 0, snap.Hash, nil)
 	if !errors.Is(err, finality.ErrFinalitySignatureVerificationFailed) {
@@ -625,12 +620,10 @@ func TestVerifyFinalitySignature(t *testing.T) {
 	votedBitSet.SetBit(0)
 	votedBitSet.SetBit(1)
 	votedBitSet.SetBit(2)
-	votedBitSet.SetBit(3)
 	aggregatedSignature = blst.AggregateSignatures([]blsCommon.Signature{
 		signature[0],
 		signature[1],
 		signature[2],
-		signature[3],
 	})
 	err = c.verifyFinalitySignatures(nil, votedBitSet, aggregatedSignature, 0, snap.Hash, nil)
 	if err != nil {


### PR DESCRIPTION
Due to the change in REP-0003, a block is finalized when there are at least floor(2/3*numValidators) + 1, this commit changes the calculation to follow the rule.