### PR TITLE
ci: add test coverage

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -25,5 +25,5 @@ jobs:
         with:
           go-version: '1.20'
 
-      - name: 'Go Test'
+      - name: 'Go Test- Test Coverage'
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ios:
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 
 test: all
-	$(GORUN) build/ci.go test
+	$(GORUN) build/ci.go test --coverage
 
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint


### PR DESCRIPTION
Using flag coverage in ci.go for enabling atomic cover_mode. 