### PR TITLE
devp2p: add IP filter and ronin mainnet/testnet filter for nodeset filter

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -34,6 +34,7 @@ var (
 	RinkebyGenesisHash      = common.HexToHash("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177")
 	GoerliGenesisHash       = common.HexToHash("0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a")
 	RoninMainnetGenesisHash = common.HexToHash("0x6e675ee97607f4e695188786c3c1853fb1562f1c075629eb5dbcff269422a1a4")
+	RoninTestnetGenesisHash = common.HexToHash("0x13e47595099383189b8b0d5f3b67aa161495e478bb3fea64f4cf85cdf69cac4d")
 )
 
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of
@@ -235,6 +236,9 @@ var (
 
 	RoninMainnetBlacklistContract             = common.HexToAddress("0x313b24994c93FA0471CB4D7aB796b07467041806")
 	RoninMainnetFenixValidatorContractAddress = common.HexToAddress("0x7f13232Bdc3a010c3f749a1c25bF99f1C053CE70")
+	RoninMainnetRoninValidatorSetAddress      = common.HexToAddress("0x617c5d73662282EA7FfD231E020eCa6D2B0D552f")
+	RoninMainnetSlashIndicatorAddress         = common.HexToAddress("0xEBFFF2b32fA0dF9C5C8C5d5AAa7e8b51d5207bA3")
+	RoninMainnetStakingContractAddress        = common.HexToAddress("0x545edb750eB8769C868429BE9586F5857A768758")
 
 	RoninMainnetChainConfig = &ChainConfig{
 		ChainID:                       big.NewInt(2020),
@@ -251,9 +255,55 @@ var (
 		BlacklistContractAddress:      &RoninMainnetBlacklistContract,
 		FenixValidatorContractAddress: &RoninMainnetFenixValidatorContractAddress,
 		Consortium: &ConsortiumConfig{
-			Period: 3,
-			Epoch:  600,
+			Period:  3,
+			Epoch:   600,
+			EpochV2: 200,
 		},
+		ConsortiumV2Contracts: &ConsortiumV2Contracts{
+			RoninValidatorSet: RoninMainnetRoninValidatorSetAddress,
+			SlashIndicator:    RoninMainnetSlashIndicatorAddress,
+			StakingContract:   RoninMainnetStakingContractAddress,
+		},
+		ConsortiumV2Block: big.NewInt(23155200),
+		PuffyBlock:        big.NewInt(0),
+		BubaBlock:         big.NewInt(0),
+		OlekBlock:         big.NewInt(24935500),
+	}
+
+	RoninTestnetBlacklistContract             = common.HexToAddress("0xF53EED5210c9cF308abFe66bA7CF14884c95A8aC")
+	RoninTestnetFenixValidatorContractAddress = common.HexToAddress("0x1454cAAd1637b662432Bb795cD5773d21281eDAb")
+	RoninTestnetRoninValidatorSetAddress      = common.HexToAddress("0x54B3AC74a90E64E8dDE60671b6fE8F8DDf18eC9d")
+	RoninTestnetSlashIndicatorAddress         = common.HexToAddress("0xF7837778b6E180Df6696C8Fa986d62f8b6186752")
+	RoninTestnetStakingContractAddress        = common.HexToAddress("0x9C245671791834daf3885533D24dce516B763B28")
+
+	RoninTestnetChainConfig = &ChainConfig{
+		ChainID:                       big.NewInt(2021),
+		HomesteadBlock:                big.NewInt(0),
+		EIP150Block:                   big.NewInt(0),
+		EIP155Block:                   big.NewInt(0),
+		EIP158Block:                   big.NewInt(0),
+		ByzantiumBlock:                big.NewInt(0),
+		ConstantinopleBlock:           big.NewInt(0),
+		PetersburgBlock:               big.NewInt(0),
+		IstanbulBlock:                 big.NewInt(0),
+		OdysseusBlock:                 big.NewInt(3315095),
+		FenixBlock:                    big.NewInt(6770400),
+		BlacklistContractAddress:      &RoninTestnetBlacklistContract,
+		FenixValidatorContractAddress: &RoninTestnetFenixValidatorContractAddress,
+		Consortium: &ConsortiumConfig{
+			Period:  3,
+			Epoch:   30,
+			EpochV2: 200,
+		},
+		ConsortiumV2Contracts: &ConsortiumV2Contracts{
+			RoninValidatorSet: RoninTestnetRoninValidatorSetAddress,
+			SlashIndicator:    RoninTestnetSlashIndicatorAddress,
+			StakingContract:   RoninTestnetStakingContractAddress,
+		},
+		ConsortiumV2Block: big.NewInt(11706000),
+		PuffyBlock:        big.NewInt(12254000),
+		BubaBlock:         big.NewInt(14260600),
+		OlekBlock:         big.NewInt(16849000),
 	}
 
 	// GoerliTrustedCheckpoint contains the light client trusted checkpoint for the Görli test network.

--- a/script/gen_dns_txt.sh
+++ b/script/gen_dns_txt.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Create the DNS TXT record from the list of nodes
+
+unset BOOTNODES
+unset NETWORK
+unset DOMAIN
+unset IP_LIST
+PROGNAME=$(basename "$0")
+
+USAGE="$PROGNAME -b bootnodes -n network -d domain [-i ip_list]
+
+where:
+    bootnodes:  list of bootnodes to crawl from (comma separated)
+    network:    ronin-mainnet | ronin-testnet to choose the network
+    domain:     the DNS domain name
+    ip_list:    the list of IPs to include in ENR tree (comma separated)
+"
+
+set -e
+
+while getopts :hb:n:d:i: option; do
+  case $option in
+    h)
+      echo "$USAGE"
+      exit 0
+      ;;
+    b) BOOTNODES=$OPTARG ;;
+    n) NETWORK=$OPTARG ;;
+    d) DOMAIN=$OPTARG ;;
+    i) IP_LIST=$OPTARG ;;
+    :)
+      echo "$PROGNAME: option requires an argument -- '$OPTARG'" >&2
+      exit 1
+      ;;
+    *)
+      echo "$PROGNAME: bad option -$OPTARG" >&2
+      echo "Try '$PROGNAME -h' for more information" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ -z $BOOTNODES || -z $NETWORK || -z $DOMAIN ]]; then
+  echo "$PROGNAME: missing mandatory option" >&2
+  echo "Try '$(basename "$0") -h' for more information" >&2
+  exit 1
+fi
+
+DNS_DIR=dns_record
+
+if [[ -z $PRIVATE_KEY ]]; then
+  echo "The PRIVATE_KEY environment for signing DNS record must be provided"
+  exit 1
+fi
+
+if [[ -z $PASSWORD ]]; then
+  echo "The PASSWORD environment for decrypting the private key must be provided"
+  exit 1
+fi
+
+echo "$PASSWORD" > password
+echo "$PRIVATE_KEY" > private_key
+unset PASSWORD
+unset PRIVATE_KEY
+
+set -x
+# Create an encrypted keyfile.json
+ethkey generate --passwordfile password --privatekey private_key
+
+devp2p discv4 crawl --timeout 1m --bootnodes $BOOTNODES all_nodes.json
+
+mkdir -p $DNS_DIR
+
+set +x
+IP_LIST_PARAMS=""
+if [[ ! -z $IP_LIST ]]; then
+  IP_LIST_PARAMS="-ip-list $IP_LIST"
+fi
+set -x
+
+devp2p nodeset filter all_nodes.json -eth-network $NETWORK $IP_LIST_PARAMS > $DNS_DIR/nodes.json
+devp2p dns sign $DNS_DIR keyfile.json password --domain $DOMAIN
+devp2p dns to-txt $DNS_DIR $DNS_DIR/txt_record.json
+
+echo "Cleanup files"
+rm private_key
+rm password
+rm keyfile.json


### PR DESCRIPTION
- devp2p: add IP filter and ronin mainnet/testnet filter for nodeset filter

This commit adds IP or-filter, updates the ronin mainnet and testnet
configuration that are used for nodeset filter. This also allows DNS sign to use
password file instead of entering via prompt.

- script: add script to generate DNS TXT record from list of nodes