### PR TITLE
internal/ethapi: reduce database read when handling eth_getTransactionReceipt

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -836,12 +836,8 @@ func (fb *filterBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*t
 	return fb.bc.GetHeaderByHash(hash), nil
 }
 
-func (fb *filterBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
-	number := rawdb.ReadHeaderNumber(fb.db, hash)
-	if number == nil {
-		return nil, nil
-	}
-	return rawdb.ReadReceipts(fb.db, hash, *number, fb.bc.Config()), nil
+func (fb *filterBackend) GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error) {
+	return rawdb.ReadReceipts(fb.db, hash, number, fb.bc.Config()), nil
 }
 
 func (fb *filterBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -204,11 +204,24 @@ func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {
 		return receipts.(types.Receipts)
 	}
-	number := rawdb.ReadHeaderNumber(bc.db, hash)
+	number := bc.hc.GetBlockNumber(hash)
 	if number == nil {
 		return nil
 	}
 	receipts := rawdb.ReadReceipts(bc.db, hash, *number, bc.chainConfig)
+	if receipts == nil {
+		return nil
+	}
+	bc.receiptsCache.Add(hash, receipts)
+	return receipts
+}
+
+// GetReceiptsByHashAndNumber is the same as GetReceiptsByHash with extra block number parameter
+func (bc *BlockChain) GetReceiptsByHashAndNumber(hash common.Hash, number uint64) types.Receipts {
+	if receipts, ok := bc.receiptsCache.Get(hash); ok {
+		return receipts.(types.Receipts)
+	}
+	receipts := rawdb.ReadReceipts(bc.db, hash, number, bc.chainConfig)
 	if receipts == nil {
 		return nil
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -191,7 +191,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
-func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
+func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error) {
 	return b.eth.blockchain.GetReceiptsByHash(hash), nil
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -192,7 +192,7 @@ func (b *EthAPIBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 }
 
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error) {
-	return b.eth.blockchain.GetReceiptsByHash(hash), nil
+	return b.eth.blockchain.GetReceiptsByHashAndNumber(hash, number), nil
 }
 
 func (b *EthAPIBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
@@ -279,7 +279,7 @@ func (b *EthAPIBackend) GetPoolTransaction(hash common.Hash) *types.Transaction 
 }
 
 func (b *EthAPIBackend) GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error) {
-	tx, blockHash, blockNumber, index := rawdb.ReadTransaction(b.eth.ChainDb(), txHash)
+	tx, blockHash, blockNumber, index := b.eth.blockchain.GetTransaction(txHash)
 	return tx, blockHash, blockNumber, index, nil
 }
 

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -38,7 +38,7 @@ type Backend interface {
 	ChainDb() ethdb.Database
 	HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*types.Header, error)
 	HeaderByHash(ctx context.Context, blockHash common.Hash) (*types.Header, error)
-	GetReceipts(ctx context.Context, blockHash common.Hash) (types.Receipts, error)
+	GetReceipts(ctx context.Context, blockHash common.Hash, number uint64) (types.Receipts, error)
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
 
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
@@ -283,7 +283,7 @@ func (f *Filter) checkMatches(ctx context.Context, header *types.Header) (logs [
 	if len(logs) > 0 {
 		// We have matching logs, check if we need to resolve full logs via the light client
 		if logs[0].TxHash == (common.Hash{}) {
-			receipts, err := f.backend.GetReceipts(ctx, header.Hash())
+			receipts, err := f.backend.GetReceipts(ctx, header.Hash(), header.Number.Uint64())
 			if err != nil {
 				return nil, err
 			}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -460,7 +460,7 @@ func (es *EventSystem) lightFilterLogs(header *types.Header, addresses []common.
 		logs := filterLogs(unfiltered, nil, nil, addresses, topics)
 		if len(logs) > 0 && logs[0].TxHash == (common.Hash{}) {
 			// We have matching but non-derived logs
-			receipts, err := es.backend.GetReceipts(ctx, header.Hash())
+			receipts, err := es.backend.GetReceipts(ctx, header.Hash(), header.Number.Uint64())
 			if err != nil {
 				return nil
 			}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -86,11 +86,8 @@ func (b *testBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*type
 	return rawdb.ReadHeader(b.db, hash, *number), nil
 }
 
-func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
-	if number := rawdb.ReadHeaderNumber(b.db, hash); number != nil {
-		return rawdb.ReadReceipts(b.db, hash, *number, params.TestChainConfig), nil
-	}
-	return nil, nil
+func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error) {
+	return rawdb.ReadReceipts(b.db, hash, number, params.TestChainConfig), nil
 }
 
 func (b *testBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -257,7 +257,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 						if len(rewardPercentiles) != 0 {
 							fees.block, fees.err = oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNumber))
 							if fees.block != nil && fees.err == nil {
-								fees.receipts, fees.err = oracle.backend.GetReceipts(ctx, fees.block.Hash())
+								fees.receipts, fees.err = oracle.backend.GetReceipts(ctx, fees.block.Hash(), blockNumber)
 								fees.header = fees.block.Header()
 							}
 						} else {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -53,7 +53,7 @@ type Config struct {
 type OracleBackend interface {
 	HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error)
 	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
-	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
+	GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 	ChainConfig() *params.ChainConfig
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -75,8 +75,8 @@ func (b *testBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber)
 	return b.chain.GetBlockByNumber(uint64(number)), nil
 }
 
-func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
-	return b.chain.GetReceiptsByHash(hash), nil
+func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error) {
+	return b.chain.GetReceiptsByHashAndNumber(hash, number), nil
 }
 
 func (b *testBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -531,15 +531,11 @@ func (b *Block) resolveHeader(ctx context.Context) (*types.Header, error) {
 // if necessary.
 func (b *Block) resolveReceipts(ctx context.Context) ([]*types.Receipt, error) {
 	if b.receipts == nil {
-		hash := b.hash
-		if hash == (common.Hash{}) {
-			header, err := b.resolveHeader(ctx)
-			if err != nil {
-				return nil, err
-			}
-			hash = header.Hash()
+		header, err := b.resolveHeader(ctx)
+		if err != nil {
+			return nil, err
 		}
-		receipts, err := b.backend.GetReceipts(ctx, hash)
+		receipts, err := b.backend.GetReceipts(ctx, header.Hash(), header.Number.Uint64())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1677,7 +1677,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 	if err != nil || tx == nil {
 		return nil, nil
 	}
-	receipts, err := s.b.GetReceipts(ctx, blockHash)
+	receipts, err := s.b.GetReceipts(ctx, blockHash, blockNumber)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -65,7 +65,7 @@ type Backend interface {
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
 	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
-	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
+	GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error)
 	GetTd(ctx context.Context, hash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error)
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -19,9 +19,10 @@ package les
 import (
 	"context"
 	"errors"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum/eth/tracers"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -162,11 +163,8 @@ func (b *LesApiBackend) StateAndHeaderByNumberOrHash(ctx context.Context, blockN
 	return nil, nil, errors.New("invalid arguments; neither block nor hash specified")
 }
 
-func (b *LesApiBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
-	if number := rawdb.ReadHeaderNumber(b.eth.chainDb, hash); number != nil {
-		return light.GetBlockReceipts(ctx, b.eth.odr, hash, *number)
-	}
-	return nil, nil
+func (b *LesApiBackend) GetReceipts(ctx context.Context, hash common.Hash, number uint64) (types.Receipts, error) {
+	return light.GetBlockReceipts(ctx, b.eth.odr, hash, number)
 }
 
 func (b *LesApiBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {


### PR DESCRIPTION
- internal/ethapi: reduce database read when handling eth_getTransactionReceipt

This commit changes the GetReceipts interface to accept block number paramenter
as block number is available in most case. This helps to reduce the database
read to resolve the block number from block hash.

- blockchain_reader: utilize body cache when serving eth_getTransactionReceipt

Currently, when serving eth_getTransactionReceipt, block body is read and
decoded twice in GetTransaction and GetReceipts. This commit makes both
GetTransaction and GetReceipts call to blockchain reader. In blockchain reader,
the handlers of these 2 requests are the same as rawdb handlers but the body
read is cache. As a result, the second body read hits the cache, avoid an
additional database read and body decode.