### PR TITLE
build: add option to build ronin with race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ ronin:
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/ronin\" to launch ronin."
 
+ronin-race-detector:
+	$(GORUN) build/ci.go install --race ./cmd/ronin
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/ronin\" to launch ronin."
+
 bootnode:
 	$(GORUN) build/ci.go install ./cmd/bootnode
 	@echo "Done building."

--- a/build/ci.go
+++ b/build/ci.go
@@ -202,6 +202,7 @@ func doInstall(cmdline []string) {
 		dlgo = flag.Bool("dlgo", false, "Download Go and build with it")
 		arch = flag.String("arch", "", "Architecture to cross build for")
 		cc   = flag.String("cc", "", "C compiler to cross build with")
+		race = flag.Bool("race", false, "Execute the race detector")
 	)
 	flag.CommandLine.Parse(cmdline)
 
@@ -215,6 +216,10 @@ func doInstall(cmdline []string) {
 	// Configure the build.
 	env := build.Env()
 	gobuild := tc.Go("build", buildFlags(env)...)
+
+	if *race {
+		gobuild.Args = append(gobuild.Args, "-race")
+	}
 
 	// arm64 CI builders are memory-constrained and can't handle concurrent builds,
 	// better disable it. This check isn't the best, it should probably


### PR DESCRIPTION
With this commit, we can use `make ronin-race-detector` to build ronin with race detector.