### PR TITLE
chaincmd: correctly create consortium engine in import chain

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2230,7 +2230,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	} else if config.Consortium != nil {
 		ethApiBackend, fixupEth = eth.MakeEthApiBackend(chainDb)
 		ethApi := ethapi.NewPublicBlockChainAPI(ethApiBackend)
-		engine = consortium.New(config, chainDb, ethApi)
+		engine = consortium.New(config, chainDb, ethApi, true)
 	} else {
 		engine = ethash.NewFaker()
 		if !ctx.Bool(FakePoWFlag.Name) {

--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -27,10 +27,10 @@ type Consortium struct {
 }
 
 // New creates a Consortium proxy that decides what Consortium version will be called
-func New(chainConfig *params.ChainConfig, db ethdb.Database, ee *ethapi.PublicBlockChainAPI, genesisHash common.Hash) *Consortium {
+func New(chainConfig *params.ChainConfig, db ethdb.Database, ee *ethapi.PublicBlockChainAPI) *Consortium {
 	// Set any missing consensus parameters to their defaults
 	consortiumV1 := v1.New(chainConfig, db, ee)
-	consortiumV2 := v2.New(chainConfig, db, ee, genesisHash, consortiumV1)
+	consortiumV2 := v2.New(chainConfig, db, ee, consortiumV1)
 
 	return &Consortium{
 		chainConfig: chainConfig,

--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -27,9 +27,9 @@ type Consortium struct {
 }
 
 // New creates a Consortium proxy that decides what Consortium version will be called
-func New(chainConfig *params.ChainConfig, db ethdb.Database, ee *ethapi.PublicBlockChainAPI) *Consortium {
+func New(chainConfig *params.ChainConfig, db ethdb.Database, ee *ethapi.PublicBlockChainAPI, skipV1Check bool) *Consortium {
 	// Set any missing consensus parameters to their defaults
-	consortiumV1 := v1.New(chainConfig, db, ee)
+	consortiumV1 := v1.New(chainConfig, db, ee, skipV1Check)
 	consortiumV2 := v2.New(chainConfig, db, ee, consortiumV1)
 
 	return &Consortium{

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -94,7 +94,6 @@ type Consortium struct {
 	chainConfig *params.ChainConfig
 	config      *params.ConsortiumConfig // Consensus engine configuration parameters
 	forkedBlock uint64
-	genesisHash common.Hash
 	db          ethdb.Database // Database to store and retrieve snapshot checkpoints
 
 	recents    *lru.ARCCache // Snapshots for recent block to speed up reorgs
@@ -120,7 +119,6 @@ func New(
 	chainConfig *params.ChainConfig,
 	db ethdb.Database,
 	ethAPI *ethapi.PublicBlockChainAPI,
-	genesisHash common.Hash,
 	v1 consortiumCommon.ConsortiumAdapter,
 ) *Consortium {
 	consortiumConfig := chainConfig.Consortium
@@ -136,7 +134,6 @@ func New(
 	consortium := Consortium{
 		chainConfig: chainConfig,
 		config:      consortiumConfig,
-		genesisHash: genesisHash,
 		db:          db,
 		ethAPI:      ethAPI,
 		recents:     recents,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -352,6 +352,24 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	return eth, nil
 }
 
+// MakeEthApiBackend is used by MakeChain to create a minimal eth API backend for consortium
+// engine.
+// This code looks hacky as it returns a function to set the private blockchain, engine field.
+// This is due to the circular dependency as blockchain needs consortium engine which requires
+// eth API backend. As the eth API backend is not used right after being created, we create a
+// eth API backend without blockchain here and set that field later when blockchain is available.
+func MakeEthApiBackend(chainDb ethdb.Database) (*EthAPIBackend, func(chain *core.BlockChain, engine consensus.Engine)) {
+	eth := &Ethereum{
+		chainDb: chainDb,
+		config:  &ethconfig.Defaults,
+	}
+	apiBackend := &EthAPIBackend{eth: eth}
+	return apiBackend, func(chain *core.BlockChain, engine consensus.Engine) {
+		eth.blockchain = chain
+		eth.engine = engine
+	}
+}
+
 func makeExtraData(extra []byte) []byte {
 	if len(extra) == 0 {
 		// create default extradata

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -163,7 +163,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		log.Info("Unprotected transactions allowed")
 	}
 	ethAPI := ethapi.NewPublicBlockChainAPI(eth.APIBackend)
-	eth.engine = ethconfig.CreateConsensusEngine(stack, chainConfig, &ethashConfig, config.Miner.Notify, config.Miner.Noverify, chainDb, ethAPI, genesisHash)
+	eth.engine = ethconfig.CreateConsensusEngine(stack, chainConfig, &ethashConfig, config.Miner.Notify, config.Miner.Noverify, chainDb, ethAPI)
 
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)
 	var dbVer = "<nil>"

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -239,7 +239,7 @@ func CreateConsensusEngine(
 		return clique.New(chainConfig.Clique, db)
 	}
 	if chainConfig.Consortium != nil {
-		return consortium.New(chainConfig, db, ee)
+		return consortium.New(chainConfig, db, ee, false)
 	}
 	// Otherwise assume proof-of-work
 	switch config.PowMode {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -225,13 +225,21 @@ type Config struct {
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.
-func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, config *ethash.Config, notify []string, noverify bool, db ethdb.Database, ee *ethapi.PublicBlockChainAPI, genesisHash common.Hash) consensus.Engine {
+func CreateConsensusEngine(
+	stack *node.Node,
+	chainConfig *params.ChainConfig,
+	config *ethash.Config,
+	notify []string,
+	noverify bool,
+	db ethdb.Database,
+	ee *ethapi.PublicBlockChainAPI,
+) consensus.Engine {
 	// If proof-of-authority is requested, set it up
 	if chainConfig.Clique != nil {
 		return clique.New(chainConfig.Clique, db)
 	}
 	if chainConfig.Consortium != nil {
-		return consortium.New(chainConfig, db, ee, genesisHash)
+		return consortium.New(chainConfig, db, ee)
 	}
 	// Otherwise assume proof-of-work
 	switch config.PowMode {

--- a/les/client.go
+++ b/les/client.go
@@ -109,7 +109,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 		eventMux:       stack.EventMux(),
 		reqDist:        newRequestDistributor(peers, &mclock.System{}),
 		accountManager: stack.AccountManager(),
-		engine:         ethconfig.CreateConsensusEngine(stack, chainConfig, &config.Ethash, nil, false, chainDb, nil, genesisHash),
+		engine:         ethconfig.CreateConsensusEngine(stack, chainConfig, &config.Ethash, nil, false, chainDb, nil),
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
 		bloomIndexer:   core.NewBloomIndexer(chainDb, params.BloomBitsBlocksClient, params.HelperTrieConfirmations),
 		p2pServer:      stack.Server(),


### PR DESCRIPTION
Currently, when import chain is used, we don't recognize the chain config to
create the consortium engine. This commit creates the consortium engine when it
is set in the chain config.