### PR TITLE
consortium: remove transaction signing logic in getTransactionOpts

### DIFF
--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -44,12 +44,8 @@ func getTransactionOpts(from common.Address, nonce uint64, chainId *big.Int, sig
 		Nonce:  new(big.Int).SetUint64(nonce),
 		NoSend: true,
 		Signer: func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
-			// signTxFn is nil when mining is not enabled, then we just return the transaction directly
-			if signTxFn == nil {
-				return tx, nil
-			}
-
-			return signTxFn(accounts.Account{Address: from}, tx, chainId)
+			// The transaction signing will happen later in ApplyTransaction
+			return tx, nil
 		},
 	}
 }


### PR DESCRIPTION
The transaction signing logic happens later in ApplyTransaction. The getTransactionOpts is only used to prepare the transaction data. Furthermore, the logic in getTransactionOpts does not properly handle block insert path, it requires that the system transaction signing is executed successfully even in the block insert path which is not correct. This commit removes the transaction signing logic in getTransactionOpts to fix the logic when inserting block.