### PR TITLE
core: adjust reserved gas for system transactions in non-checkpoint block

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -621,7 +621,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// Ensure the transaction doesn't exceed the current block limit gas.
 	var reservedGas uint64 = 0
 	if pool.chainconfig.Consortium != nil {
-		reservedGas = params.ReservedGasForSystemTransactions
+		if pool.chain.CurrentBlock().NumberU64()%pool.chainconfig.Consortium.EpochV2 == pool.chainconfig.Consortium.EpochV2-1 {
+			reservedGas = params.ReservedGasForCheckpointSystemTransactions
+		} else {
+			reservedGas = params.ReservedGasForNormalSystemTransactions
+		}
 	}
 	if pool.currentMaxGas-reservedGas < tx.Gas() {
 		return ErrGasLimit

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -19,7 +19,8 @@ package params
 import "math/big"
 
 const (
-	ReservedGasForSystemTransactions uint64 = 10_000_000 // The reserved gas for system transactions in each block.
+	ReservedGasForCheckpointSystemTransactions uint64 = 10_000_000 // The reserved gas for system transactions in checkpoint blocks.
+	ReservedGasForNormalSystemTransactions     uint64 = 2_000_000  // The reserved gas for system transactions in normal blocks.
 
 	GasLimitBoundDivisor           uint64 = 1024 // The bound divisor of the gas limit, used in update calculations.
 	ConsortiumGasLimitBoundDivisor uint64 = 256


### PR DESCRIPTION
Currently, reserved gas for system transaction is hardcoded as 10M gas. (https://github.com/axieinfinity/ronin/blob/95e3707865263a9c751307c951ef5c02a8247717/miner/worker.go#L879-L890). However, only the checkpoint block - 1 (the block at the end of epoch) needs to reserve that much (because wrap up epoch transaction requires a lot of gas), it is necessary to adjust the logic to reserve lower gas in normal block or higher gas in checkpoint block.