### PR TITLE
state_processor: remove the whitelist deployer check in applyTransaction

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -143,14 +143,6 @@ func applyTransaction(
 	evm.Reset(txContext, statedb)
 	from := msg.From()
 
-	// Check if sender is authorized to deploy
-	if msg.To() == nil && config.Consortium != nil {
-		whitelistedDeployer := state.IsWhitelistedDeployer(statedb, from)
-		if !whitelistedDeployer {
-			return nil, nil, ErrUnauthorizedDeployer
-		}
-	}
-
 	// Check if sender and recipient are blacklisted
 	if config.Consortium != nil && config.IsOdysseus(blockNumber) {
 		contractAddr := config.BlacklistContractAddress


### PR DESCRIPTION
We need to update the check in applyTransaction to support the whitelist deployer version 2. However, since we move the whitelist deployer check to the later Create operation to cover both CREATE2/CREATE opcode and contract deploy transaction, this check is not necessary anymore.

Does removing this check create backward incompatibility (cannot sync from genesis)?
The backward incompatability happens only when the old transactions does not pass the check and when running with newer Ronin version, it passes because we remove the check. However, this is not the case here, as the error in applyTransaction means the transaction is not included into the block.