### PR TITLE
rawdb: add Consortium snapshot to inspect db's result

### DIFF
--- a/consensus/consortium/v1/snapshot.go
+++ b/consensus/consortium/v1/snapshot.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -65,7 +66,7 @@ func newSnapshot(config *params.ConsortiumConfig, sigcache *lru.ARCCache, number
 
 // loadSnapshot loads an existing snapshot from the database.
 func loadSnapshot(config *params.ConsortiumConfig, sigcache *lru.ARCCache, db ethdb.Database, hash common.Hash) (*Snapshot, error) {
-	blob, err := db.Get(append([]byte("consortium-"), hash[:]...))
+	blob, err := db.Get(append(rawdb.ConsortiumSnapshotPrefix, hash[:]...))
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -11,6 +11,7 @@ import (
 	consortiumCommon "github.com/ethereum/go-ethereum/consensus/consortium/common"
 	v1 "github.com/ethereum/go-ethereum/consensus/consortium/v1"
 	"github.com/ethereum/go-ethereum/consensus/consortium/v2/finality"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	blsCommon "github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -111,7 +112,7 @@ func (s *Snapshot) store(db ethdb.Database) error {
 	if err != nil {
 		return err
 	}
-	return db.Put(append([]byte("consortium-"), s.Hash[:]...), blob)
+	return db.Put(append(rawdb.ConsortiumSnapshotPrefix, s.Hash[:]...), blob)
 }
 
 // copy creates a deep copy of the snapshot.

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -407,6 +407,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		preimages       stat
 		bloomBits       stat
 		cliqueSnaps     stat
+		consortiumSnaps stat
 
 		// Ancient store statistics
 		ancientHeadersSize  common.StorageSize
@@ -466,6 +467,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			bloomBits.Add(size)
 		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
 			cliqueSnaps.Add(size)
+		case bytes.HasPrefix(key, ConsortiumSnapshotPrefix) && len(key) == len(ConsortiumSnapshotPrefix)+common.HashLength:
+			consortiumSnaps.Add(size)
 		case bytes.HasPrefix(key, []byte("cht-")) ||
 			bytes.HasPrefix(key, []byte("chtIndexV2-")) ||
 			bytes.HasPrefix(key, []byte("chtRootV2-")): // Canonical hash trie
@@ -528,6 +531,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Account snapshot", accountSnaps.Size(), accountSnaps.Count()},
 		{"Key-Value store", "Storage snapshot", storageSnaps.Size(), storageSnaps.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
+		{"Key-Value store", "Consortium snapshots", consortiumSnaps.Size(), consortiumSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -81,6 +81,8 @@ var (
 	// lastFinalityVoteKey tracks the highest finality vote
 	highestFinalityVoteKey = []byte("HighestFinalityVote")
 
+	ConsortiumSnapshotPrefix = []byte("consortium-") // key = ConsortiumSnapshotPrefix + block hash
+
 	// Data item prefixes (use single byte to avoid mixing data types, avoid `i`, used for indexes).
 	headerPrefix       = []byte("h") // headerPrefix + num (uint64 big endian) + hash -> header
 	headerTDSuffix     = []byte("t") // headerPrefix + num (uint64 big endian) + hash + headerTDSuffix -> td


### PR DESCRIPTION
This commit adds the key that Consortium snapshot uses to store the value into key-value DB to database inspect command. This helps to get storage stats of Consortium snapshot.