### PR TITLE
blockchain: fix the write known block check

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1675,7 +1675,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		)
 		for block != nil && bc.skipBlock(err, it) {
 			externTd = new(big.Int).Add(externTd, block.Difficulty())
-			if bc.reorgNeeded(current, localTd, block, externTd) {
+			if localTd.Cmp(externTd) < 0 && bc.reorgNeeded(current, localTd, block, externTd) {
 				break
 			}
 			log.Debug("Ignoring already known block", "number", block.Number(), "hash", block.Hash())


### PR DESCRIPTION
Before commit bf2f0d1787d ("blockchain: fix inconsistent reorg behavior"), the write known block only checks the if the external total difficulty (TD) is higher than local one without following the fast finality rule, so it can reorg an justified block. That commit replaces the check with reorgNeeded function to enforce the fast finality rule. However, the reorgNeeded function does not strictly enforce that the external TD is higher than local one, it allows that the external TD may be equal to the local one. This leads to warning with an impossible reorg case.

This commit adds back the TD check combining with the reorgNeeded function to correcly enforce the rule here.

Fixes: #403 