### PR TITLE
state_processor: fix out-of-order system txs

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -33,6 +33,9 @@ var (
 	ErrNoGenesis = errors.New("genesis not found in chain")
 
 	errSideChainReceipts = errors.New("side blocks can't be accepted as ancient chain data")
+
+	// ErrOutOfOrderSystemTx is returned when a system transaction is followed by a common transaction
+	ErrOutOfOrderSystemTx = errors.New("out-of-order system transaction detected")
 )
 
 // List of evm-call-message pre-checking errors. All state transition messages will


### PR DESCRIPTION
The current way that transactions are processed by Consortium V2 engine allows a system transaction to be placed before a common transaction in a block. However, the generated logs and receipts are ordered so that those of system transactions are stored at the end (see `core/state_processor.go/Process`). This leads to mismatching betwwen logs/receipts and their corresponding transactions because the handler of `eth_getLogs` assume that receipts are stored in the same order with that of `block.Transactions()` (see `core/rawdb/accessors_chain.go/deriveLogFields`).