### PR TITLE
tx_pool, state_transition: accept sponsored tx with expired time = 0

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3574,7 +3574,23 @@ func TestSponsoredTxTransition(t *testing.T) {
 		t.Fatalf("Expect error %s, get %s", ErrInsufficientSenderFunds, err)
 	}
 
-	// 5. Successfully add tx
+	// 5. Successfully add tx, sponsored tx with expired time = 0 is accepted
+	innerTx.ExpiredTime = 0
+	innerTx.PayerR, innerTx.PayerS, innerTx.PayerV, err = types.PayerSign(
+		payerKey,
+		mikoSigner,
+		crypto.PubkeyToAddress(senderKey.PublicKey),
+		&innerTx,
+	)
+	if err != nil {
+		t.Fatalf("Payer fails to sign transaction, err %s", err)
+	}
+
+	sponsoredTx, err = types.SignNewTx(senderKey, mikoSigner, &innerTx)
+	if err != nil {
+		t.Fatalf("Fail to sign transaction, err %s", err)
+	}
+
 	blocks, _ = GenerateChain(&chainConfig, blocks[0], engine, db, 1, func(i int, bg *BlockGen) {
 		tx, err := types.SignTx(types.NewTransaction(1, senderAddr, innerTx.Value, params.TxGas, bg.header.BaseFee, nil), mikoSigner, adminKey)
 		if err != nil {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -283,7 +283,8 @@ func (st *StateTransition) preCheck() error {
 
 	// Check expired time, gas fee cap and tip cap in sponsored transaction
 	if st.msg.Payer() != st.msg.From() {
-		if st.msg.ExpiredTime() <= st.evm.Context.Time {
+		expiredTime := st.msg.ExpiredTime()
+		if expiredTime != 0 && expiredTime <= st.evm.Context.Time {
 			return fmt.Errorf("%w: expiredTime: %d, blockTime: %d", ErrExpiredSponsoredTx,
 				st.msg.ExpiredTime(), st.evm.Context.Time)
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -204,7 +204,12 @@ func (st *StateTransition) buyGas() error {
 	// transaction, st.gasPrice is the already calculated gas
 	// price based on block base fee, gas fee cap and gas tip cap
 	effectiveGasFee := new(big.Int).Mul(gas, st.gasPrice)
-	maxGasFee := new(big.Int).Mul(gas, st.gasFeeCap)
+	var maxGasFee *big.Int
+	if st.gasFeeCap != nil {
+		maxGasFee = new(big.Int).Mul(gas, st.gasFeeCap)
+	} else {
+		maxGasFee = new(big.Int).Mul(gas, st.gasPrice)
+	}
 
 	if st.msg.Payer() != st.msg.From() {
 		// This is sponsored transaction, check gas fee with payer's balance and msg.value with sender's balance

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -376,9 +376,10 @@ func (l *txList) Filter(
 		if tx.Type() == types.SponsoredTxType {
 			payer, _ := types.Payer(l.signer, tx)
 			gasFee := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
+			expiredTime := tx.ExpiredTime()
 			return gasFee.Cmp(payerCostLimit[payer]) > 0 ||
 				tx.Value().Cmp(costLimit) > 0 ||
-				tx.ExpiredTime() <= currentTime
+				(expiredTime != 0 && expiredTime <= currentTime)
 		} else {
 			return tx.Cost().Cmp(costLimit) > 0
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -795,6 +795,10 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 	// Try to replace an existing transaction in the pending pool
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if list := pool.pending[from]; list != nil && list.Overlaps(tx) {
+		if !pool.signer.Equal(pool.pending[from].Signer()) {
+			pool.pending[from].UpdateSigner(pool.signer)
+		}
+
 		// Nonce already pending, check if required price bump is met
 		inserted, old := list.Add(tx, pool.config.PriceBump)
 		if !inserted {
@@ -845,6 +849,8 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction, local boo
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if pool.queue[from] == nil {
 		pool.queue[from] = newTxList(false, pool.signer)
+	} else if !pool.signer.Equal(pool.queue[from].Signer()) {
+		pool.queue[from].UpdateSigner(pool.signer)
 	}
 	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
 	if !inserted {
@@ -897,6 +903,8 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
 		pool.pending[addr] = newTxList(true, pool.signer)
+	} else if !pool.signer.Equal(pool.pending[addr].Signer()) {
+		pool.pending[addr].UpdateSigner(pool.signer)
 	}
 	list := pool.pending[addr]
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -661,7 +661,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		}
 
 		// Ensure sponsored transaction is not expired
-		if tx.ExpiredTime() <= pool.currentTime {
+		expiredTime := tx.ExpiredTime()
+		if expiredTime != 0 && expiredTime <= pool.currentTime {
 			return ErrExpiredSponsoredTx
 		}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1333,6 +1333,7 @@ type RPCTransaction struct {
 	V                *hexutil.Big      `json:"v"`
 	R                *hexutil.Big      `json:"r"`
 	S                *hexutil.Big      `json:"s"`
+	Payer            *common.Address   `json:"payer,omitempty"`
 	ExpiredTime      *hexutil.Uint64   `json:"expiredTime,omitempty"`
 	PayerV           *hexutil.Big      `json:"payerV,omitempty"`
 	PayerR           *hexutil.Big      `json:"payerR,omitempty"`
@@ -1384,6 +1385,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			result.GasPrice = (*hexutil.Big)(tx.GasFeeCap())
 		}
 	case types.SponsoredTxType:
+		payer, _ := types.Payer(signer, tx)
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
 		result.GasFeeCap = (*hexutil.Big)(tx.GasFeeCap())
 		result.GasTipCap = (*hexutil.Big)(tx.GasTipCap())
@@ -1401,6 +1403,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.PayerR = (*hexutil.Big)(r)
 		result.PayerS = (*hexutil.Big)(s)
 		result.PayerV = (*hexutil.Big)(v)
+		result.Payer = &payer
 	}
 	return result
 }


### PR DESCRIPTION
- tx_pool, state_transition: accept sponsored tx with expired time = 0

The sponsored transaction with expired time = 0 means there is no expired time
for that transaction, so we skip the expired time check for that one.

- api: add payer field to sponsored transaction in RPC response

This commit adds payer field to sponsored transaction in RPC response of APIs
related to transactions to easy lookup without manually recovering from the
returned payer's signature.

- txpool: update the signer of txlist when it differs from txpool's signer

txpool's signer can change when we reach higher block that triggers the new
signer. This commit checks the txpool's and txlist's signer when adding the new
transaction to txlist, update the txlist's signer with txpool's one when they
differ.

- state_transition: nil check gasFeeCap before using in buyGas

In normal case, gasFeeCap is never nil. In transactions other than dynamic fee
transaction, gasFeeCap is set to gasPrice. However, in some test cases,
gasFeeCap can be nil. In these cases, nil check the gasFeeCap and use gasPrice
instead.