### PR TITLE
cmd/flag: correctly enable finality vote monitor

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1843,7 +1843,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 
 	if ctx.GlobalBool(MonitorFinalityVoteFlag.Name) {
-		cfg.EnableMonitorDoubleSign = true
+		cfg.EnableMonitorFinalityVote = true
 	}
 }
 


### PR DESCRIPTION
Fix the incorrect config set when --monitor.finalityvote is used.