### PR TITLE
blockchain: add the finalized block number and block hash to chain event

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -173,6 +173,7 @@ var (
 		utils.BlsPasswordPath,
 		utils.BlsWalletPath,
 		utils.DisableRoninProtocol,
+		utils.AdditionalChainEventFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -58,6 +58,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MonitorDoubleSign,
 			utils.StoreInternalTransactions,
 			utils.DisableRoninProtocol,
+			utils.AdditionalChainEventFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -904,6 +904,11 @@ var (
 		Name:  "ronin.disable",
 		Usage: "Disable ronin p2p protocol",
 	}
+
+	AdditionalChainEventFlag = cli.BoolFlag{
+		Name:  "additionalchainevent.enable",
+		Usage: "Enable additional chain event",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1830,6 +1835,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 
 	if ctx.GlobalBool(MonitorDoubleSign.Name) {
 		cfg.EnableMonitorDoubleSign = true
+	}
+
+	if ctx.GlobalBool(AdditionalChainEventFlag.Name) {
+		cfg.EnableAdditionalChainEvent = true
 	}
 }
 

--- a/core/events.go
+++ b/core/events.go
@@ -34,12 +34,14 @@ type RemovedLogsEvent struct{ Logs []*types.Log }
 type NewVoteEvent struct{ Vote *types.VoteEnvelope }
 
 type ChainEvent struct {
-	Block         *types.Block
-	Hash          common.Hash
-	Logs          []*types.Log
-	InternalTxs   []*types.InternalTransaction
-	DirtyAccounts []*types.DirtyStateAccount
-	Receipts      types.Receipts
+	Block                *types.Block
+	Hash                 common.Hash
+	Logs                 []*types.Log
+	InternalTxs          []*types.InternalTransaction
+	DirtyAccounts        []*types.DirtyStateAccount
+	Receipts             types.Receipts
+	FinalizedBlockNumber uint64
+	FinalizedBlockHash   common.Hash
 }
 
 type ChainSideEvent struct {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -205,6 +205,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if config.EnableMonitorDoubleSign {
 		go eth.blockchain.StartDoubleSignMonitor()
 	}
+	if config.EnableAdditionalChainEvent {
+		eth.blockchain.EnableAdditionalChainEvent()
+	}
 
 	// Rewind the chain in case of an incompatible config upgrade.
 	if compat, ok := genesisErr.(*params.ConfigCompatError); ok {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -215,6 +215,9 @@ type Config struct {
 
 	// Disable ronin p2p protocol
 	DisableRoninProtocol bool
+
+	// Send additional chain event
+	EnableAdditionalChainEvent bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -735,7 +735,7 @@ func (w *worker) resultLoop() {
 				logs = append(logs, receipt.Logs...)
 			}
 			// Commit block and state to database.
-			_, _, err := w.chain.WriteBlockWithState(block, receipts, logs, task.state, true)
+			_, err := w.chain.WriteBlockWithState(block, receipts, logs, task.state, true)
 			if err != nil {
 				log.Error("Failed writing block to chain", "err", err)
 				continue


### PR DESCRIPTION
This commit adds the finalized block number and block hash to chain event in writeBlockWithState. It also adds the additionalchainevent.enable flag and moves all blockchain's functionality related to subscriber under this flag.