### PR TITLE
eth: better active protocol handler tracking (#27665)

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -121,7 +121,9 @@ type handler struct {
 
 	chainSync *chainSyncer
 	wg        sync.WaitGroup
-	peerWG    sync.WaitGroup
+
+	handlerStartCh chan struct{}
+	handlerDoneCh  chan struct{}
 }
 
 // newHandler returns a handler for all Ethereum chain management protocol.
@@ -131,15 +133,17 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		config.EventMux = new(event.TypeMux) // Nicety initialization for tests
 	}
 	h := &handler{
-		networkID:  config.Network,
-		forkFilter: forkid.NewFilter(config.Chain),
-		eventMux:   config.EventMux,
-		database:   config.Database,
-		txpool:     config.TxPool,
-		chain:      config.Chain,
-		peers:      newPeerSet(),
-		whitelist:  config.Whitelist,
-		quitSync:   make(chan struct{}),
+		networkID:      config.Network,
+		forkFilter:     forkid.NewFilter(config.Chain),
+		eventMux:       config.EventMux,
+		database:       config.Database,
+		txpool:         config.TxPool,
+		chain:          config.Chain,
+		peers:          newPeerSet(),
+		whitelist:      config.Whitelist,
+		quitSync:       make(chan struct{}),
+		handlerDoneCh:  make(chan struct{}),
+		handlerStartCh: make(chan struct{}),
 	}
 	if config.Sync == downloader.FullSync {
 		// The database seems empty as the current block is the genesis. Yet the fast
@@ -231,9 +235,50 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	return h, nil
 }
 
+// protoTracker tracks the number of active protocol handlers.
+func (h *handler) protoTracker() {
+	defer h.wg.Done()
+	var active int
+	for {
+		select {
+		case <-h.handlerStartCh:
+			active++
+		case <-h.handlerDoneCh:
+			active--
+		case <-h.quitSync:
+			// Wait for all active handlers to finish.
+			for ; active > 0; active-- {
+				<-h.handlerDoneCh
+			}
+			return
+		}
+	}
+}
+
+// incHandlers signals to increment the number of active handlers if not
+// quitting.
+func (h *handler) incHandlers() bool {
+	select {
+	case h.handlerStartCh <- struct{}{}:
+		return true
+	case <-h.quitSync:
+		return false
+	}
+}
+
+// decHandlers signals to decrement the number of active handlers.
+func (h *handler) decHandlers() {
+	h.handlerDoneCh <- struct{}{}
+}
+
 // runEthPeer registers an eth peer into the joint eth/snap peerset, adds it to
 // various subsistems and starts handling messages.
 func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
+	if !h.incHandlers() {
+		return p2p.DiscQuitting
+	}
+	defer h.decHandlers()
+
 	// If the peer has a `snap` extension, wait for it to connect so we can have
 	// a uniform initialization/teardown mechanism
 	snap, err := h.peers.waitSnapExtension(peer)
@@ -241,12 +286,6 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		peer.Log().Error("Snapshot extension barrier failed", "err", err)
 		return err
 	}
-	// TODO(karalabe): Not sure why this is needed
-	if !h.chainSync.handlePeerEvent(peer) {
-		return p2p.DiscQuitting
-	}
-	h.peerWG.Add(1)
-	defer h.peerWG.Done()
 
 	// Execute the Ethereum handshake
 	var (
@@ -302,7 +341,7 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 			return err
 		}
 	}
-	h.chainSync.handlePeerEvent(peer)
+	h.chainSync.handlePeerEvent()
 
 	// Propagate existing transactions. new transactions appearing
 	// after this will be sent via broadcasts.
@@ -342,8 +381,10 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 // `eth`, all subsystem registrations and lifecycle management will be done by
 // the main `eth` handler to prevent strange races.
 func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error {
-	h.peerWG.Add(1)
-	defer h.peerWG.Done()
+	if !h.incHandlers() {
+		return p2p.DiscQuitting
+	}
+	defer h.decHandlers()
 
 	if err := h.peers.registerSnapExtension(peer); err != nil {
 		peer.Log().Info("Snapshot extension registration failed", "err", err)
@@ -408,6 +449,10 @@ func (h *handler) Start(maxPeers int) {
 	// start sync handlers
 	h.wg.Add(1)
 	go h.chainSync.loop()
+
+	// start peer handler tracker
+	h.wg.Add(1)
+	go h.protoTracker()
 }
 
 func (h *handler) Stop() {
@@ -417,14 +462,13 @@ func (h *handler) Stop() {
 	// Quit chainSync and txsync64.
 	// After this is done, no new peers will be accepted.
 	close(h.quitSync)
-	h.wg.Wait()
 
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.
 	// sessions which are already established but not added to h.peers yet
 	// will exit when they try to register.
 	h.peers.close()
-	h.peerWG.Wait()
+	h.wg.Wait()
 
 	log.Info("Ethereum protocol stopped")
 }

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -212,7 +212,7 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td
 	// Update the peer's total difficulty if better than the previous
 	if _, td := peer.Head(); trueTD.Cmp(td) > 0 {
 		peer.SetHead(trueHead, trueTD)
-		h.chainSync.handlePeerEvent(peer)
+		h.chainSync.handlePeerEvent()
 	}
 	return nil
 }

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -88,7 +88,7 @@ func newChainSyncer(handler *handler) *chainSyncer {
 // handlePeerEvent notifies the syncer about a change in the peer set.
 // This is called for new peers and every time a peer announces a new
 // chain head.
-func (cs *chainSyncer) handlePeerEvent(peer *eth.Peer) bool {
+func (cs *chainSyncer) handlePeerEvent() bool {
 	select {
 	case cs.peerEventCh <- struct{}{}:
 		return true


### PR DESCRIPTION
Fixes an issue where waitgroups were used erroneously, which could lead to waitgroup being added to while wait was already invoked.

We randomly observed this when restart node running with race detector
```
WARNING: DATA RACE
Read at 0x00c005eef778 by goroutine 37506:
  runtime.raceread()
      <autogenerated>:1 +0x24
  github.com/ethereum/go-ethereum/eth.(*handler).runSnapExtension()
      github.com/ethereum/go-ethereum/eth/handler.go:366 +0x79
  github.com/ethereum/go-ethereum/eth.(*snapHandler).RunPeer()
      github.com/ethereum/go-ethereum/eth/handler_snap.go:33 +0x44
  github.com/ethereum/go-ethereum/eth/protocols/snap.MakeProtocols.func2()
      github.com/ethereum/go-ethereum/eth/protocols/snap/handler.go:102 +0xee
  github.com/ethereum/go-ethereum/p2p.(*Peer).startProtocols.func1()
      github.com/ethereum/go-ethereum/p2p/peer.go:426 +0xf0

Previous write at 0x00c005eef778 by goroutine 37497:
  runtime.racewrite()
      <autogenerated>:1 +0x24
  github.com/ethereum/go-ethereum/eth.(*handler).Stop()
      github.com/ethereum/go-ethereum/eth/handler.go:470 +0x134
  github.com/ethereum/go-ethereum/eth.(*Ethereum).Stop()
      github.com/ethereum/go-ethereum/eth/backend.go:640 +0x92
  github.com/ethereum/go-ethereum/node.(*Node).stopServices()
      github.com/ethereum/go-ethereum/node/node.go:300 +0x14e
  github.com/ethereum/go-ethereum/node.(*Node).Close()
      github.com/ethereum/go-ethereum/node/node.go:220 +0x1a4
  github.com/ethereum/go-ethereum/cmd/utils.StartNode.func1.3()
      github.com/ethereum/go-ethereum/cmd/utils/cmd.go:92 +0x39
```
This is due to the incorrect use of peerWG waitgroup which could lead to panic. This PR cherry-picks the commit from Ethereum to remove this waitgroup and use channel for correctly spin down node.