### PR TITLE
consortium-v2: new RLP encoder/decoder for HeaderExtraData

### DIFF
--- a/consensus/consortium/v2/api.go
+++ b/consensus/consortium/v2/api.go
@@ -52,8 +52,7 @@ func (api *consortiumV2Api) GetFinalityVoteAtHash(hash common.Hash) (*finalityVo
 		return nil, consortiumCommon.ErrUnknownBlock
 	}
 
-	isShillin := api.consortium.chainConfig.IsShillin(header.Number)
-	extraData, err := finality.DecodeExtra(header.Extra, isShillin)
+	extraData, err := finality.DecodeExtraV2(header.Extra, api.consortium.chainConfig, header.Number)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -3,9 +3,11 @@ package v2
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"math/big"
+	mrand "math/rand"
 	"testing"
 	"time"
 
@@ -527,6 +529,124 @@ func TestExtraDataDecode(t *testing.T) {
 
 	if !decodedData.CheckpointValidators[0].BlsPublicKey.Equals(extraData.CheckpointValidators[0].BlsPublicKey) {
 		t.Errorf("Mismatch decoded data")
+	}
+}
+
+func mockExtraData(nVal int, bits uint32) *finality.HeaderExtraData {
+	var (
+		vanity                  = make([]byte, finality.ExtraVanity)
+		hasFinalityVote         uint8
+		finalityVotedValidators finality.FinalityVoteBitSet
+		aggregatedFinalityVotes blsCommon.Signature
+		checkpointValidators    = make([]finality.ValidatorWithBlsPub, 0, nVal)
+		seal                    = make([]byte, finality.ExtraSeal)
+	)
+	ret := &finality.HeaderExtraData{}
+
+	hasFinalityVote = uint8(mrand.Intn(2))
+	ret.HasFinalityVote = hasFinalityVote
+
+	if ret.HasFinalityVote == 1 {
+		finalityVotedValidators = finality.FinalityVoteBitSet(mrand.Uint64())
+		ret.FinalityVotedValidators = finalityVotedValidators
+
+		delegated, _ := blst.RandKey()
+		msg := make([]byte, 64)
+		rand.Read(msg)
+		aggregatedFinalityVotes = delegated.Sign(msg)
+		ret.AggregatedFinalityVotes = aggregatedFinalityVotes
+	}
+
+	bits = bits % 7 // ensure bits can be represented by 3-bit integer
+	for i := 0; i < 3; i++ {
+		if bits&(1<<i) != 0 {
+			switch i {
+			case 0:
+				rand.Read(vanity)
+				ret.Vanity = [finality.ExtraVanity]byte(vanity)
+			case 1:
+				for i := 0; i < nVal; i++ {
+					s, _ := blst.RandKey()
+					sk, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+					addr := crypto.PubkeyToAddress(sk.PublicKey)
+					val := finality.ValidatorWithBlsPub{
+						Address:      addr,
+						BlsPublicKey: s.PublicKey(),
+					}
+					checkpointValidators = append(checkpointValidators, val)
+				}
+				ret.CheckpointValidators = checkpointValidators
+			case 2:
+				rand.Read(seal)
+				ret.Seal = [finality.ExtraSeal]byte(seal)
+			}
+		}
+	}
+	return ret
+}
+
+func TestExtraDataEncodeRLP(t *testing.T) {
+	nVal := 22
+	for i := 0; i < 7; i++ {
+		ext := mockExtraData(nVal, uint32(i))
+		_, err := ext.EncodeRLP()
+		if err != nil {
+			t.Errorf("encode rlp error: %v", err)
+		}
+	}
+}
+
+func TestExtraDataDecodeRLP(t *testing.T) {
+	nVals := 22
+	// loop 64 times, equivalent to 64 combinations of 6 bits
+	for i := 0; i < 7; i++ {
+		ext := mockExtraData(nVals, uint32(i))
+		enc, err := ext.EncodeRLP()
+		if err != nil {
+			t.Errorf("encode rlp error: %v", err)
+		}
+		dec, err := finality.DecodeExtraRLP(enc)
+		if err != nil {
+			t.Errorf("decode rlp error: %v", err)
+		}
+		if !bytes.Equal(dec.Vanity[:], ext.Vanity[:]) {
+			t.Errorf("Mismatched decoded data")
+		}
+		if dec.HasFinalityVote != ext.HasFinalityVote {
+			t.Errorf("Mismatch decoded data")
+		}
+		if dec.FinalityVotedValidators != ext.FinalityVotedValidators {
+			t.Errorf("Mismatch decoded data")
+		}
+		if (dec.AggregatedFinalityVotes != nil && ext.AggregatedFinalityVotes == nil) ||
+			(dec.AggregatedFinalityVotes == nil && ext.AggregatedFinalityVotes != nil) {
+			t.Errorf("Mismatch decoded data")
+		}
+		if dec.AggregatedFinalityVotes != nil &&
+			ext.AggregatedFinalityVotes != nil &&
+			!bytes.Equal(dec.AggregatedFinalityVotes.Marshal(), ext.AggregatedFinalityVotes.Marshal()) {
+			t.Errorf("Mismatch decoded data")
+		}
+		if len(dec.CheckpointValidators) != len(ext.CheckpointValidators) {
+			t.Errorf("Mismatch decoded data")
+		}
+		for i := 0; i < len(ext.CheckpointValidators); i++ {
+			if dec.CheckpointValidators[i].Address.Hex() != ext.CheckpointValidators[i].Address.Hex() {
+				t.Errorf("Mismatch decoded data")
+			}
+			if (dec.CheckpointValidators[i].BlsPublicKey == nil && ext.CheckpointValidators[i].BlsPublicKey != nil) ||
+				(dec.CheckpointValidators[i].BlsPublicKey != nil && ext.CheckpointValidators[i].BlsPublicKey == nil) {
+				t.Errorf("Mismatch decoded data")
+			}
+			if dec.CheckpointValidators[i].BlsPublicKey != nil &&
+				ext.CheckpointValidators[i].BlsPublicKey != nil &&
+				!bytes.Equal(dec.CheckpointValidators[i].BlsPublicKey.Marshal(), ext.CheckpointValidators[i].BlsPublicKey.Marshal()) {
+				t.Errorf("Mismatch decoded data")
+			}
+		}
+		if !bytes.Equal(dec.Seal[:], ext.Seal[:]) {
+			t.Errorf("Mismatch decoded data")
+		}
 	}
 }
 

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"math/big"
+	"strconv"
 	"testing"
 	"time"
 
@@ -639,6 +640,54 @@ func TestExtraDataDecodeRLP(t *testing.T) {
 		if !bytes.Equal(dec.Seal[:], ext.Seal[:]) {
 			t.Errorf("Mismatch decoded data")
 		}
+	}
+}
+
+func TestEncodedSize(t *testing.T) {
+	nVal := 22
+	for i := 0; i < 7; i++ {
+		ext := mockExtraData(nVal, uint32(i))
+		old := ext.Encode(true)
+		new, _ := ext.EncodeRLP()
+		t.Logf("binary: %v, original: %v; new: %v", strconv.FormatInt(int64(i), 2), len(old), len(new))
+	}
+}
+
+func BenchmarkEncodeRLP(b *testing.B) {
+	nVal := 22
+	ext := mockExtraData(nVal, 7)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ext.EncodeRLP()
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	nVal := 22
+	ext := mockExtraData(nVal, 7)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ext.Encode(true)
+	}
+}
+
+func BenchmarkDecodeRLP(b *testing.B) {
+	nVal := 22
+	ext := mockExtraData(nVal, 7)
+	dec, _ := ext.EncodeRLP()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		finality.DecodeExtraRLP(dec)
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	nVal := 22
+	ext := mockExtraData(nVal, 7)
+	dec := ext.Encode(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		finality.DecodeExtra(dec, true)
 	}
 }
 

--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -72,8 +72,10 @@ var (
 	// ErrInvalidExtraData is returned if the bls public key is nil
 	ErrInvalidExtraData = errors.New("invalid header extra data")
 
-	// ErrInvalidArgument  is returned if the chain config is nil
+	// ErrInvalidArgument is returned if the chain config is nil
 	ErrInvalidArgument = errors.New("invalid argument")
+
+	ErrInvalidEncodedExtraData = errors.New("invalid encoded extra data")
 )
 
 type ValidatorWithBlsPub struct {
@@ -166,26 +168,6 @@ type HeaderExtraData struct {
 	Seal                    [ExtraSeal]byte       // the sealing block signature
 }
 
-func (extraData *HeaderExtraData) EncodeV2(chainConfig *params.ChainConfig, number *big.Int) ([]byte, error) {
-	if chainConfig == nil || number == nil {
-		return nil, ErrInvalidArgument
-	}
-	if chainConfig.IsTripp(number) {
-		return extraData.EncodeRLP()
-	}
-	return extraData.Encode(chainConfig.IsShillin(number)), nil
-}
-
-func DecodeExtraV2(enc []byte, chainConfig *params.ChainConfig, number *big.Int) (*HeaderExtraData, error) {
-	if chainConfig == nil || number == nil {
-		return nil, ErrInvalidArgument
-	}
-	if chainConfig.IsTripp(number) {
-		return DecodeExtraRLP(enc)
-	}
-	return DecodeExtra(enc, chainConfig.IsShillin(number))
-}
-
 func (extraData *HeaderExtraData) Encode(isShillin bool) []byte {
 	var rawBytes []byte
 
@@ -206,87 +188,6 @@ func (extraData *HeaderExtraData) Encode(isShillin bool) []byte {
 	rawBytes = append(rawBytes, extraData.Seal[:]...)
 
 	return rawBytes
-}
-
-type extraDataRLP struct {
-	Vanity                  [ExtraVanity]byte
-	HasFinalityVote         uint8
-	FinalityVotedValidators FinalityVoteBitSet
-	AggregatedFinalityVotes []byte
-	CheckpointValidators    []validatorWithBlsPubRLP
-	Seal                    [ExtraSeal]byte
-}
-
-type validatorWithBlsPubRLP struct {
-	Address      common.Address
-	BlsPublicKey []byte
-}
-
-func (extraData *HeaderExtraData) EncodeRLP() ([]byte, error) {
-	ext := &extraDataRLP{
-		Vanity:          extraData.Vanity,
-		HasFinalityVote: extraData.HasFinalityVote,
-		Seal:            extraData.Seal,
-	}
-	cp := make([]validatorWithBlsPubRLP, 0)
-	for _, val := range extraData.CheckpointValidators {
-		v := validatorWithBlsPubRLP{
-			Address: val.Address,
-		}
-		if val.BlsPublicKey == nil {
-			return nil, ErrInvalidExtraData
-		}
-		v.BlsPublicKey = val.BlsPublicKey.Marshal()
-		cp = append(cp, v)
-	}
-	ext.CheckpointValidators = cp
-	if extraData.HasFinalityVote != 0 && extraData.HasFinalityVote != 1 {
-		return nil, ErrInvalidHasFinalityVote
-	}
-	if extraData.HasFinalityVote == 1 {
-		ext.FinalityVotedValidators = extraData.FinalityVotedValidators
-		if extraData.AggregatedFinalityVotes == nil {
-			return nil, ErrInvalidExtraData
-		}
-		ext.AggregatedFinalityVotes = extraData.AggregatedFinalityVotes.Marshal()
-	}
-	return rlp.EncodeToBytes(ext)
-}
-
-func DecodeExtraRLP(enc []byte) (*HeaderExtraData, error) {
-	var err error
-	dec := &extraDataRLP{}
-	if err := rlp.DecodeBytes(enc, dec); err != nil {
-		return nil, err
-	}
-	ret := &HeaderExtraData{
-		Vanity:          dec.Vanity,
-		HasFinalityVote: dec.HasFinalityVote,
-		Seal:            dec.Seal,
-	}
-	cp := make([]ValidatorWithBlsPub, 0)
-	for _, val := range dec.CheckpointValidators {
-		v := ValidatorWithBlsPub{
-			Address: val.Address,
-		}
-		v.BlsPublicKey, err = blst.PublicKeyFromBytes(val.BlsPublicKey)
-		if err != nil {
-			return nil, err
-		}
-		cp = append(cp, v)
-	}
-	ret.CheckpointValidators = cp
-	if dec.HasFinalityVote != 1 && dec.HasFinalityVote != 0 {
-		return nil, ErrInvalidHasFinalityVote
-	}
-	if dec.HasFinalityVote == 1 {
-		ret.FinalityVotedValidators = dec.FinalityVotedValidators
-		ret.AggregatedFinalityVotes, err = blst.SignatureFromBytes(dec.AggregatedFinalityVotes)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return ret, nil
 }
 
 func DecodeExtra(rawBytes []byte, isShillin bool) (*HeaderExtraData, error) {
@@ -355,6 +256,119 @@ func DecodeExtra(rawBytes []byte, isShillin bool) (*HeaderExtraData, error) {
 	copy(extraData.Seal[:], rawBytes[currentPosition:])
 
 	return &extraData, nil
+}
+
+// extraDataRLP excludes vanity, hasFinalityVotes because vanity is not used in
+// Consortium and filled with zero by default; whereas hasFinalityVotes can be determined
+// by AggregatedFinalityVotes and FinalityVotedValidators. On the other hand, seal is 
+// appended manually, enabling encodeSigHeader easily to exclude Seal before signing process
+type extraDataRLP struct {
+	FinalityVotedValidators FinalityVoteBitSet
+	AggregatedFinalityVotes []byte
+	CheckpointValidators    []validatorWithBlsPubRLP
+}
+
+type validatorWithBlsPubRLP struct {
+	Address      common.Address
+	BlsPublicKey []byte
+}
+
+// EncodeRLP computes rlp-based encoding for HeaderExtraData before
+// appending Seal manually, enabling encodeSigHeader easily to exclude
+// Seal before signing process.
+func (extraData *HeaderExtraData) EncodeRLP() ([]byte, error) {
+	var ext = &extraDataRLP{}
+	if extraData.HasFinalityVote != 0 && extraData.HasFinalityVote != 1 {
+		return nil, ErrInvalidHasFinalityVote
+	}
+	if extraData.HasFinalityVote == 1 {
+		if extraData.AggregatedFinalityVotes == nil || len(extraData.FinalityVotedValidators.Indices()) == 0 {
+			return nil, ErrInvalidExtraData
+		}
+		ext.FinalityVotedValidators = extraData.FinalityVotedValidators
+		ext.AggregatedFinalityVotes = extraData.AggregatedFinalityVotes.Marshal()
+	}
+
+	cp := make([]validatorWithBlsPubRLP, len(extraData.CheckpointValidators))
+	for i, val := range extraData.CheckpointValidators {
+		if val.BlsPublicKey == nil {
+			return nil, ErrInvalidExtraData
+		}
+		cp[i] = validatorWithBlsPubRLP{
+			Address:      val.Address,
+			BlsPublicKey: val.BlsPublicKey.Marshal(),
+		}
+	}
+	ext.CheckpointValidators = cp
+
+	enc, err := rlp.EncodeToBytes(ext)
+	if err != nil {
+		return nil, err
+	}
+	// Seal is appended at the end of the raw bytes data
+	rawBytes := append(enc, extraData.Seal[:]...)
+	return rawBytes, nil
+}
+
+// DecodeExtraRLP decodes HeaderExtraData from bytes. It is necessary to exclude
+// the last ExtraSeal bytes before rlp-decoding, as Seal is not rlp encoded.
+func DecodeExtraRLP(enc []byte) (*HeaderExtraData, error) {
+	var (
+		err error
+		dec = &extraDataRLP{}
+		ret = &HeaderExtraData{}
+	)
+	if len(enc) < ExtraSeal {
+		return nil, ErrInvalidEncodedExtraData
+	}
+	// Exclude the seal before rlp decoding.
+	if err := rlp.DecodeBytes(enc[:len(enc)-ExtraSeal], dec); err != nil {
+		return nil, err
+	}
+	cp := make([]ValidatorWithBlsPub, len(dec.CheckpointValidators))
+	for i, val := range dec.CheckpointValidators {
+		blsPublicKey, err := blst.PublicKeyFromBytes(val.BlsPublicKey)
+		if err != nil {
+			return nil, err
+		}
+		cp[i] = ValidatorWithBlsPub{
+			Address:      val.Address,
+			BlsPublicKey: blsPublicKey,
+		}
+	}
+	ret.CheckpointValidators = cp
+	if len(dec.AggregatedFinalityVotes) != 0 && len(dec.FinalityVotedValidators.Indices()) != 0 {
+		ret.HasFinalityVote = 1
+		ret.FinalityVotedValidators = dec.FinalityVotedValidators
+		ret.AggregatedFinalityVotes, err = blst.SignatureFromBytes(dec.AggregatedFinalityVotes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	copy(ret.Seal[:], enc[len(enc)-ExtraSeal:])
+	return ret, nil
+}
+
+// After Tripp, HeaderExtraData switches to use RLP encoding method
+func (extraData *HeaderExtraData) EncodeV2(chainConfig *params.ChainConfig, number *big.Int) ([]byte, error) {
+	if chainConfig == nil || number == nil {
+		return nil, ErrInvalidArgument
+	}
+	if chainConfig.IsTripp(number) {
+		return extraData.EncodeRLP()
+	}
+	return extraData.Encode(chainConfig.IsShillin(number)), nil
+}
+
+// After Tripp, HeaderExtraData switches to use RLP decoding method
+func DecodeExtraV2(enc []byte, chainConfig *params.ChainConfig, number *big.Int) (*HeaderExtraData, error) {
+	if chainConfig == nil || number == nil {
+		return nil, ErrInvalidArgument
+	}
+	if chainConfig.IsTripp(number) {
+		return DecodeExtraRLP(enc)
+	}
+	return DecodeExtra(enc, chainConfig.IsShillin(number))
 }
 
 // ParseCheckpointData retrieves the list of validator addresses and finality voter's public keys

--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -205,7 +205,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 		snap.Recents[number] = validator
 
 		if chain.Config().IsShillin(header.Number) {
-			extraData, err := finality.DecodeExtra(header.Extra, true)
+			extraData, err := finality.DecodeExtraV2(header.Extra, chain.Config(), header.Number)
 			if err != nil {
 				return nil, err
 			}
@@ -240,7 +240,7 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 			} else {
 				isShillin := chain.Config().IsShillin(checkpointHeader.Number)
 				// Get validator set from headers and use that for new validator set
-				extraData, err := finality.DecodeExtra(checkpointHeader.Extra, isShillin)
+				extraData, err := finality.DecodeExtraV2(checkpointHeader.Extra, chain.Config(), checkpointHeader.Number)
 				if err != nil {
 					return nil, err
 				}

--- a/crypto/bls/blst/public_key.go
+++ b/crypto/bls/blst/public_key.go
@@ -4,6 +4,7 @@ package blst
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/params"
 	lru "github.com/hashicorp/golang-lru"

--- a/crypto/bls/blst/public_key.go
+++ b/crypto/bls/blst/public_key.go
@@ -4,7 +4,6 @@ package blst
 
 import (
 	"fmt"
-
 	"github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/params"
 	lru "github.com/hashicorp/golang-lru"

--- a/monitor/finality_vote.go
+++ b/monitor/finality_vote.go
@@ -64,7 +64,7 @@ func prettyPrintAddress(addresses []common.Address) string {
 }
 
 func (monitor *FinalityVoteMonitor) CheckFinalityVote(block *types.Block) error {
-	extraData, err := finality.DecodeExtra(block.Extra(), true)
+	extraData, err := finality.DecodeExtraV2(block.Extra(), monitor.chain.Config(), block.Number())
 	// This should not happen because the block has been verified
 	if err != nil {
 		log.Error("Unexpected error when decode extradata", "err", err)


### PR DESCRIPTION
Currently, HeaderExtraData is encoded/decoded manually, which is error prone and hard to extend. Hence, this PR implements a new RLP encoder/decoder for HeaderExtraData and changes to use this new method. 