### PR TITLE
consortium/v2: add VerifyVote and fix blsPublicKey access

### DIFF
--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -238,6 +238,12 @@ func (c *Consortium) IsActiveValidatorAt(chain consensus.ChainHeaderReader, head
 	return false
 }
 
+// VerifyVote check if the finality voter is in the validator set, it assumes the signature is
+// already verified
+func (c *Consortium) VerifyVote(chain consensus.ChainHeaderReader, vote *types.VoteEnvelope) error {
+	return c.v2.VerifyVote(chain, vote)
+}
+
 // GetActiveValidatorAt always return false before Shillin
 // See the comment for GetActiveValidatorAt in v2 package
 // for more information


### PR DESCRIPTION
- consortium: add VerifyVote to the outer consortium

As required by the FastFinalityPoSA interface, VerifyVote is needed in the outer
consortium. We add VerifyVote to outer consortium which simply forwards to the
consortium v2 function.

- consortium/v2: access blsPublicKey only after Shillin

The BLS public key is only available in checkpoint header after Shillin, so
don't access this field before Shillin.