### PR TITLE
blockchain: make tries in memory configurable via flag

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -101,6 +101,7 @@ var (
 		utils.GCModeFlag,
 		utils.SnapshotFlag,
 		utils.TxLookupLimitFlag,
+		utils.TriesInMemoryFlag,
 		utils.LightServeFlag,
 		utils.LightIngressFlag,
 		utils.LightEgressFlag,

--- a/cmd/ronin/usage.go
+++ b/cmd/ronin/usage.go
@@ -50,6 +50,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.ExitWhenSyncedFlag,
 			utils.GCModeFlag,
 			utils.TxLookupLimitFlag,
+			utils.TriesInMemoryFlag,
 			utils.EthStatsURLFlag,
 			utils.IdentityFlag,
 			utils.LightKDFFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -231,6 +231,11 @@ var (
 		Usage: "Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)",
 		Value: ethconfig.Defaults.TxLookupLimit,
 	}
+	TriesInMemoryFlag = cli.IntFlag{
+		Name:  "triesinmemory",
+		Usage: "The number of tries is kept in memory before pruning (default = 128)",
+		Value: 128,
+	}
 	MonitorDoubleSign = cli.BoolFlag{
 		Name:  "monitor.doublesign",
 		Usage: "Enable double sign monitoring",
@@ -1730,6 +1735,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheSnapshotFlag.Name) {
 		cfg.SnapshotCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheSnapshotFlag.Name) / 100
 	}
+	cfg.TriesInMemory = ctx.GlobalInt(TriesInMemoryFlag.Name)
 	if !ctx.GlobalBool(SnapshotFlag.Name) {
 		// If snap-sync is requested, this flag is also required
 		if cfg.SyncMode == downloader.SnapSync {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -196,6 +196,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			TrieTimeLimit:       config.TrieTimeout,
 			SnapshotLimit:       config.SnapshotCache,
 			Preimages:           config.Preimages,
+			TriesInMemory:       config.TriesInMemory,
 		}
 	)
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -92,11 +92,11 @@ var Defaults = Config{
 		BlockProduceLeftOver: 200 * time.Millisecond,
 		BlockSizeReserve:     500000,
 	},
-	TxPool:         core.DefaultTxPoolConfig,
-	RPCGasCap:      50000000,
-	RPCEVMTimeout:  5 * time.Second,
-	GPO:            FullNodeGPO,
-	RPCTxFeeCap:    1, // 1 ether
+	TxPool:        core.DefaultTxPoolConfig,
+	RPCGasCap:     50000000,
+	RPCEVMTimeout: 5 * time.Second,
+	GPO:           FullNodeGPO,
+	RPCTxFeeCap:   1, // 1 ether
 }
 
 func init() {
@@ -172,6 +172,7 @@ type Config struct {
 	TrieTimeout             time.Duration
 	SnapshotCache           int
 	Preimages               bool
+	TriesInMemory           int
 
 	// Mining options
 	Miner miner.Config

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -316,7 +316,7 @@ func TestGetStaleCodeLes4(t *testing.T) { testGetStaleCode(t, 4) }
 
 func testGetStaleCode(t *testing.T, protocol int) {
 	netconfig := testnetConfig{
-		blocks:    core.TriesInMemory + 4,
+		blocks:    core.DefaultTriesInMemory + 4,
 		protocol:  protocol,
 		nopruning: true,
 	}
@@ -430,7 +430,7 @@ func TestGetStaleProofLes4(t *testing.T) { testGetStaleProof(t, 4) }
 
 func testGetStaleProof(t *testing.T, protocol int) {
 	netconfig := testnetConfig{
-		blocks:    core.TriesInMemory + 4,
+		blocks:    core.DefaultTriesInMemory + 4,
 		protocol:  protocol,
 		nopruning: true,
 	}

--- a/les/peer.go
+++ b/les/peer.go
@@ -1058,7 +1058,7 @@ func (p *clientPeer) Handshake(td *big.Int, head common.Hash, headNum uint64, ge
 
 			// If local ethereum node is running in archive mode, advertise ourselves we have
 			// all version state data. Otherwise only recent state is available.
-			stateRecent := uint64(core.TriesInMemory - blockSafetyMargin)
+			stateRecent := uint64(core.DefaultTriesInMemory - blockSafetyMargin)
 			if server.archiveMode {
 				stateRecent = 0
 			}

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -297,7 +297,7 @@ func handleGetCode(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 			// Refuse to search stale state data in the database since looking for
 			// a non-exist key is kind of expensive.
 			local := bc.CurrentHeader().Number.Uint64()
-			if !backend.ArchiveMode() && header.Number.Uint64()+core.TriesInMemory <= local {
+			if !backend.ArchiveMode() && header.Number.Uint64()+core.DefaultTriesInMemory <= local {
 				p.Log().Debug("Reject stale code request", "number", header.Number.Uint64(), "head", local)
 				p.bumpInvalid()
 				continue
@@ -396,7 +396,7 @@ func handleGetProofs(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 				// Refuse to search stale state data in the database since looking for
 				// a non-exist key is kind of expensive.
 				local := bc.CurrentHeader().Number.Uint64()
-				if !backend.ArchiveMode() && header.Number.Uint64()+core.TriesInMemory <= local {
+				if !backend.ArchiveMode() && header.Number.Uint64()+core.DefaultTriesInMemory <= local {
 					p.Log().Debug("Reject stale trie request", "number", header.Number.Uint64(), "head", local)
 					p.bumpInvalid()
 					continue

--- a/les/test_helper.go
+++ b/les/test_helper.go
@@ -375,7 +375,7 @@ func (p *testPeer) handshakeWithClient(t *testing.T, td *big.Int, head common.Ha
 	sendList = sendList.add("serveHeaders", nil)
 	sendList = sendList.add("serveChainSince", uint64(0))
 	sendList = sendList.add("serveStateSince", uint64(0))
-	sendList = sendList.add("serveRecentState", uint64(core.TriesInMemory-4))
+	sendList = sendList.add("serveRecentState", uint64(core.DefaultTriesInMemory-4))
 	sendList = sendList.add("txRelay", nil)
 	sendList = sendList.add("flowControl/BL", testBufLimit)
 	sendList = sendList.add("flowControl/MRR", testBufRecharge)


### PR DESCRIPTION
This commit adds --triesinmemory flag to configure the number of tries that is kept in memory before pruning.