### PR TITLE
params: add optimistic fast finality testnet configuration

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -22,11 +22,14 @@
     "consortiumV2Contracts": {
       "roninValidatorSet": "0x54B3AC74a90E64E8dDE60671b6fE8F8DDf18eC9d",
       "slashIndicator": "0xF7837778b6E180Df6696C8Fa986d62f8b6186752",
-      "stakingContract": "0x9C245671791834daf3885533D24dce516B763B28"
+      "stakingContract": "0x9C245671791834daf3885533D24dce516B763B28",
+      "profileContract": "0x3b67c8D22a91572a6AB18acC9F70787Af04A4043",
+      "finalityTracking": "0x41aCDFe786171824a037f2Cd6224c5916A58969a"
     },
     "puffyBlock": 12254000,
     "bubaBlock": 14260600,
-    "olekBlock": 16849000
+    "olekBlock": 16849000,
+    "shillinBlock": 20268000
   },
   "alloc": {
     "0x0000000000000000000000000000000000000011": {

--- a/params/config.go
+++ b/params/config.go
@@ -281,6 +281,8 @@ var (
 	RoninTestnetRoninValidatorSetAddress      = common.HexToAddress("0x54B3AC74a90E64E8dDE60671b6fE8F8DDf18eC9d")
 	RoninTestnetSlashIndicatorAddress         = common.HexToAddress("0xF7837778b6E180Df6696C8Fa986d62f8b6186752")
 	RoninTestnetStakingContractAddress        = common.HexToAddress("0x9C245671791834daf3885533D24dce516B763B28")
+	RoninTestnetProfileContractAddress        = common.HexToAddress("0x3b67c8D22a91572a6AB18acC9F70787Af04A4043")
+	RoninTestnetFinalityTrackingAddress       = common.HexToAddress("0x41aCDFe786171824a037f2Cd6224c5916A58969a")
 
 	RoninTestnetChainConfig = &ChainConfig{
 		ChainID:                       big.NewInt(2021),
@@ -305,11 +307,14 @@ var (
 			RoninValidatorSet: RoninTestnetRoninValidatorSetAddress,
 			SlashIndicator:    RoninTestnetSlashIndicatorAddress,
 			StakingContract:   RoninTestnetStakingContractAddress,
+			ProfileContract:   RoninTestnetProfileContractAddress,
+			FinalityTracking:  RoninTestnetFinalityTrackingAddress,
 		},
 		ConsortiumV2Block: big.NewInt(11706000),
 		PuffyBlock:        big.NewInt(12254000),
 		BubaBlock:         big.NewInt(14260600),
 		OlekBlock:         big.NewInt(16849000),
+		ShillinBlock:      big.NewInt(20268000),
 	}
 
 	// GoerliTrustedCheckpoint contains the light client trusted checkpoint for the Görli test network.


### PR DESCRIPTION
This commit adds a Shillin hardfork on testnet to enable optimistic fast finality. The hardfork is scheduled around Sept 12 2023, 7:00 GMT+7 (https://saigon-app.roninchain.com/block/20268000)