### PR TITLE
miner, txpool: add a reserved gas constant for system transactions

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1529,9 +1529,6 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	if ctx.GlobalIsSet(MinerGasLimitFlag.Name) {
 		cfg.GasCeil = ctx.GlobalUint64(MinerGasLimitFlag.Name)
 	}
-	if ctx.GlobalIsSet(MinerGasReserveFlag.Name) {
-		cfg.GasReserve = ctx.GlobalUint64(MinerGasReserveFlag.Name)
-	}
 	if ctx.GlobalIsSet(MinerGasPriceFlag.Name) {
 		cfg.GasPrice = GlobalBig(ctx, MinerGasPriceFlag.Name)
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -610,7 +610,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrNegativeValue
 	}
 	// Ensure the transaction doesn't exceed the current block limit gas.
-	if pool.currentMaxGas < tx.Gas() {
+	var reservedGas uint64 = 0
+	if pool.chainconfig.Consortium != nil {
+		reservedGas = params.ReservedGasForSystemTransactions
+	}
+	if pool.currentMaxGas-reservedGas < tx.Gas() {
 		return ErrGasLimit
 	}
 	// Sanity check for extremely large numbers

--- a/eth/api.go
+++ b/eth/api.go
@@ -136,11 +136,6 @@ func (api *PrivateMinerAPI) SetGasLimit(gasLimit hexutil.Uint64) bool {
 	return true
 }
 
-func (api *PrivateMinerAPI) SetGasReserve(gasReserve hexutil.Uint64) bool {
-	api.e.Miner().SetGasReserve(uint64(gasReserve))
-	return true
-}
-
 // SetEtherbase sets the etherbase of the miner
 func (api *PrivateMinerAPI) SetEtherbase(etherbase common.Address) bool {
 	api.e.SetEtherbase(etherbase)

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -49,7 +49,6 @@ type Config struct {
 	ExtraData            hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
 	GasFloor             uint64         // Target gas floor for mined blocks.
 	GasCeil              uint64         // Target gas ceiling for mined blocks.
-	GasReserve           uint64         // Reserved gas for system transactions
 	GasPrice             *big.Int       // Minimum gas price for mining a transaction
 	Recommit             time.Duration  // The time interval for miner to re-create mining work.
 	Noverify             bool           // Disable remote mining solution verification(only useful in ethash).
@@ -217,11 +216,6 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 // For pre-1559 blocks, it sets the ceiling.
 func (miner *Miner) SetGasCeil(ceil uint64) {
 	miner.worker.setGasCeil(ceil)
-}
-
-// SetGasReserve sets the reserved gas for system transactions
-func (miner *Miner) SetGasReserve(reserve uint64) {
-	miner.worker.setGasReserve(reserve)
 }
 
 func (miner *Miner) SetBlockProducerLeftover(interval time.Duration) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -875,6 +875,19 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	gasLimit := w.current.header.GasLimit
 	if w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(gasLimit)
+
+		// If the gas pool is newly created, reserve some gas for system transactions
+		if w.chainConfig.Consortium != nil {
+			if err := w.current.gasPool.SubGas(params.ReservedGasForSystemTransactions); err != nil {
+				log.Error(
+					"Failed to reserve gas for system transactions",
+					"pool", w.current.gasPool,
+					"reserve", params.ReservedGasForSystemTransactions,
+					"error", err,
+				)
+				return true
+			}
+		}
 	}
 
 	var coalescedLogs []*types.Log

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -290,12 +290,6 @@ func (w *worker) setGasCeil(ceil uint64) {
 	w.config.GasCeil = ceil
 }
 
-func (w *worker) setGasReserve(reserve uint64) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.config.GasReserve = reserve
-}
-
 // setExtra sets the content used to initialize the block extra field.
 func (w *worker) setExtra(extra []byte) {
 	w.mu.Lock()
@@ -881,12 +875,6 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 	gasLimit := w.current.header.GasLimit
 	if w.current.gasPool == nil {
 		w.current.gasPool = new(core.GasPool).AddGas(gasLimit)
-
-		// If the gas pool is newly created, reserve some gas for system transactions
-		if err := w.current.gasPool.SubGas(w.config.GasReserve); err != nil {
-			log.Error("Failed to reserve gas for system transactions", "pool", w.current.gasPool, "reserve", w.config.GasReserve, "error", err)
-			return true
-		}
 	}
 
 	var coalescedLogs []*types.Log

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -19,6 +19,8 @@ package params
 import "math/big"
 
 const (
+	ReservedGasForSystemTransactions uint64 = 10_000_000 // The reserved gas for system transactions in each block.
+
 	GasLimitBoundDivisor           uint64 = 1024 // The bound divisor of the gas limit, used in update calculations.
 	ConsortiumGasLimitBoundDivisor uint64 = 256
 	MinGasLimit                    uint64 = 5000    // Minimum the gas limit may ever be.


### PR DESCRIPTION
This commit adds the reserved gas for system transaction, which is previously a
user provided flag, as a constant.

In the miner part, the miner stops commit normal transactions to block when
block gas used is over the block's gas limit - reserved gas. So when finalizing
and including system transactions into block, the block's gas used does not exceed
the block's gas limit.

In the txpool part, when validating a transaction before putting it into the
pool, previously, we only check if the transaction's gas limit is not over the
block's gas limit. However, if the transaction's gas limit is over the block's
gas limit - reserved gas, it is never included into the block but still always
stay in pending transaction pool. This commit fixes the check to reject the
transaction with gas limit over the block's gas limit - reserved gas.