### PR TITLE
monitor/finality: add slack alert for fast finality rule violation

### DIFF
--- a/monitor/finality_vote_test.go
+++ b/monitor/finality_vote_test.go
@@ -18,6 +18,7 @@ func TestCheckSameHeightVote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create bls key, err %s", err)
 	}
+	signature := key1.Sign([]byte{1})
 	address1 := common.Address{0x1}
 
 	key2, err := blst.RandKey()
@@ -28,19 +29,19 @@ func TestCheckSameHeightVote(t *testing.T) {
 
 	voterPublicKey := []blsCommon.PublicKey{key1.PublicKey()}
 	voterAddress := []common.Address{address1}
-	if monitor.checkSameHeightVote(0, common.Hash{0x1}, voterPublicKey, voterAddress) != nil {
+	if monitor.checkSameHeightVote(0, common.Hash{0x1}, voterPublicKey, voterAddress, signature) != nil {
 		t.Fatalf("Expect no error when checkSameHeightVote")
 	}
 
 	voterPublicKey = []blsCommon.PublicKey{key2.PublicKey()}
 	voterAddress = []common.Address{address2}
-	if monitor.checkSameHeightVote(0, common.Hash{0x2}, voterPublicKey, voterAddress) != nil {
+	if monitor.checkSameHeightVote(0, common.Hash{0x2}, voterPublicKey, voterAddress, signature) != nil {
 		t.Fatalf("Expect no error when checkSameHeightVote")
 	}
 
 	voterPublicKey = []blsCommon.PublicKey{key2.PublicKey()}
 	voterAddress = []common.Address{address2}
-	if monitor.checkSameHeightVote(0, common.Hash{0x3}, voterPublicKey, voterAddress) == nil {
+	if monitor.checkSameHeightVote(0, common.Hash{0x3}, voterPublicKey, voterAddress, signature) == nil {
 		t.Fatalf("Expect error when checkSameHeightVote")
 	}
 }

--- a/monitor/slack_alerter.go
+++ b/monitor/slack_alerter.go
@@ -1,0 +1,85 @@
+package monitor
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const reponseBuffer = 2048
+
+type slackAlerter struct {
+	url    string
+	client *http.Client
+}
+
+func formatMessage(header, body string) string {
+	headerSection := map[string]interface{}{
+		"type": "header",
+		"text": map[string]interface{}{
+			"type":  "plain_text",
+			"text":  header,
+			"emoji": true,
+		},
+	}
+
+	bodySection := map[string]interface{}{
+		"type": "section",
+		"text": map[string]interface{}{
+			"type":  "plain_text",
+			"text":  body,
+			"emoji": true,
+		},
+	}
+
+	messageBlock := map[string]interface{}{
+		"blocks": []interface{}{
+			headerSection,
+			bodySection,
+		},
+	}
+
+	message, _ := json.Marshal(messageBlock)
+	return string(message)
+}
+
+func (alerter *slackAlerter) Alert(header, body string) {
+	message := formatMessage(header, body)
+
+	request, err := http.NewRequest("POST", alerter.url, strings.NewReader(message))
+	if err != nil {
+		log.Error("Failed to send Slack alert", "err", err)
+		return
+	}
+
+	response, err := alerter.client.Do(request)
+	if err != nil {
+		log.Error("Failed to send HTTP request", "err", err)
+		return
+	}
+
+	if response.StatusCode >= 400 {
+		responseBody := make([]byte, reponseBuffer)
+		response.Body.Read(responseBody)
+		log.Error("Error response from server", "status", response.StatusCode, "body", responseBody)
+		return
+	}
+}
+
+func NewSlackAlert() *slackAlerter {
+	slackUrl := os.Getenv("SLACK_WEBHOOK_URL")
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return errors.New("invalid redirect")
+		},
+	}
+
+	return &slackAlerter{
+		url:    slackUrl,
+		client: client,
+	}
+}


### PR DESCRIPTION
The slack webhook URL for alerting is input via the environment variable SLACK_WEBHOOK_URL.