### PR TITLE
consortium-v2: make finality vote weight proportional to staked amount

### DIFF
--- a/consensus/consortium/common/constants.go
+++ b/consensus/consortium/common/constants.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	ExtraSeal   = crypto.SignatureLength
-	ExtraVanity = 32
+	ExtraSeal                        = crypto.SignatureLength
+	ExtraVanity                      = 32
+	MaxFinalityVotePercentage uint16 = 10_000
 )
 
 var (

--- a/consensus/consortium/common/mock_contract.go
+++ b/consensus/consortium/common/mock_contract.go
@@ -14,7 +14,7 @@ import (
 var Validators *MockValidators
 
 type MockValidators struct {
-	validators []common.Address
+	validators    []common.Address
 	blsPublicKeys map[common.Address]blsCommon.PublicKey
 }
 
@@ -25,7 +25,7 @@ func SetMockValidators(validators, publicKeys string) error {
 		return errors.New("mismatch length between mock validators and mock blsPubKey")
 	}
 	Validators = &MockValidators{
-		validators: make([]common.Address, len(vals)),
+		validators:    make([]common.Address, len(vals)),
 		blsPublicKeys: make(map[common.Address]blsCommon.PublicKey),
 	}
 	for i, val := range vals {
@@ -79,4 +79,8 @@ func (contract *MockContract) FinalityReward(*ApplyTransactOpts, []common.Addres
 
 func (contract *MockContract) GetBlsPublicKey(_ *big.Int, addr common.Address) (blsCommon.PublicKey, error) {
 	return Validators.GetPublicKey(addr)
+}
+
+func (contract *MockContract) GetStakedAmount(_ *big.Int, _ []common.Address) ([]*big.Int, error) {
+	return nil, nil
 }

--- a/consensus/consortium/common/utils_test.go
+++ b/consensus/consortium/common/utils_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -63,5 +64,63 @@ func TestRemoveInvalidRecents(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expect %v but got %v", expected, actual)
+	}
+}
+
+func TestNormalizeFinalityVoteWeight(t *testing.T) {
+	// All staked amounts are equal
+	var stakedAmounts []*big.Int
+	for i := 0; i < 22; i++ {
+		stakedAmounts = append(stakedAmounts, big.NewInt(1_000_000))
+	}
+
+	voteWeights := NormalizeFinalityVoteWeight(stakedAmounts)
+	for _, voteWeight := range voteWeights {
+		if voteWeight != 454 {
+			t.Fatalf("Incorrect vote weight, expect %d got %d", 454, voteWeight)
+		}
+	}
+
+	// All staked amount differs
+	for i := 0; i < 22; i++ {
+		stakedAmounts[i] = big.NewInt(int64(i) + 1)
+	}
+	voteWeights = NormalizeFinalityVoteWeight(stakedAmounts)
+	expectedVoteWeights := []uint16{51, 103, 155, 207, 259, 311, 363, 415, 467, 519, 571, 597, 597, 597, 597, 597, 597, 597, 597, 597, 597, 597}
+
+	for i := range voteWeights {
+		if voteWeights[i] != expectedVoteWeights[i] {
+			t.Fatalf("Incorrect vote weight, expect %d got %d", expectedVoteWeights[i], voteWeights[i])
+		}
+	}
+
+	// Staked amount differences are small
+	for i := 0; i < 22; i++ {
+		stakedAmounts[i] = big.NewInt(int64(i) + 1_000_000)
+	}
+	voteWeights = NormalizeFinalityVoteWeight(stakedAmounts)
+	for i := range voteWeights {
+		if voteWeights[i] != 454 {
+			t.Fatalf("Incorrect vote weight, expect %d got %d", 454, voteWeights[i])
+		}
+	}
+
+	// Some staked amounts differ greatly
+	for i := 0; i < 20; i++ {
+		stakedAmounts[i] = big.NewInt(1_000_000)
+	}
+	stakedAmounts[20] = big.NewInt(1000)
+	stakedAmounts[21] = big.NewInt(2500)
+	voteWeights = NormalizeFinalityVoteWeight(stakedAmounts)
+	for i := 0; i < 20; i++ {
+		if voteWeights[i] != 499 {
+			t.Fatalf("Incorrect vote weight, expect %d got %d", 499, voteWeights[i])
+		}
+	}
+	if voteWeights[20] != 0 {
+		t.Fatalf("Incorrect vote weight, expect %d got %d", 0, voteWeights[20])
+	}
+	if voteWeights[21] != 1 {
+		t.Fatalf("Incorrect vote weight, expect %d got %d", 1, voteWeights[21])
 	}
 }

--- a/consensus/consortium/generated_contracts/staking/staking.go
+++ b/consensus/consortium/generated_contracts/staking/staking.go
@@ -1,0 +1,211 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package staking
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// StakingMetaData contains all meta data concerning the Staking contract.
+var StakingMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"TConsensus[]\",\"name\":\"consensusAddrs\",\"type\":\"address[]\"}],\"name\":\"getManyStakingTotals\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"stakingAmounts_\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+// StakingABI is the input ABI used to generate the binding from.
+// Deprecated: Use StakingMetaData.ABI instead.
+var StakingABI = StakingMetaData.ABI
+
+// Staking is an auto generated Go binding around an Ethereum contract.
+type Staking struct {
+	StakingCaller     // Read-only binding to the contract
+	StakingTransactor // Write-only binding to the contract
+	StakingFilterer   // Log filterer for contract events
+}
+
+// StakingCaller is an auto generated read-only Go binding around an Ethereum contract.
+type StakingCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StakingTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type StakingTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StakingFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type StakingFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StakingSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type StakingSession struct {
+	Contract     *Staking          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// StakingCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type StakingCallerSession struct {
+	Contract *StakingCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// StakingTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type StakingTransactorSession struct {
+	Contract     *StakingTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// StakingRaw is an auto generated low-level Go binding around an Ethereum contract.
+type StakingRaw struct {
+	Contract *Staking // Generic contract binding to access the raw methods on
+}
+
+// StakingCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type StakingCallerRaw struct {
+	Contract *StakingCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// StakingTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type StakingTransactorRaw struct {
+	Contract *StakingTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewStaking creates a new instance of Staking, bound to a specific deployed contract.
+func NewStaking(address common.Address, backend bind.ContractBackend) (*Staking, error) {
+	contract, err := bindStaking(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Staking{StakingCaller: StakingCaller{contract: contract}, StakingTransactor: StakingTransactor{contract: contract}, StakingFilterer: StakingFilterer{contract: contract}}, nil
+}
+
+// NewStakingCaller creates a new read-only instance of Staking, bound to a specific deployed contract.
+func NewStakingCaller(address common.Address, caller bind.ContractCaller) (*StakingCaller, error) {
+	contract, err := bindStaking(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingCaller{contract: contract}, nil
+}
+
+// NewStakingTransactor creates a new write-only instance of Staking, bound to a specific deployed contract.
+func NewStakingTransactor(address common.Address, transactor bind.ContractTransactor) (*StakingTransactor, error) {
+	contract, err := bindStaking(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingTransactor{contract: contract}, nil
+}
+
+// NewStakingFilterer creates a new log filterer instance of Staking, bound to a specific deployed contract.
+func NewStakingFilterer(address common.Address, filterer bind.ContractFilterer) (*StakingFilterer, error) {
+	contract, err := bindStaking(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &StakingFilterer{contract: contract}, nil
+}
+
+// bindStaking binds a generic wrapper to an already deployed contract.
+func bindStaking(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(StakingABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Staking *StakingRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Staking.Contract.StakingCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Staking *StakingRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Staking.Contract.StakingTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Staking *StakingRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Staking.Contract.StakingTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Staking *StakingCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Staking.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Staking *StakingTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Staking.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Staking *StakingTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Staking.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetManyStakingTotals is a free data retrieval call binding the contract method 0x91f8723f.
+//
+// Solidity: function getManyStakingTotals(address[] consensusAddrs) view returns(uint256[] stakingAmounts_)
+func (_Staking *StakingCaller) GetManyStakingTotals(opts *bind.CallOpts, consensusAddrs []common.Address) ([]*big.Int, error) {
+	var out []interface{}
+	err := _Staking.contract.Call(opts, &out, "getManyStakingTotals", consensusAddrs)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// GetManyStakingTotals is a free data retrieval call binding the contract method 0x91f8723f.
+//
+// Solidity: function getManyStakingTotals(address[] consensusAddrs) view returns(uint256[] stakingAmounts_)
+func (_Staking *StakingSession) GetManyStakingTotals(consensusAddrs []common.Address) ([]*big.Int, error) {
+	return _Staking.Contract.GetManyStakingTotals(&_Staking.CallOpts, consensusAddrs)
+}
+
+// GetManyStakingTotals is a free data retrieval call binding the contract method 0x91f8723f.
+//
+// Solidity: function getManyStakingTotals(address[] consensusAddrs) view returns(uint256[] stakingAmounts_)
+func (_Staking *StakingCallerSession) GetManyStakingTotals(consensusAddrs []common.Address) ([]*big.Int, error) {
+	return _Staking.Contract.GetManyStakingTotals(&_Staking.CallOpts, consensusAddrs)
+}

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -273,14 +273,10 @@ func (c *Consortium) verifyFinalitySignatures(
 	parentHash common.Hash,
 	parents []*types.Header,
 ) error {
+	isTripp := c.chainConfig.IsTripp(new(big.Int).SetUint64(parentNumber + 1))
 	snap, err := c.snapshot(chain, parentNumber, parentHash, parents)
 	if err != nil {
 		return err
-	}
-
-	votedValidatorPositions := finalityVotedValidators.Indices()
-	if len(votedValidatorPositions) < int(math.Floor(finalityRatio*float64(len(snap.ValidatorsWithBlsPub))))+1 {
-		return finality.ErrNotEnoughFinalityVote
 	}
 
 	voteData := types.VoteData{
@@ -290,13 +286,34 @@ func (c *Consortium) verifyFinalitySignatures(
 	digest := voteData.Hash()
 
 	// verify aggregated signature
-	var publicKeys []blsCommon.PublicKey
+	var (
+		publicKeys            []blsCommon.PublicKey
+		accumulatedVoteWeight int
+		finalityThreshold     int
+	)
+	votedValidatorPositions := finalityVotedValidators.Indices()
 	for _, position := range votedValidatorPositions {
 		if position >= len(snap.ValidatorsWithBlsPub) {
 			return finality.ErrInvalidFinalityVotedBitSet
 		}
 		publicKeys = append(publicKeys, snap.ValidatorsWithBlsPub[position].BlsPublicKey)
+		if isTripp {
+			accumulatedVoteWeight += int(snap.FinalityVoteWeight[position])
+		} else {
+			accumulatedVoteWeight += 1
+		}
 	}
+
+	if isTripp {
+		finalityThreshold = int(math.Floor(finalityRatio*float64(consortiumCommon.MaxFinalityVotePercentage))) + 1
+	} else {
+		finalityThreshold = int(math.Floor(finalityRatio*float64(len(snap.ValidatorsWithBlsPub)))) + 1
+	}
+
+	if accumulatedVoteWeight < finalityThreshold {
+		return finality.ErrNotEnoughFinalityVote
+	}
+
 	if !finalitySignatures.FastAggregateVerify(publicKeys, digest) {
 		return finality.ErrFinalitySignatureVerificationFailed
 	}
@@ -681,7 +698,10 @@ func (c *Consortium) getCheckpointValidatorsFromContract(
 	)
 
 	isShillin := c.chainConfig.IsShillin(header.Number)
-	if isShillin {
+	isTripp := c.chainConfig.IsTripp(header.Number)
+	// After Tripp, BLS key of validator is read at the start of new period,
+	// not the start of epoch anymore.
+	if isShillin && !isTripp {
 		// The filteredValidators shares the same underlying array with newValidators
 		// See more: https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 		filteredValidators = filteredValidators[:0]
@@ -698,7 +718,7 @@ func (c *Consortium) getCheckpointValidatorsFromContract(
 		validatorWithBlsPub := finality.ValidatorWithBlsPub{
 			Address: filteredValidators[i],
 		}
-		if isShillin {
+		if isShillin && !isTripp {
 			validatorWithBlsPub.BlsPublicKey = blsPublicKeys[i]
 		}
 
@@ -735,6 +755,7 @@ func (c *Consortium) Prepare(chain consensus.ChainHeaderReader, header *types.He
 			return err
 		}
 		extraData.CheckpointValidators = checkpointValidator
+		// TODO: if is Tripp and new period, read all validator candidates and their amounts, appends to header
 	}
 
 	// After Shillin, extraData.hasFinalityVote = 0 here as we does
@@ -891,6 +912,7 @@ func (c *Consortium) Finalize(chain consensus.ChainHeaderReader, header *types.H
 		if err != nil {
 			return err
 		}
+		// TODO: if is Tripp and new period, read all validator candidates and their amounts, check with stored data in header
 		extraData, err := finality.DecodeExtra(header.Extra, isShillin)
 		if err != nil {
 			return err
@@ -1228,14 +1250,24 @@ func (c *Consortium) assembleFinalityVote(header *types.Header, snap *Snapshot) 
 		var (
 			signatures              []blsCommon.Signature
 			finalityVotedValidators finality.FinalityVoteBitSet
-			finalityThreshold       int = int(math.Floor(finalityRatio*float64(len(snap.ValidatorsWithBlsPub)))) + 1
+			finalityThreshold       int
+			accumulatedVoteWeight   int
 		)
+
+		isTripp := c.chainConfig.IsTripp(header.Number)
+		if isTripp {
+			finalityThreshold = int(math.Floor(finalityRatio*float64(consortiumCommon.MaxFinalityVotePercentage))) + 1
+		} else {
+			finalityThreshold = int(math.Floor(finalityRatio*float64(len(snap.ValidatorsWithBlsPub)))) + 1
+		}
 
 		// We assume the signature has been verified in vote pool
 		// so we do not verify signature here
 		if c.votePool != nil {
 			votes := c.votePool.FetchVoteByBlockHash(header.ParentHash)
-			if len(votes) >= finalityThreshold {
+			// Before Tripp (!isTripp), every vote has the same weight so if the number of votes
+			// is lower than threshold, we can short-circuit and skip all the checks
+			if isTripp || len(votes) >= finalityThreshold {
 				for _, vote := range votes {
 					publicKey, err := blst.PublicKeyFromBytes(vote.PublicKey[:])
 					if err != nil {
@@ -1245,14 +1277,22 @@ func (c *Consortium) assembleFinalityVote(header *types.Header, snap *Snapshot) 
 					authorized := false
 					for valPosition, validator := range snap.ValidatorsWithBlsPub {
 						if publicKey.Equals(validator.BlsPublicKey) {
+							authorized = true
 							signature, err := blst.SignatureFromBytes(vote.Signature[:])
 							if err != nil {
 								log.Warn("Malformed signature from vote pool", "err", err)
 								break
 							}
+							if finalityVotedValidators.GetBit(valPosition) != 0 {
+								log.Warn("More than 1 vote from validator", "address", validator.Address.Hex(),
+									"blockHash", header.Hash(), "blockNumber", header.Number)
+								break
+							}
 							signatures = append(signatures, signature)
 							finalityVotedValidators.SetBit(valPosition)
-							authorized = true
+							if isTripp {
+								accumulatedVoteWeight += int(snap.FinalityVoteWeight[valPosition])
+							}
 							break
 						}
 					}
@@ -1261,8 +1301,10 @@ func (c *Consortium) assembleFinalityVote(header *types.Header, snap *Snapshot) 
 					}
 				}
 
-				bitSetCount := len(finalityVotedValidators.Indices())
-				if bitSetCount >= finalityThreshold {
+				if !isTripp {
+					accumulatedVoteWeight = len(finalityVotedValidators.Indices())
+				}
+				if accumulatedVoteWeight >= finalityThreshold {
 					extraData, err := finality.DecodeExtra(header.Extra, true)
 					if err != nil {
 						// This should not happen
@@ -1277,7 +1319,6 @@ func (c *Consortium) assembleFinalityVote(header *types.Header, snap *Snapshot) 
 			}
 		}
 	}
-
 }
 
 // GetFinalizedBlock gets the fast finality finalized block

--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -139,6 +139,14 @@ func (bitSet *FinalityVoteBitSet) Indices() []int {
 	return votedValidatorPositions
 }
 
+func (bitSet *FinalityVoteBitSet) GetBit(index int) int {
+	if index >= finalityVoteBitSetByteLength*8 {
+		return 0
+	}
+
+	return int((uint64(*bitSet) >> index) & 1)
+}
+
 func (bitSet *FinalityVoteBitSet) SetBit(index int) {
 	if index >= finalityVoteBitSetByteLength*8 {
 		return

--- a/consensus/consortium/v2/finality/consortium_header_test.go
+++ b/consensus/consortium/v2/finality/consortium_header_test.go
@@ -1,0 +1,39 @@
+package finality
+
+import "testing"
+
+func TestFinalityVoteBitSet(t *testing.T) {
+	var bitSet FinalityVoteBitSet
+
+	bitSet.SetBit(0)
+	bitSet.SetBit(40)
+	// index >= 64 has no effect
+	bitSet.SetBit(64)
+
+	// 2 ** 40 + 2 ** 0
+	if uint64(bitSet) != 1099511627777 {
+		t.Fatalf("Wrong bitset value, exp %d got %d", 1099511627777, uint64(bitSet))
+	}
+
+	indices := bitSet.Indices()
+	if len(indices) != 2 {
+		t.Fatalf("Wrong indices length, exp %d got %d", 2, len(indices))
+	}
+	if indices[0] != 0 {
+		t.Fatalf("Wrong index, exp %d got %d", 0, indices[0])
+	}
+	if indices[1] != 40 {
+		t.Fatalf("Wrong index, exp %d got %d", 40, indices[1])
+	}
+
+	if bitSet.GetBit(40) != 1 {
+		t.Fatalf("Wrong bit, exp %d got %d", 1, bitSet.GetBit(40))
+	}
+	if bitSet.GetBit(50) != 0 {
+		t.Fatalf("Wrong bit, exp %d got %d", 1, bitSet.GetBit(50))
+	}
+	// index >= 64 returns 0
+	if bitSet.GetBit(70) != 0 {
+		t.Fatalf("Wrong bit, exp %d got %d", 0, bitSet.GetBit(70))
+	}
+}

--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -21,6 +21,7 @@ import (
 
 // Snapshot is the state of the authorization validators at a given point in time.
 type Snapshot struct {
+	// private fields are not json.Marshalled
 	chainConfig *params.ChainConfig
 	config      *params.ConsortiumConfig // Consensus engine parameters to fine tune behavior
 	ethAPI      *ethapi.PublicBlockChainAPI
@@ -32,7 +33,8 @@ type Snapshot struct {
 	Recents    map[uint64]common.Address   `json:"recents"`              // Set of recent validators for spam protections
 
 	// Finality additional fields
-	ValidatorsWithBlsPub []finality.ValidatorWithBlsPub `json:"validatorWithBlsPub,omitempty"`  // Array of sorted authorized validators and BLS public keys after Shillin
+	ValidatorsWithBlsPub []finality.ValidatorWithBlsPub `json:"validatorWithBlsPub,omitempty"` // Array of sorted authorized validators and BLS public keys after Shillin
+	FinalityVoteWeight   []uint16                       `json:"finalityVoteWeight,omitempty"`
 	JustifiedBlockNumber uint64                         `json:"justifiedBlockNumber,omitempty"` // The justified block number
 	JustifiedBlockHash   common.Hash                    `json:"justifiedBlockHash,omitempty"`   // The justified block hash
 }
@@ -239,6 +241,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 				snap.ValidatorsWithBlsPub = nil
 			} else {
 				isShillin := chain.Config().IsShillin(checkpointHeader.Number)
+				isTripp := chain.Config().IsTripp(checkpointHeader.Number)
 				// Get validator set from headers and use that for new validator set
 				extraData, err := finality.DecodeExtra(checkpointHeader.Extra, isShillin)
 				if err != nil {
@@ -253,7 +256,11 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 					}
 				}
 
-				if isShillin {
+				if isTripp {
+					// TODO: if at the start of period, read BLS key, consensus and staked amount from header
+
+					// TODO: if at the start of epoch, read block producer's consensus address
+				} else if isShillin {
 					// The validator information in checkpoint header is already sorted,
 					// we don't need to sort here
 					snap.ValidatorsWithBlsPub = make([]finality.ValidatorWithBlsPub, len(extraData.CheckpointValidators))


### PR DESCRIPTION
Currently, the finality vote weights of all validators are the same. After this commit, the finality vote weight is based on the staked amount of the validator. The rule of finality vote weight follows what is stated in REP-0010: Introducing Rotating Validators

	- If the staked amount of a validator is smaller than or equal to 1/22 of total stake, the weight is directly proportional to the staked amount.
	- If the staked amount of a validator is bigger than 1/22 of total stake, the weight equals 1/22 of total stake.