### PR TITLE
consortium/v2: fix the incorrect snapshot lookup in GetFinalizedBlock

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -1197,8 +1197,14 @@ func (c *Consortium) GetFinalizedBlock(
 		justifiedHash, descendantJustifiedHash     common.Hash
 	)
 
+	justifiedNumber = headNumber
+	justifiedHash = headHash
+
 	for {
-		justifiedNumber, justifiedHash = c.GetJustifiedBlock(chain, headNumber, headHash)
+		// When getting the snapshot at block N, the maximum justified number is N - 1.
+		// Here, we want to check if the block at justifiedNumber - 1 is justified too.
+		// So, the snapshot we need to look up is at justifiedNumber.
+		justifiedNumber, justifiedHash = c.GetJustifiedBlock(chain, justifiedNumber, justifiedHash)
 		if justifiedNumber == 0 {
 			return 0, common.Hash{}
 		}
@@ -1235,9 +1241,6 @@ func (c *Consortium) GetFinalizedBlock(
 			}
 		}
 
-		header := chain.GetHeaderByHash(justifiedHash)
-		headNumber = header.Number.Uint64() - 1
-		headHash = header.ParentHash
 		descendantJustifiedNumber = justifiedNumber
 		descendantJustifiedHash = justifiedHash
 	}


### PR DESCRIPTION
Currently, to check if the justified block number - 1 is justfied, we look at the snapshot at justfied block number - 1. This is incorrect because at the snapshot N, the maximum justified block number is N - 1. So, we need to look at the snapshot at justified block number to check if the justified block number - 1 is justified.