### PR TITLE
core/state: filter out nil trie for copy (#25575)

### DIFF
--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -127,6 +127,9 @@ func (p *triePrefetcher) copy() *triePrefetcher {
 	// If the prefetcher is already a copy, duplicate the data
 	if p.fetches != nil {
 		for root, fetch := range p.fetches {
+			if fetch == nil {
+				continue
+			}
 			copy.fetches[root] = p.db.CopyTrie(fetch)
 		}
 		return copy


### PR DESCRIPTION
We randomly observed RPC handler crash as below
```
Trie prefetcher failed opening trie      root=fa2e9d..feb309 err="missing trie node fa2e9d5691bc60f8fd9954a3b5d7cee13b5e6cd62ce89300dda9f6b60efeb309 (path )"
RPC method eth_getCode crashed: unknown trie type <nil>
goroutine 262465 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
	github.com/ethereum/go-ethereum/rpc/service.go:200 +0x9e
panic({0x1e77de0, 0xc04b6d4b20})
	runtime/panic.go:890 +0x263
github.com/ethereum/go-ethereum/core/state.(*cachingDB).CopyTrie(0x1e9a560?, {0x0?, 0x0?})
	github.com/ethereum/go-ethereum/core/state/database.go:158 +0x145
github.com/ethereum/go-ethereum/core/state.(*triePrefetcher).copy(0xc04a9cd040)
	github.com/ethereum/go-ethereum/core/state/trie_prefetcher.go:130 +0x930
github.com/ethereum/go-ethereum/core/state.(*StateDB).Copy(0xc01d06d520)
	github.com/ethereum/go-ethereum/core/state/statedb.go:723 +0x1696
github.com/ethereum/go-ethereum/miner.(*worker).pending(0xc029cb18c0)
	github.com/ethereum/go-ethereum/miner/worker.go:341 +0x105
github.com/ethereum/go-ethereum/miner.(*Miner).Pending(...)
	github.com/ethereum/go-ethereum/miner/miner.go:194
github.com/ethereum/go-ethereum/eth.(*EthAPIBackend).StateAndHeaderByNumber(0xc029c838d8, {0x2459430, 0xc01db10fa0}, 0xfffffffffffffffe)
	github.com/ethereum/go-ethereum/eth/api_backend.go:153 +0x31b
github.com/ethereum/go-ethereum/eth.(*EthAPIBackend).StateAndHeaderByNumberOrHash(0xc029c838d8, {0x2459430, 0xc01db10fa0}, {0xc0212b29e8, 0x0, 0x0})
	github.com/ethereum/go-ethereum/eth/api_backend.go:170 +0x66d
```
This PR cherry-picks a commit from Ethereum to nil check before copying trie.