### PR TITLE
consortium-v2: fix the system transaction's sender check in ApplyTransaction

### DIFF
--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -297,7 +297,7 @@ func ApplyTransaction(msg types.Message, opts *ApplyTransactOpts) (err error) {
 
 	signer := opts.Signer
 	signTxFn := opts.SignTxFn
-	miner := opts.Header.Coinbase
+	coinbase := opts.Header.Coinbase
 	mining := opts.Mining
 	chainConfig := opts.ChainConfig
 	receivedTxs := opts.ReceivedTxs
@@ -316,7 +316,11 @@ func ApplyTransaction(msg types.Message, opts *ApplyTransactOpts) (err error) {
 		return fmt.Errorf("%w: address %v, codehash: %s", core.ErrSenderNoEOA, sender.Hex(), codeHash)
 	}
 
-	if msg.From() == miner && mining {
+	if sender != coinbase {
+		return fmt.Errorf("sender of system transaction is not coinbase, sender: %s, coinbase: %s", sender, coinbase)
+	}
+
+	if mining {
 		expectedTx, err = signTxFn(accounts.Account{Address: msg.From()}, expectedTx, chainConfig.ChainID)
 		if err != nil {
 			return err

--- a/consensus/consortium/common/contract_test.go
+++ b/consensus/consortium/common/contract_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -49,5 +50,23 @@ func TestApplyTransactionSender(t *testing.T) {
 	)
 	if !errors.Is(err, core.ErrSenderNoEOA) {
 		t.Fatalf("Expect err: %s, have %s", core.ErrSenderNoEOA, err)
+	}
+
+	state.SetCode(sender, []byte{})
+	coinbase := common.Address{0x2}
+	err = ApplyTransaction(
+		msg,
+		&ApplyTransactOpts{
+			ApplyMessageOpts: &ApplyMessageOpts{
+				State:  state,
+				Header: &types.Header{Coinbase: coinbase},
+			},
+			Signer: signer,
+		},
+	)
+
+	expectedErr := fmt.Errorf("sender of system transaction is not coinbase, sender: %s, coinbase: %s", sender, coinbase)
+	if err == nil || err.Error() != expectedErr.Error() {
+		t.Fatalf("Expect err: %s, have %s", expectedErr, err)
 	}
 }

--- a/consensus/consortium/common/contract_test.go
+++ b/consensus/consortium/common/contract_test.go
@@ -1,0 +1,53 @@
+package common
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestApplyTransactionSender(t *testing.T) {
+	signer := types.NewMikoSigner(big.NewInt(2020))
+	privateKey, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	tx, err := types.SignNewTx(privateKey, signer, &types.LegacyTx{
+		Nonce:    0,
+		GasPrice: common.Big0,
+		Gas:      21000,
+		To:       &sender,
+	})
+	if err != nil {
+		t.Fatalf("Failed to sign transaction, err: %s", err)
+	}
+
+	state, err := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	if err != nil {
+		t.Fatalf("Failed to create stateDB, err %s", err)
+	}
+
+	msg, err := tx.AsMessage(signer, nil)
+	if err != nil {
+		t.Fatalf("Failed to create message, err %s", err)
+	}
+	err = ApplyTransaction(
+		msg,
+		&ApplyTransactOpts{
+			ApplyMessageOpts: &ApplyMessageOpts{
+				State:  state,
+				Header: &types.Header{},
+			},
+			Signer: signer,
+		},
+	)
+	if !errors.Is(err, core.ErrSenderNoEOA) {
+		t.Fatalf("Expect err: %s, have %s", core.ErrSenderNoEOA, err)
+	}
+}


### PR DESCRIPTION
- consortium-v2: check that sender of system transaction is EOA

Following EIP-3607 ("Reject transactions from senders with deployed code"), if
the sender of transaction has deployed code (not an EOA), the transaction is
rejected. This commit adds the same check to system transaction.

- consortium-v2: cleanup the check of system transaction's sender with coinbase

Currently, the system transaction's sender check looks weird, it still allows
that sender is different from coinbase. However, the sender is checked to be
equal to coinbase in IsSystemMessage already, so there must be no issue here.
This commit fixes that check in ApplyTransaction, we keep this check to make it
more explicit though the check is redundant.