### PR TITLE
consortium: Implement mocking logics for consortium v2

### DIFF
--- a/cmd/ronin/config.go
+++ b/cmd/ronin/config.go
@@ -20,13 +20,14 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"math/big"
 	"os"
 	"reflect"
 	"unicode"
 
+	"github.com/ethereum/go-ethereum/common"
+	consortiumCommon "github.com/ethereum/go-ethereum/consensus/consortium/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/ethereum/go-ethereum/accounts/external"
@@ -88,10 +89,10 @@ type ethstatsConfig struct {
 }
 
 type gethConfig struct {
-	Eth      ethconfig.Config
-	Node     node.Config
-	Ethstats ethstatsConfig
-	Metrics  metrics.Config
+	Eth        ethconfig.Config
+	Node       node.Config
+	Ethstats   ethstatsConfig
+	Metrics    metrics.Config
 }
 
 func loadConfig(file string, cfg *gethConfig) error {
@@ -151,6 +152,14 @@ func makeConfigNode(ctx *cli.Context) (*node.Node, gethConfig) {
 		cfg.Ethstats.URL = ctx.GlobalString(utils.EthStatsURLFlag.Name)
 	}
 	applyMetricConfig(ctx, &cfg)
+
+	// setup mock config
+	if ctx.GlobalIsSet(utils.MockValidatorsFlag.Name) && ctx.GlobalIsSet(utils.MockBlsPublicKeysFlag.Name) {
+		err = consortiumCommon.SetMockValidators(ctx.GlobalString(utils.MockValidatorsFlag.Name), ctx.GlobalString(utils.MockBlsPublicKeysFlag.Name))
+		if err != nil {
+			utils.Fatalf("failed on create mock validators %v", err)
+		}
+	}
 
 	return stack, cfg
 }

--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -233,6 +233,11 @@ var (
 		utils.PyroscopeBlockProfileRate,
 		utils.PyroscopeMutexProfileFraction,
 	}
+
+	mockFlags = []cli.Flag{
+		utils.MockValidatorsFlag,
+		utils.MockBlsPublicKeysFlag,
+	}
 )
 
 func init() {
@@ -281,6 +286,7 @@ func init() {
 	app.Flags = append(app.Flags, debug.Flags...)
 	app.Flags = append(app.Flags, metricsFlags...)
 	app.Flags = append(app.Flags, pyroscopeFlags...)
+	app.Flags = append(app.Flags, mockFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
 		return debug.Setup(ctx)

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -264,6 +264,13 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.BlsWalletPath,
 		},
 	},
+	{
+		Name: "MOCK",
+		Flags: []cli.Flag{
+			utils.MockValidatorsFlag,
+			utils.MockBlsPublicKeysFlag,
+		},
+	},
 }
 
 func init() {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -913,6 +913,16 @@ var (
 		Name:  "additionalchainevent.enable",
 		Usage: "Enable additional chain event",
 	}
+
+	MockValidatorsFlag = cli.StringFlag{
+		Name: "mock.validators",
+		Usage: "List of mock validators",
+	}
+
+	MockBlsPublicKeysFlag = cli.StringFlag{
+		Name: "mock.blspublickeys",
+		Usage: "List of mock bls public keys which are reflect 1:1 with mock.validators",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating

--- a/consensus/consortium/common/mock_contract.go
+++ b/consensus/consortium/common/mock_contract.go
@@ -1,0 +1,82 @@
+package common
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/bls/blst"
+	blsCommon "github.com/ethereum/go-ethereum/crypto/bls/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var Validators *MockValidators
+
+type MockValidators struct {
+	validators []common.Address
+	blsPublicKeys map[common.Address]blsCommon.PublicKey
+}
+
+func SetMockValidators(validators, publicKeys string) error {
+	vals := strings.Split(validators, ",")
+	pubs := strings.Split(publicKeys, ",")
+	if len(vals) != len(pubs) {
+		return errors.New("mismatch length between mock validators and mock blsPubKey")
+	}
+	Validators = &MockValidators{
+		validators: make([]common.Address, len(vals)),
+		blsPublicKeys: make(map[common.Address]blsCommon.PublicKey),
+	}
+	for i, val := range vals {
+		Validators.validators[i] = common.HexToAddress(val)
+		pubKey, err := blst.PublicKeyFromBytes(common.Hex2Bytes(pubs[i]))
+		if err != nil {
+			return err
+		}
+		Validators.blsPublicKeys[Validators.validators[i]] = pubKey
+	}
+	return nil
+}
+
+func (m *MockValidators) GetValidators() []common.Address {
+	return m.validators
+}
+
+func (m *MockValidators) GetPublicKey(addr common.Address) (blsCommon.PublicKey, error) {
+	if key, ok := m.blsPublicKeys[addr]; ok {
+		return key, nil
+	}
+	return nil, errors.New("public key not found")
+}
+
+type MockContract struct {
+}
+
+func (contract *MockContract) GetValidators(*big.Int) ([]common.Address, error) {
+	return Validators.GetValidators(), nil
+}
+
+func (contract *MockContract) WrapUpEpoch(*ApplyTransactOpts) error {
+	log.Info("WrapUpEpoch")
+	return nil
+}
+
+func (contract *MockContract) SubmitBlockReward(*ApplyTransactOpts) error {
+	log.Info("SubmitBlockReward")
+	return nil
+}
+
+func (contract *MockContract) Slash(*ApplyTransactOpts, common.Address) error {
+	log.Info("Slash")
+	return nil
+}
+
+func (contract *MockContract) FinalityReward(*ApplyTransactOpts, []common.Address) error {
+	log.Info("FinalityReward")
+	return nil
+}
+
+func (contract *MockContract) GetBlsPublicKey(_ *big.Int, addr common.Address) (blsCommon.PublicKey, error) {
+	return Validators.GetPublicKey(addr)
+}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -92,11 +92,11 @@ var Defaults = Config{
 		BlockProduceLeftOver: 200 * time.Millisecond,
 		BlockSizeReserve:     500000,
 	},
-	TxPool:        core.DefaultTxPoolConfig,
-	RPCGasCap:     50000000,
-	RPCEVMTimeout: 5 * time.Second,
-	GPO:           FullNodeGPO,
-	RPCTxFeeCap:   1, // 1 ether
+	TxPool:         core.DefaultTxPoolConfig,
+	RPCGasCap:      50000000,
+	RPCEVMTimeout:  5 * time.Second,
+	GPO:            FullNodeGPO,
+	RPCTxFeeCap:    1, // 1 ether
 }
 
 func init() {


### PR DESCRIPTION
## Purpose
In order to setup and test Ronin nodes locally, we need to do the following steps:
- Config and deploy DPOS contracts on consortium v1
- Add DPOS contracts to genesis file and define forked block number to switch to consortium v2

These steps could affect to demands of developing and testing other features.
Therefore, the ideas of running consortium v2 node without DPOS contracts are come up. 

## Implementation
- In order to do that, we need to implement a mock layer for `ContractInteraction` to mock all of the following function (mock_contract):
```
	GetValidators(blockNumber *big.Int) ([]common.Address, error)
	WrapUpEpoch(opts *ApplyTransactOpts) error
	SubmitBlockReward(opts *ApplyTransactOpts) error
	Slash(opts *ApplyTransactOpts, spoiledValidator common.Address) error
	FinalityReward(opts *ApplyTransactOpts, votedValidators []common.Address) error
	GetBlsPublicKey(blockNumber *big.Int, validator common.Address) (blsCommon.PublicKey, error)
```
- Add global variables `Validators` which contains validators set as well as their public keys which is used for finality vote mocking.
- if `Validators` is not nil, mocked contract is used
- Add `--mock.validators` and `--mock.blspublickeys` flags to add validators and public keys to `Validators` variable

## Running steps:
- Generate key and bls key into your datadir (eg: /node)
```
ronin account new --datadir /node/keystore --password /node/keystore/password
ronin account generatebls --finality.blswalletpath /node/keystore --finality.blspasswordpath /node/keystore/password
```
- Run ronin node with flags `--mock.validators` and `--mock.blspublickeys` (validators and public keys are separated by colon(,))