### PR TITLE
consortium-v2, precompiled: add contract for sorting validator with random beacon

### DIFF
--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -1094,7 +1094,7 @@ func pickNonRotatingValidator(
 
 func (contract *pickValidatorSetBeacon) requestSortValidator(method *abi.Method, args []interface{}) ([]byte, error) {
 	if len(args) != 8 {
-		return nil, fmt.Errorf("invalid arguments, expected 4 got %d", len(args))
+		return nil, fmt.Errorf("invalid arguments, expected 8 got %d", len(args))
 	}
 	beacon, ok := args[0].(*big.Int)
 	if !ok {

--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -32,6 +32,7 @@ const (
 	GetDoubleSignSlashingConfig
 	ValidateFinalityVoteProof
 	ValidateProofOfPossession
+	PickValidatorSetBeacon
 	NumOfAbis
 )
 
@@ -43,6 +44,7 @@ var (
 	rawGetDoubleSignSlashingConfigsAbi = `[{"inputs":[],"name":"getDoubleSignSlashingConfigs","outputs":[{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]`
 	rawValidateFinalityVoteProofAbi    = `[{"inputs":[{"internalType":"bytes","name":"voterPublicKey","type":"bytes"},{"internalType":"uint256","name":"targetBlockNumber","type":"uint256"},{"internalType":"bytes32[2]","name":"targetBlockHash","type":"bytes32[2]"},{"internalType":"bytes[][2]","name":"listOfPublicKey","type":"bytes[][2]"},{"internalType":"bytes[2]","name":"aggregatedSignature","type":"bytes[2]"}],"name":"validateFinalityVoteProof","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}]`
 	rawValidateProofOfPossessionAbi    = `[{"inputs":[{"internalType":"bytes","name":"publicKey","type":"bytes"},{"internalType":"bytes","name":"signature","type":"bytes"}],"name":"validateProofOfPossession","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}]`
+	rawPickValidatorSetBeaconAbi       = `[{"inputs":[{"internalType":"uint256","name":"period","type":"uint256"},{"internalType":"uint256","name":"epoch","type":"uint256"}],"name":"pickValidatorSet","outputs":[{"internalType":"address[]","name":"pickedValidatorIds","type":"address[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"beacon","type":"uint256"},{"internalType":"uint256","name":"period","type":"uint256"},{"internalType":"uint256","name":"numGovernanceValidator","type":"uint256"},{"internalType":"uint256","name":"numStandardValidator","type":"uint256"},{"internalType":"uint256","name":"numRotatingValidator","type":"uint256"},{"internalType":"address[]","name":"ids","type":"address[]"},{"internalType":"uint256[]","name":"stakedAmounts","type":"uint256[]"},{"internalType":"uint256[]","name":"trustedWeights","type":"uint256[]"}],"name":"requestSortValidatorSet","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
 
 	rawABIs = [NumOfAbis]string{
 		LogContract:                 rawConsortiumLogAbi,
@@ -52,9 +54,11 @@ var (
 		GetDoubleSignSlashingConfig: rawGetDoubleSignSlashingConfigsAbi,
 		ValidateFinalityVoteProof:   rawValidateFinalityVoteProofAbi,
 		ValidateProofOfPossession:   rawValidateProofOfPossessionAbi,
+		PickValidatorSetBeacon:      rawPickValidatorSetBeaconAbi,
 	}
 
-	unmarshalledABIs = [NumOfAbis]*abi.ABI{}
+	unmarshalledABIs              = [NumOfAbis]*abi.ABI{}
+	PickValidatorSetBeaconAddress = common.BytesToAddress([]byte{107})
 )
 
 const (
@@ -71,6 +75,16 @@ const (
 	validateFinalityVoteProof = "validateFinalityVoteProof"
 	validateProofOfPossession = "validateProofOfPossession"
 	maxBlsPublicKeyListLength = 100
+
+	requestSortValidatorSet   = "requestSortValidatorSet"
+	maxNumberOfEpochPerPeriod = 144
+
+	// pickValidatorSetBeacon storage slot
+	periodSlot                        = 0
+	numberOfEpochsSlot                = 1
+	numberOfNonRotatingValidatorsSlot = 2
+	numberOfRotatingValidatorsSlot    = 3
+	validatorArrayStartSlot           = 100
 )
 
 func init() {
@@ -97,6 +111,12 @@ func PrecompiledContractsConsortium(caller ContractRef, evm *EVM) map[common.Add
 func PrecompiledContractsConsortiumMiko(caller ContractRef, evm *EVM) map[common.Address]PrecompiledContract {
 	contracts := PrecompiledContractsConsortium(caller, evm)
 	contracts[common.BytesToAddress([]byte{106})] = &consortiumValidateProofOfPossession{caller: caller, evm: evm}
+	return contracts
+}
+
+func PrecompiledContractsConsortiumTripp(caller ContractRef, evm *EVM) map[common.Address]PrecompiledContract {
+	contracts := PrecompiledContractsConsortiumMiko(caller, evm)
+	contracts[common.BytesToAddress([]byte{107})] = &pickValidatorSetBeacon{caller: caller, evm: evm}
 	return contracts
 }
 
@@ -172,7 +192,7 @@ func (c *consortiumPickValidatorSet) Run(input []byte) ([]byte, error) {
 	}
 
 	if len(args) != 5 {
-		return nil, errors.New(fmt.Sprintf("invalid arguments, expected 5 got %d", len(args)))
+		return nil, fmt.Errorf("invalid arguments, expected 5 got %d", len(args))
 	}
 
 	// cast args[0] to list addresses
@@ -303,7 +323,7 @@ func (c *consortiumValidatorSorting) Run(input []byte) ([]byte, error) {
 		return nil, errors.New("invalid method")
 	}
 	if len(args) != 2 {
-		return nil, errors.New(fmt.Sprintf("invalid arguments, expected 2 got %d", len(args)))
+		return nil, fmt.Errorf("invalid arguments, expected 2 got %d", len(args))
 	}
 	// cast args[0] to list addresses
 	validators, ok := args[0].([]common.Address)
@@ -327,64 +347,25 @@ func (c *consortiumValidatorSorting) Run(input []byte) ([]byte, error) {
 	return method.Outputs.Pack(validators)
 }
 
-type SortableValidators struct {
-	validators []common.Address
-	weights    []*big.Int
-}
-
-func (s *SortableValidators) Len() int {
-	return len(s.validators)
-}
-
-func (s *SortableValidators) Less(i, j int) bool {
-	cmp := s.weights[i].Cmp(s.weights[j])
-
-	if cmp == 0 {
-		return new(big.Int).SetBytes(s.validators[i].Bytes()).Cmp(new(big.Int).SetBytes(s.validators[j].Bytes())) > 0
-	}
-
-	return cmp > 0
-}
-
-func (s *SortableValidators) Swap(i, j int) {
-	s.validators[i], s.validators[j] = s.validators[j], s.validators[i]
-	s.weights[i], s.weights[j] = s.weights[j], s.weights[i]
-}
-
 func sortValidators(validators []common.Address, weights []*big.Int) {
 	if len(validators) < 2 {
 		return
 	}
 	// start sorting validators
-	vals := &SortableValidators{validators: validators, weights: weights}
-	sort.Sort(vals)
-	return
-}
-
-type SmartContractCaller struct {
-	evm    *EVM
-	smcAbi abi.ABI
-	sender common.Address
-}
-
-func (c *SmartContractCaller) validators() ([]common.Address, error) {
-	res, err := c.staticCall(getValidatorsMethod, c.evm.ChainConfig().ConsortiumV2Contracts.RoninValidatorSet)
-	if err != nil {
-		return nil, err
+	var validatorWithWeights []validatorWithWeight
+	for i := range validators {
+		validatorWithWeights = append(validatorWithWeights, validatorWithWeight{
+			address: validators[i],
+			weight:  weights[i],
+		})
 	}
-	return *abi.ConvertType(res[0], new([]common.Address)).(*[]common.Address), nil
-}
 
-func (c *SmartContractCaller) totalBalances(validators []common.Address) ([]*big.Int, error) {
-	res, err := c.staticCall(totalBalancesMethod, c.evm.ChainConfig().ConsortiumV2Contracts.RoninValidatorSet, validators)
-	if err != nil {
-		return nil, err
+	sort.Sort(sortByWeight(validatorWithWeights))
+
+	for i, validator := range validatorWithWeights {
+		validators[i] = validator.address
+		weights[i] = validator.weight
 	}
-	return *abi.ConvertType(res[0], new([]*big.Int)).(*[]*big.Int), nil
-}
-
-func (c *SmartContractCaller) staticCall(method string, contract common.Address, args ...interface{}) ([]interface{}, error) {
-	return staticCall(c.evm, c.smcAbi, method, contract, c.sender, args...)
 }
 
 func staticCall(evm *EVM, smcAbi abi.ABI, method string, contract, sender common.Address, args ...interface{}) ([]interface{}, error) {
@@ -457,7 +438,7 @@ func (c *consortiumVerifyHeaders) Run(input []byte) ([]byte, error) {
 		return nil, errors.New("invalid method")
 	}
 	if len(args) != 3 {
-		return nil, errors.New(fmt.Sprintf("invalid arguments, expected 2 got %d", len(args)))
+		return nil, fmt.Errorf("invalid arguments, expected 2 got %d", len(args))
 	}
 	consensusAddr, ok := args[0].(common.Address)
 	if !ok {
@@ -772,4 +753,467 @@ func (contract *consortiumValidateProofOfPossession) Run(input []byte) ([]byte, 
 	}
 
 	return method.Outputs.Pack(true)
+}
+
+// This precompiled contract has 2 methods
+// - requestSortValidatorSet: is called at the end of old period, with the information about
+// beacon, staked amount of validator candidates. Sort and pick validator set for each epoch
+// in the next period and store the result into contract's storage
+// - pickValidatorSet: get the validator (block producer) list of an epoch
+//
+// The contract storage layout
+// Storage slot 0: period number
+// Storage slot 1: number of epochs in a period
+// Storage slot 2: number of non-rotating validators
+// Storage slot 3: number of rotating validators
+//
+// Storage slot 100: store N non-rotating validator addresses
+// Storage slot 100 + N: 2D array of rotating validators in each epoch
+// The storage slot of rotating validator ith in epoch jth is
+// 100 + N + j * number of rotating validators in each epoch + i
+type pickValidatorSetBeacon struct {
+	caller ContractRef
+	evm    *EVM
+	// This is true only when running benchmark
+	skipPeriodCheck bool
+}
+
+func (contract *pickValidatorSetBeacon) RequiredGas(input []byte) uint64 {
+	_, method, args, err := loadMethodAndArgs(PickValidatorSetBeacon, input)
+	if err != nil {
+		return math.MaxUint64
+	}
+
+	if method.Name == requestSortValidatorSet {
+		numRotatingValidator, ok := args[4].(*big.Int)
+		if !ok {
+			return math.MaxUint64
+		}
+		return numRotatingValidator.Uint64() * maxNumberOfEpochPerPeriod * params.SstoreClearGas
+	} else {
+		return maxNumberOfEpochPerPeriod * params.SloadGasEIP2200
+	}
+}
+
+func (contract *pickValidatorSetBeacon) Run(input []byte) ([]byte, error) {
+	if err := isSystemContractCaller(contract.caller, contract.evm); err != nil {
+		return nil, err
+	}
+
+	_, method, args, err := loadMethodAndArgs(PickValidatorSetBeacon, input)
+	if err != nil {
+		return nil, err
+	}
+
+	if method.Name == requestSortValidatorSet {
+		return contract.requestSortValidator(method, args)
+	} else {
+		return contract.pickValidator(method, args)
+	}
+}
+
+func (contract *pickValidatorSetBeacon) pickValidator(method *abi.Method, args []interface{}) ([]byte, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("invalid arguments, expected 2 got %d", len(args))
+	}
+	period, ok := args[0].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid period argument type")
+	}
+	epoch, ok := args[1].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid epoch argument type")
+	}
+	validators, err := contract.readValidatorAtEpoch(int(period.Int64()), int(epoch.Int64()))
+	if err != nil {
+		return nil, err
+	}
+	output, err := method.Outputs.Pack(validators)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func (contract *pickValidatorSetBeacon) readMetadataFromStorage() (
+	period int,
+	numOfEpochs int,
+	numOfNonRotatingValidators int,
+	numOfRotatingValidators int,
+) {
+	stateDB := contract.evm.StateDB
+	contractAddress := PickValidatorSetBeaconAddress
+
+	periodValue := stateDB.GetState(contractAddress, common.BigToHash(big.NewInt(periodSlot)))
+	numOfEpochsValue := stateDB.GetState(contractAddress, common.BigToHash(big.NewInt(numberOfEpochsSlot)))
+	numOfNonRotatingValidatorsValue := stateDB.GetState(
+		contractAddress,
+		common.BigToHash(big.NewInt(numberOfNonRotatingValidatorsSlot)),
+	)
+	numOfRotatingValidatorsValue := stateDB.GetState(
+		contractAddress,
+		common.BigToHash(big.NewInt(numberOfRotatingValidatorsSlot)),
+	)
+
+	return int(periodValue.Big().Int64()),
+		int(numOfEpochsValue.Big().Int64()),
+		int(numOfNonRotatingValidatorsValue.Big().Int64()),
+		int(numOfRotatingValidatorsValue.Big().Int64())
+}
+
+func (contract *pickValidatorSetBeacon) readValidatorAtEpoch(period int, epochNumber int) ([]common.Address, error) {
+	stateDB := contract.evm.StateDB
+	contractAddress := PickValidatorSetBeaconAddress
+	storedPeriod, numOfEpochs, numOfNonRotatingValidators, numOfRotatingValidators := contract.readMetadataFromStorage()
+
+	if storedPeriod != period {
+		return nil, fmt.Errorf("queried period mismatches with stored one, queried: %d, stored: %d", period, storedPeriod)
+	}
+
+	// Queried epoch number starts from 1, but the stored index starts from 0.
+	// So we need to subtract 1 from queried epoch to get the correct stored index.
+	epochNumber = epochNumber - 1
+	if epochNumber < 0 || epochNumber > numOfEpochs {
+		return nil, errors.New("invalid epoch number")
+	}
+
+	consensusAddrs := make([]common.Address, 0, numOfNonRotatingValidators+numOfRotatingValidators)
+	// Read non-rotating validators
+	for i := 0; i < numOfNonRotatingValidators; i++ {
+		value := stateDB.GetState(contractAddress, common.BigToHash(big.NewInt(int64(validatorArrayStartSlot+i))))
+		address := common.BytesToAddress(value.Bytes())
+		consensusAddrs = append(consensusAddrs, address)
+	}
+
+	// Read rotating validators
+	startSlot := validatorArrayStartSlot + numOfNonRotatingValidators + epochNumber*numOfRotatingValidators
+	for i := 0; i < numOfRotatingValidators; i++ {
+		value := stateDB.GetState(contractAddress, common.BigToHash(big.NewInt(int64(startSlot+i))))
+		address := common.BytesToAddress(value.Bytes())
+		consensusAddrs = append(consensusAddrs, address)
+	}
+
+	return consensusAddrs, nil
+}
+
+// rotating validators dimension: [numOfEpochs][numOfRotatingValidators]common.Address
+func (contract *pickValidatorSetBeacon) writeToStorage(
+	period int,
+	nonRotatingValidators []common.Address,
+	rotatingValidators [][]common.Address,
+) {
+	stateDB := contract.evm.StateDB
+	contractAddress := PickValidatorSetBeaconAddress
+
+	var (
+		numOfRotatingValidators int
+		numOfEpochs             int = maxNumberOfEpochPerPeriod
+	)
+	if len(rotatingValidators) != 0 {
+		numOfRotatingValidators = len(rotatingValidators[0])
+		numOfEpochs = len(rotatingValidators)
+	}
+
+	stateDB.SetState(
+		contractAddress,
+		common.BigToHash(big.NewInt(periodSlot)),
+		common.BigToHash(big.NewInt(int64(period))),
+	)
+	stateDB.SetState(
+		contractAddress,
+		common.BigToHash(big.NewInt(numberOfEpochsSlot)),
+		common.BigToHash(big.NewInt(int64(numOfEpochs))),
+	)
+	stateDB.SetState(
+		contractAddress,
+		common.BigToHash(big.NewInt(numberOfNonRotatingValidatorsSlot)),
+		common.BigToHash(big.NewInt(int64(len(nonRotatingValidators)))),
+	)
+	stateDB.SetState(
+		contractAddress,
+		common.BigToHash(big.NewInt(numberOfRotatingValidatorsSlot)),
+		common.BigToHash(big.NewInt(int64(numOfRotatingValidators))),
+	)
+
+	// Write non-rotating validators
+	for i, validator := range nonRotatingValidators {
+		stateDB.SetState(
+			contractAddress,
+			common.BigToHash(big.NewInt(int64(validatorArrayStartSlot+i))),
+			common.BytesToHash(validator.Bytes()),
+		)
+	}
+
+	// Write rotating validators
+	startSlot := validatorArrayStartSlot + len(nonRotatingValidators)
+	for epochNumber, validators := range rotatingValidators {
+		for valIndex, validator := range validators {
+			stateDB.SetState(
+				contractAddress,
+				common.BigToHash(big.NewInt(int64(startSlot+epochNumber*numOfRotatingValidators+valIndex))),
+				common.BytesToHash(validator.Bytes()),
+			)
+		}
+	}
+}
+
+func (contract *pickValidatorSetBeacon) cleanupStorage(oldEnd int, newEnd int) {
+	stateDB := contract.evm.StateDB
+	contractAddress := PickValidatorSetBeaconAddress
+
+	for i := newEnd; i < oldEnd; i++ {
+		stateDB.SetState(contractAddress, common.BigToHash(big.NewInt(int64(i))), common.Hash{})
+	}
+}
+
+// calculateValidatorWeight calculates the weight to choose rotating validators
+// uint256 random = hash(beacon || epochNumber || address)
+// random = higher128(random) xor lower128(random)
+// stakeAmount = stakedAmount / 10**18
+// weight =  random * stakedAmount * stakedAmount
+// with || is the concatenation operation
+func calculateValidatorWeight(
+	hasher crypto.KeccakState,
+	beacon *big.Int,
+	epochNumber int,
+	consensusAddr common.Address,
+	stakedAmount *big.Int,
+) *big.Int {
+	var (
+		hashbuf common.Hash
+		output  [32]byte
+	)
+
+	hasher.Reset()
+	beacon.FillBytes(output[:])
+	hasher.Write(output[:])
+
+	big.NewInt(int64(epochNumber)).FillBytes(output[:])
+	hasher.Write(output[:])
+
+	new(big.Int).SetBytes(consensusAddr.Bytes()).FillBytes(output[:])
+	hasher.Write(output[:])
+
+	hasher.Read(hashbuf[:])
+
+	ether := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	amount := new(big.Int).Div(stakedAmount, ether)
+	amount = new(big.Int).Mul(amount, amount)
+
+	hashResult := make([]byte, len(hashbuf)/2)
+	for i := range hashResult {
+		hashResult[i] = hashbuf[i] ^ hashbuf[i+16]
+	}
+
+	randomHash := new(big.Int).SetBytes(hashResult)
+	return new(big.Int).Mul(randomHash, amount)
+}
+
+type validatorWithWeight struct {
+	address common.Address
+	weight  *big.Int
+}
+
+// Sort validator based on weight in descending order
+type sortByWeight []validatorWithWeight
+
+func (validators sortByWeight) Len() int { return len(validators) }
+func (validators sortByWeight) Swap(i, j int) {
+	validators[i], validators[j] = validators[j], validators[i]
+}
+func (validators sortByWeight) Less(i, j int) bool {
+	cmp := validators[i].weight.Cmp(validators[j].weight)
+	if cmp != 0 {
+		return cmp > 0
+	} else {
+		return bytes.Compare(validators[i].address[:], validators[j].address[:]) > 0
+	}
+}
+
+// pickNonRotatingValidator assumes that len(consensusAddress) > numGovernanceValidator + numStandardValidator.
+// It always picks numGovernanceValidator + numStandardValidator validators. In case, the available governance
+// validators are fewer than the maximum number, the remaining number is transfered to standard maximum number
+// (if we cannot pick enough governance validator, we will pick more standard validator).
+func pickNonRotatingValidator(
+	numGovernanceValidator int,
+	numStandardValidator int,
+	consensusAddress []common.Address,
+	stakedAmounts []*big.Int,
+	isGovernanceValidator []*big.Int,
+) []common.Address {
+	var governanceValidator []validatorWithWeight
+	for i := range isGovernanceValidator {
+		if isGovernanceValidator[i].Cmp(common.Big1) == 0 {
+			governanceValidator = append(governanceValidator, validatorWithWeight{
+				address: consensusAddress[i],
+				weight:  stakedAmounts[i],
+			})
+		}
+	}
+
+	if len(governanceValidator) > numGovernanceValidator {
+		sort.Sort(sortByWeight(governanceValidator))
+		governanceValidator = governanceValidator[:numGovernanceValidator]
+	} else {
+		// The number of governance validators is fewer than the maximum governance
+		// validator, the remainning number is transfered to standard validator case
+		numStandardValidator += numGovernanceValidator - len(governanceValidator)
+	}
+
+	chosen := make(map[common.Address]struct{})
+	for _, validator := range governanceValidator {
+		chosen[validator.address] = struct{}{}
+	}
+
+	var standardValidator []validatorWithWeight
+	for i := range consensusAddress {
+		if _, ok := chosen[consensusAddress[i]]; !ok {
+			standardValidator = append(standardValidator, validatorWithWeight{
+				address: consensusAddress[i],
+				weight:  stakedAmounts[i],
+			})
+		}
+	}
+
+	if len(standardValidator) > numStandardValidator {
+		sort.Sort(sortByWeight(standardValidator))
+		standardValidator = standardValidator[:numStandardValidator]
+	}
+
+	nonRotatingValidator := make([]common.Address, 0, len(governanceValidator)+len(standardValidator))
+	for _, validator := range governanceValidator {
+		nonRotatingValidator = append(nonRotatingValidator, validator.address)
+	}
+	for _, validator := range standardValidator {
+		nonRotatingValidator = append(nonRotatingValidator, validator.address)
+	}
+
+	return nonRotatingValidator
+}
+
+func (contract *pickValidatorSetBeacon) requestSortValidator(method *abi.Method, args []interface{}) ([]byte, error) {
+	if len(args) != 8 {
+		return nil, fmt.Errorf("invalid arguments, expected 4 got %d", len(args))
+	}
+	beacon, ok := args[0].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid beacon argument type")
+	}
+	period, ok := args[1].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid period argument type")
+	}
+	numGovernanceValidator, ok := args[2].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid number of governance validators argument type")
+	}
+	numStandardValidator, ok := args[3].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid number of standard validators argument type")
+	}
+	numRotatingValidator, ok := args[4].(*big.Int)
+	if !ok {
+		return nil, errors.New("invalid number of rotating validators argument type")
+	}
+	consensusAddrs, ok := args[5].([]common.Address)
+	if !ok {
+		return nil, errors.New("invalid consensus address argument type")
+	}
+	stakedAmounts, ok := args[6].([]*big.Int)
+	if !ok {
+		return nil, errors.New("invalid staked amount argument type")
+	}
+	isGovernanceValidator, ok := args[7].([]*big.Int)
+	if !ok {
+		return nil, errors.New("invalid is govnernance validator argument type")
+	}
+	if len(consensusAddrs) != len(stakedAmounts) {
+		return nil, errors.New("consensus addresses and staked amounts length mismatched")
+	}
+	if len(isGovernanceValidator) != len(stakedAmounts) {
+		return nil, errors.New("is governance validator and staked amounts length mismatched")
+	}
+
+	oldPeriod, numOfEpochs, numOfPreviousNonRotatingValidators, numOfPreviousRotatingValidators := contract.readMetadataFromStorage()
+	if !contract.skipPeriodCheck && oldPeriod >= int(period.Int64()) {
+		return nil, errors.New("new period is fewer or equals to stored period")
+	}
+
+	// The number of validator candidates is too few, just pick all candidates. In this case, number of non-rotating
+	// validators is higher than the sum of number of governance validators and number of standard validators
+	if len(consensusAddrs) <=
+		int(numGovernanceValidator.Int64())+int(numStandardValidator.Int64())+int(numRotatingValidator.Int64()) {
+
+		contract.writeToStorage(int(period.Int64()), consensusAddrs, nil)
+
+		oldEnd := validatorArrayStartSlot + numOfPreviousNonRotatingValidators + numOfEpochs*numOfPreviousRotatingValidators
+		newEnd := validatorArrayStartSlot + len(consensusAddrs)
+		contract.cleanupStorage(oldEnd, newEnd)
+		return nil, nil
+	}
+
+	// Pick governance and standard validators, this set does not change across
+	// different epoch
+	nonRotatingValidators := pickNonRotatingValidator(
+		int(numGovernanceValidator.Int64()),
+		int(numStandardValidator.Int64()),
+		consensusAddrs,
+		stakedAmounts,
+		isGovernanceValidator,
+	)
+
+	chosen := make(map[common.Address]struct{})
+	for _, validator := range nonRotatingValidators {
+		chosen[validator] = struct{}{}
+	}
+
+	var rotatingValidatorCandidates []validatorWithWeight
+	for i := range consensusAddrs {
+		if _, ok := chosen[consensusAddrs[i]]; !ok {
+			rotatingValidatorCandidates = append(rotatingValidatorCandidates, validatorWithWeight{
+				address: consensusAddrs[i],
+				weight:  stakedAmounts[i],
+			})
+		}
+	}
+
+	rotatingValidators := make([][]common.Address, maxNumberOfEpochPerPeriod)
+	for epochNumber := range rotatingValidators {
+		rotatingValidators[epochNumber] = make([]common.Address, numRotatingValidator.Int64())
+	}
+
+	rotatingValidatorCandidatesWithWeight := make([]validatorWithWeight, len(rotatingValidatorCandidates))
+	hasher := sha3.NewLegacyKeccak256().(crypto.KeccakState)
+	// The epoch number starts from 1 ranges from [1, maxNumberOfEpochPerPeriod]
+	for epochNumber := 1; epochNumber <= maxNumberOfEpochPerPeriod; epochNumber++ {
+		for i, validator := range rotatingValidatorCandidates {
+			weight := calculateValidatorWeight(
+				hasher,
+				beacon,
+				epochNumber,
+				validator.address,
+				validator.weight,
+			)
+
+			rotatingValidatorCandidatesWithWeight[i] = validatorWithWeight{
+				address: validator.address,
+				weight:  weight,
+			}
+		}
+
+		sort.Sort(sortByWeight(rotatingValidatorCandidatesWithWeight))
+		// Pick numRotatingValidator with the highest weight
+		for i := 0; i < int(numRotatingValidator.Int64()); i++ {
+			rotatingValidators[epochNumber-1][i] = rotatingValidatorCandidatesWithWeight[i].address
+		}
+	}
+	contract.writeToStorage(int(period.Int64()), nonRotatingValidators, rotatingValidators)
+
+	// Clean up the storage if old validator list is larger than the new one
+	oldEnd := validatorArrayStartSlot + numOfPreviousNonRotatingValidators + numOfEpochs*numOfPreviousRotatingValidators
+	newEnd := validatorArrayStartSlot + len(nonRotatingValidators) + maxNumberOfEpochPerPeriod*int(numRotatingValidator.Int64())
+	contract.cleanupStorage(oldEnd, newEnd)
+
+	return nil, nil
 }

--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/bls/blst"
 	blsCommon "github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/params"
+	"golang.org/x/crypto/sha3"
 )
 
 /*
@@ -577,10 +578,10 @@ func TestSort(t *testing.T) {
 	sortValidators(addrs, totalBalances)
 	for i, val := range addrs {
 		if expectedBalances[i].Cmp(totalBalances[i]) != 0 {
-			t.Fatal(fmt.Sprintf("mismatched balance at %d, expected:%s got:%s", i, expectedBalances[i].String(), totalBalances[i].String()))
+			t.Fatalf("mismatched balance at %d, expected:%s got:%s", i, expectedBalances[i].String(), totalBalances[i].String())
 		}
 		if expectedAddrs[i].Hex() != val.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedValidators[i].Hex(), val.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedValidators[i].Hex(), val.Hex())
 		}
 	}
 }
@@ -616,12 +617,12 @@ func TestConsortiumValidatorSorting_Run(t *testing.T) {
 	}
 	sortedValidators := *abi.ConvertType(res[0], new([21]common.Address)).(*[21]common.Address)
 	if len(expectedValidators) != len(sortedValidators) {
-		t.Fatal(fmt.Sprintf("expected len %d, got %v", 21, len(sortedValidators)))
+		t.Fatalf("expected len %d, got %v", 21, len(sortedValidators))
 	}
 	for i, addr := range sortedValidators {
 		//println(addr.Hex())
 		if expectedValidators[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedValidators[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedValidators[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -664,11 +665,11 @@ func TestConsortiumValidatorSorting_Run2(t *testing.T) {
 
 	sortedValidators := *abi.ConvertType(res[0], new([21]common.Address)).(*[21]common.Address)
 	if len(expectedValidators) != len(sortedValidators) {
-		t.Fatal(fmt.Sprintf("expected len 21, got %v", len(sortedValidators)))
+		t.Fatalf("expected len 21, got %v", len(sortedValidators))
 	}
 	for i, addr := range sortedValidators {
 		if expectedValidators[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedValidators[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedValidators[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -817,10 +818,10 @@ func TestConsortiumVerifyHeaders_Run(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(result) != 32 {
-		t.Fatal(fmt.Sprintf("expected len 32 got %d", len(result)))
+		t.Fatalf("expected len 32 got %d", len(result))
 	}
 	if result[len(result)-1] != 1 {
-		t.Fatal(fmt.Sprintf("expected 1 (true) got %d", result[len(result)-1]))
+		t.Fatalf("expected 1 (true) got %d", result[len(result)-1])
 	}
 }
 
@@ -999,7 +1000,7 @@ func TestArrangeValidatorCandidates(t *testing.T) {
 	}
 	for i, candidate := range candidates {
 		if !bytes.Equal(expectedCandidates[i].Bytes(), candidate.Bytes()) {
-			t.Fatal(fmt.Sprintf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex()))
+			t.Fatalf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex())
 		}
 	}
 }
@@ -1048,7 +1049,7 @@ func TestArrangeValidatorCandidates_RandomTrustedOrganizations(t *testing.T) {
 
 	for i, candidate := range candidates {
 		if !bytes.Equal(expectedCandidates[i].Bytes(), candidate.Bytes()) {
-			t.Fatal(fmt.Sprintf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex()))
+			t.Fatalf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex())
 		}
 	}
 }
@@ -1096,7 +1097,7 @@ func TestArrangeValidatorCandidates_Max5Prioritized(t *testing.T) {
 
 	for i, candidate := range candidates {
 		if !bytes.Equal(expectedCandidates[i].Bytes(), candidate.Bytes()) {
-			t.Fatal(fmt.Sprintf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex()))
+			t.Fatalf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex())
 		}
 	}
 }
@@ -1138,7 +1139,7 @@ func TestArrangeValidatorCandidates_Miss5Nodes(t *testing.T) {
 	}
 	for i, candidate := range candidates {
 		if !bytes.Equal(expectedCandidates[i].Bytes(), candidate.Bytes()) {
-			t.Fatal(fmt.Sprintf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex()))
+			t.Fatalf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex())
 		}
 	}
 }
@@ -1208,7 +1209,7 @@ func TestArrangeValidatorCandidates_Has15TrustedNodes(t *testing.T) {
 
 	for i, candidate := range candidates[:newValidatorCount] {
 		if !bytes.Equal(expectedCandidates[i].Bytes(), candidate.Bytes()) {
-			t.Fatal(fmt.Sprintf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex()))
+			t.Fatalf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex())
 		}
 	}
 }
@@ -1278,7 +1279,7 @@ func TestArrangeValidatorCandidates_TrustedNodesAtBeginningArray(t *testing.T) {
 	}
 	for i, candidate := range candidates[:newValidatorCount] {
 		if !bytes.Equal(expectedCandidates[i].Bytes(), candidate.Bytes()) {
-			t.Fatal(fmt.Sprintf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex()))
+			t.Fatalf("mismatched candidate address at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), candidate.Hex())
 		}
 	}
 }
@@ -1344,12 +1345,12 @@ func TestConsortiumPickValidatorSet_Run(t *testing.T) {
 	}
 	validators := *abi.ConvertType(res[0], new([21]common.Address)).(*[21]common.Address)
 	if len(expectedCandidates) != len(validators) {
-		t.Fatal(fmt.Sprintf("expected len %d, got %v", len(expectedCandidates), len(validators)))
+		t.Fatalf("expected len %d, got %v", len(expectedCandidates), len(validators))
 	}
 
 	for i, addr := range validators {
 		if expectedCandidates[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -1409,12 +1410,12 @@ func TestConsortiumPickValidatorSet_Run2(t *testing.T) {
 	}
 	validators := *abi.ConvertType(res[0], new([15]common.Address)).(*[15]common.Address)
 	if len(expectedCandidates) != len(validators) {
-		t.Fatal(fmt.Sprintf("expected len %d, got %v", len(expectedCandidates), len(validators)))
+		t.Fatalf("expected len %d, got %v", len(expectedCandidates), len(validators))
 	}
 
 	for i, addr := range validators {
 		if expectedCandidates[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -1506,12 +1507,12 @@ func TestConsortiumPickValidatorSet_Run3(t *testing.T) {
 	validators := *abi.ConvertType(res[0], new([21]common.Address)).(*[21]common.Address)
 	fmt.Println(addressesToByte(validators[:]))
 	if len(expectedCandidates) != len(validators) {
-		t.Fatal(fmt.Sprintf("expected len %d, got %v", len(expectedCandidates), len(validators)))
+		t.Fatalf("expected len %d, got %v", len(expectedCandidates), len(validators))
 	}
 
 	for i, addr := range validators {
 		if expectedCandidates[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -1602,12 +1603,12 @@ func TestConsortiumPickValidatorSet_Run4(t *testing.T) {
 	}
 	validators := *abi.ConvertType(res[0], new([21]common.Address)).(*[21]common.Address)
 	if len(expectedCandidates) != len(validators) {
-		t.Fatal(fmt.Sprintf("expected len %d, got %v", len(expectedCandidates), len(validators)))
+		t.Fatalf("expected len %d, got %v", len(expectedCandidates), len(validators))
 	}
 
 	for i, addr := range validators {
 		if expectedCandidates[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -1678,12 +1679,12 @@ func TestConsortiumPickValidatorSet_Run5(t *testing.T) {
 	}
 
 	if len(expectedCandidates) != len(validators) {
-		t.Fatal(fmt.Sprintf("expected len 21, got %v", len(validators)))
+		t.Fatalf("expected len 21, got %v", len(validators))
 	}
 
 	for i, addr := range validators {
 		if expectedCandidates[i].Hex() != addr.Hex() {
-			t.Fatal(fmt.Sprintf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex()))
+			t.Fatalf("mismatched addr at %d, expected:%s got:%s", i, expectedCandidates[i].Hex(), addr.Hex())
 		}
 	}
 }
@@ -2161,4 +2162,569 @@ func BenchmarkPrecompiledValidateProofOfPossession(b *testing.B) {
 	}
 
 	benchmarkPrecompiled("6a", test, b)
+}
+
+func TestPickNonRotatingValidator(t *testing.T) {
+	// Case 1: There are fewer governance validators than numGovnernanceValidator
+	consensusAddrs := []common.Address{
+		common.Address{0x1},
+		common.Address{0x2},
+		common.Address{0x3},
+		common.Address{0x4},
+		common.Address{0x5},
+	}
+	stakedAmounts := []*big.Int{
+		big.NewInt(10),
+		big.NewInt(50),
+		big.NewInt(30),
+		big.NewInt(40),
+		big.NewInt(20),
+	}
+	isGovernanceValidators := []*big.Int{
+		common.Big1,
+		common.Big0,
+		common.Big0,
+		common.Big0,
+		common.Big0,
+	}
+	nonRotatingValidators := pickNonRotatingValidator(3, 2, consensusAddrs, stakedAmounts, isGovernanceValidators)
+	if len(nonRotatingValidators) != 5 {
+		t.Fatalf("Expect pickNonRotatingValidator returns %d validators, got %d", 5, len(nonRotatingValidators))
+	}
+
+	// Case 2: Governance validator is prioritised
+	consensusAddrs = []common.Address{
+		common.Address{0x1},
+		common.Address{0x2},
+		common.Address{0x3},
+		common.Address{0x4},
+		common.Address{0x5},
+		common.Address{0x6},
+	}
+	stakedAmounts = []*big.Int{
+		big.NewInt(10),
+		big.NewInt(50),
+		big.NewInt(30),
+		big.NewInt(40),
+		big.NewInt(20),
+		big.NewInt(60),
+	}
+	isGovernanceValidators = []*big.Int{
+		common.Big1,
+		common.Big0,
+		common.Big1,
+		common.Big0,
+		common.Big1,
+		common.Big0,
+	}
+	nonRotatingValidators = pickNonRotatingValidator(3, 2, consensusAddrs, stakedAmounts, isGovernanceValidators)
+	if len(nonRotatingValidators) != 5 {
+		t.Fatalf("Expect pickNonRotatingValidator returns %d validators, got %d", 5, len(nonRotatingValidators))
+	}
+	expectedConsensusAddrs := []common.Address{
+		common.Address{0x1},
+		common.Address{0x3},
+		common.Address{0x5},
+		common.Address{0x6},
+		common.Address{0x2},
+	}
+	for i := range expectedConsensusAddrs {
+		if expectedConsensusAddrs[i] != nonRotatingValidators[i] {
+			t.Fatalf("Expect to get validator: %s, got: %s", expectedConsensusAddrs[i], nonRotatingValidators[i])
+		}
+	}
+
+	// Case 3: More governance validator than max governance validator. The governance validator that is
+	// not picked in governance category can still be picked as a standard validator
+	consensusAddrs = []common.Address{
+		common.Address{0x1},
+		common.Address{0x2},
+		common.Address{0x3},
+		common.Address{0x4},
+		common.Address{0x5},
+		common.Address{0x6},
+	}
+	stakedAmounts = []*big.Int{
+		big.NewInt(10),
+		big.NewInt(50),
+		big.NewInt(30),
+		big.NewInt(40),
+		big.NewInt(20),
+		big.NewInt(60),
+	}
+	isGovernanceValidators = []*big.Int{
+		common.Big0,
+		common.Big1,
+		common.Big1,
+		common.Big1,
+		common.Big1,
+		common.Big0,
+	}
+	nonRotatingValidators = pickNonRotatingValidator(3, 2, consensusAddrs, stakedAmounts, isGovernanceValidators)
+	if len(nonRotatingValidators) != 5 {
+		t.Fatalf("Expect pickNonRotatingValidator returns %d validators, got %d", 5, len(nonRotatingValidators))
+	}
+	expectedConsensusAddrs = []common.Address{
+		common.Address{0x2},
+		common.Address{0x4},
+		common.Address{0x3},
+		common.Address{0x6},
+		common.Address{0x5},
+	}
+	for i := range expectedConsensusAddrs {
+		if expectedConsensusAddrs[i] != nonRotatingValidators[i] {
+			t.Fatalf("Expect to get validator: %s, got: %s", expectedConsensusAddrs[i], nonRotatingValidators[i])
+		}
+	}
+}
+
+func TestCalculateValidatorWeight(t *testing.T) {
+	hasher := sha3.NewLegacyKeccak256().(crypto.KeccakState)
+
+	rawBeacon := crypto.Keccak256([]byte("aaa"))
+	beacon := new(big.Int).SetBytes(rawBeacon)
+
+	ether := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	weight := calculateValidatorWeight(hasher, beacon, 12, common.BigToAddress(big.NewInt(0x11)), new(big.Int).Mul(big.NewInt(1000), ether))
+	expectedWeight := new(big.Int).SetBytes(common.Hex2Bytes("0e0b8087a009a9f3132f068fcb99f941d3d5c0"))
+	if weight.Cmp(expectedWeight) != 0 {
+		t.Fatalf("Expect %x, got %x", expectedWeight, weight)
+	}
+}
+
+func TestPickValidatorSetBeacon(t *testing.T) {
+	ether := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	contract := pickValidatorSetBeacon{
+		evm: &EVM{
+			StateDB: statedb,
+		},
+	}
+	contractAbi := *unmarshalledABIs[PickValidatorSetBeacon]
+
+	// Case 1: Consensus addresses and staked amounts length mismatch
+	beacon := common.Big0
+	period := common.Big1
+	numGovernanceValidator := big.NewInt(3)
+	numStandardValidator := big.NewInt(2)
+	numRotatingValidator := big.NewInt(1)
+	consensusAddrs := []common.Address{
+		common.Address{0x1},
+		common.Address{0x2},
+		common.Address{0x3},
+	}
+	stakedAmount := []*big.Int{
+		new(big.Int).Mul(big.NewInt(10), ether),
+		new(big.Int).Mul(big.NewInt(20), ether),
+	}
+	isGovernanceValidators := []*big.Int{
+		common.Big1,
+		common.Big0,
+		common.Big0,
+	}
+	input, err := contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+	_, err = contract.Run(input)
+	expectedErr := "consensus addresses and staked amounts length mismatched"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expect to have err %s, got %s", expectedErr, err)
+	}
+
+	// Case 2: Is govnernance validators and staked amounts length mismatch
+	stakedAmount = []*big.Int{
+		new(big.Int).Mul(big.NewInt(10), ether),
+		new(big.Int).Mul(big.NewInt(20), ether),
+		new(big.Int).Mul(big.NewInt(30), ether),
+	}
+	isGovernanceValidators = []*big.Int{
+		common.Big1,
+		common.Big0,
+	}
+	input, err = contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+
+	_, err = contract.Run(input)
+	expectedErr = "is governance validator and staked amounts length mismatched"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expect to have err %s, got %s", expectedErr, err)
+	}
+
+	// Case 3: The new period is not larger than the old one
+	period = common.Big0
+	isGovernanceValidators = []*big.Int{
+		common.Big1,
+		common.Big0,
+		common.Big0,
+	}
+	input, err = contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+
+	_, err = contract.Run(input)
+	expectedErr = "new period is fewer or equals to stored period"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expect to have err %s, got %s", expectedErr, err)
+	}
+
+	// Case 4: Number of candidates is fewer than sum of max governance validator,
+	// max standard validator, max rotating validator
+	period = common.Big1
+	input, err = contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+	_, err = contract.Run(input)
+	if err != nil {
+		t.Fatalf("Precompiled contract throws error %s", err)
+	}
+	storedPeriod, storedNumOfEpochs, storedNumOfNonRotatingValidators, storedNumOfRotatingValidators := contract.readMetadataFromStorage()
+	if storedPeriod != int(period.Int64()) {
+		t.Fatalf("Expect stored period: %d, got %d", storedPeriod, int(period.Int64()))
+	}
+	if storedNumOfEpochs != maxNumberOfEpochPerPeriod {
+		t.Fatalf("Expect stored number of epochs: %d, got %d", maxNumberOfEpochPerPeriod, storedNumOfEpochs)
+	}
+	if storedNumOfNonRotatingValidators != len(consensusAddrs) {
+		t.Fatalf("Expect stored number of non-rotating validators: %d, got %d", len(consensusAddrs), storedNumOfNonRotatingValidators)
+	}
+	if storedNumOfRotatingValidators != 0 {
+		t.Fatalf("Expect stored number of rotating validators: %d, got %d", 0, storedNumOfRotatingValidators)
+	}
+
+	// Pick validator with wrong epoch number
+	input, _ = contractAbi.Pack(pickValidatorSetMethod, period, common.Big0)
+	_, err = contract.Run(input)
+	expectedErr = "invalid epoch number"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expect to have err %s, got %s", expectedErr, err)
+	}
+
+	input, _ = contractAbi.Pack(pickValidatorSetMethod, period, big.NewInt(150))
+	_, err = contract.Run(input)
+	expectedErr = "invalid epoch number"
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expect to have err %s, got %s", expectedErr, err)
+	}
+
+	// Pick validator with wrong period number
+	queriedPeriod := new(big.Int).Sub(period, common.Big1)
+	input, _ = contractAbi.Pack(pickValidatorSetMethod, queriedPeriod, common.Big1)
+	_, err = contract.Run(input)
+	expectedErr = fmt.Sprintf("queried period mismatches with stored one, queried: %d, stored: %d", queriedPeriod, period)
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("Expect to have err %s, got %s", expectedErr, err)
+	}
+
+	for i := 1; i <= maxNumberOfEpochPerPeriod; i++ {
+		input, _ := contractAbi.Pack(pickValidatorSetMethod, period, big.NewInt(int64(i)))
+		output, err := contract.Run(input)
+		if err != nil {
+			t.Fatalf("Failed to pick validator set, err: %s", err)
+		}
+
+		ret, err := contractAbi.Unpack(pickValidatorSetMethod, output)
+		if err != nil {
+			t.Fatalf("Failed to unpack output, err: %s", err)
+		}
+
+		pickedValidator, _ := (ret[0]).([]common.Address)
+		for i := range pickedValidator {
+			if pickedValidator[i] != consensusAddrs[i] {
+				t.Fatalf("Expect picked validator %s, got %s", consensusAddrs[i], pickedValidator[i])
+			}
+		}
+	}
+
+	// Case 5: New period with fewer validators, storage must be clean up
+	// Ensure this slot is not nil before new period
+	value := statedb.GetState(PickValidatorSetBeaconAddress, common.BigToHash(big.NewInt(validatorArrayStartSlot+2)))
+	if value == (common.Hash{}) {
+		t.Fatal("Expect storage slot 102 to be not nil, got nil")
+	}
+
+	period = common.Big2
+	consensusAddrs = consensusAddrs[:len(consensusAddrs)-1]
+	stakedAmount = stakedAmount[:len(stakedAmount)-1]
+	isGovernanceValidators = isGovernanceValidators[:len(isGovernanceValidators)-1]
+	input, err = contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+	_, err = contract.Run(input)
+	if err != nil {
+		t.Fatalf("Precompiled contract throws error %s", err)
+	}
+
+	value = statedb.GetState(PickValidatorSetBeaconAddress, common.BigToHash(big.NewInt(validatorArrayStartSlot+2)))
+	if value != (common.Hash{}) {
+		t.Fatalf("Expect storage slot 102 to be clean up and equal to nil, got %s", value)
+	}
+
+	// Case 6: Pick validator set with rotating validators
+	rawBeacon := crypto.Keccak256([]byte("aaa"))
+	beacon = new(big.Int).SetBytes(rawBeacon)
+	period = common.Big3
+	numGovernanceValidator = big.NewInt(2)
+	numStandardValidator = big.NewInt(2)
+	numRotatingValidator = big.NewInt(1)
+	consensusAddrs = []common.Address{
+		common.BigToAddress(big.NewInt(1)),
+		common.BigToAddress(big.NewInt(2)),
+		common.BigToAddress(big.NewInt(3)),
+		common.BigToAddress(big.NewInt(4)),
+		common.BigToAddress(big.NewInt(5)),
+		common.BigToAddress(big.NewInt(6)),
+	}
+	stakedAmount = []*big.Int{
+		new(big.Int).Mul(big.NewInt(10), ether),
+		new(big.Int).Mul(big.NewInt(20), ether),
+		new(big.Int).Mul(big.NewInt(30), ether),
+		new(big.Int).Mul(big.NewInt(40), ether),
+		new(big.Int).Mul(big.NewInt(50), ether),
+		new(big.Int).Mul(big.NewInt(60), ether),
+	}
+	isGovernanceValidators = []*big.Int{
+		common.Big1,
+		common.Big1,
+		common.Big0,
+		common.Big0,
+		common.Big0,
+		common.Big0,
+	}
+	input, err = contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+	_, err = contract.Run(input)
+	if err != nil {
+		t.Fatalf("Precompiled contract throws error %s", err)
+	}
+
+	input, _ = contractAbi.Pack(pickValidatorSetMethod, period, big.NewInt(1))
+	output, err := contract.Run(input)
+	if err != nil {
+		t.Fatalf("Failed to pick validator set, err: %s", err)
+	}
+	ret, err := contractAbi.Unpack(pickValidatorSetMethod, output)
+	if err != nil {
+		t.Fatalf("Failed to unpack output, err: %s", err)
+	}
+
+	pickedValidator, _ := (ret[0]).([]common.Address)
+	expectedValidator := []common.Address{
+		common.BigToAddress(big.NewInt(1)),
+		common.BigToAddress(big.NewInt(2)),
+		common.BigToAddress(big.NewInt(6)),
+		common.BigToAddress(big.NewInt(5)),
+		common.BigToAddress(big.NewInt(4)),
+	}
+	for i := range pickedValidator {
+		if pickedValidator[i] != expectedValidator[i] {
+			t.Fatalf("Expect picked validator %s, got %s", expectedValidator[i], pickedValidator[i])
+		}
+	}
+
+	input, _ = contractAbi.Pack(pickValidatorSetMethod, period, big.NewInt(2))
+	output, err = contract.Run(input)
+	if err != nil {
+		t.Fatalf("Failed to pick validator set, err: %s", err)
+	}
+	ret, err = contractAbi.Unpack(pickValidatorSetMethod, output)
+	if err != nil {
+		t.Fatalf("Failed to unpack output, err: %s", err)
+	}
+	pickedValidator, _ = (ret[0]).([]common.Address)
+	expectedValidator = []common.Address{
+		common.BigToAddress(big.NewInt(1)),
+		common.BigToAddress(big.NewInt(2)),
+		common.BigToAddress(big.NewInt(6)),
+		common.BigToAddress(big.NewInt(5)),
+		common.BigToAddress(big.NewInt(3)),
+	}
+	for i := range pickedValidator {
+		if pickedValidator[i] != expectedValidator[i] {
+			t.Fatalf("Expect picked validator %s, got %s", expectedValidator[i], pickedValidator[i])
+		}
+	}
+}
+func TestRequiredGas(t *testing.T) {
+	const maxCandidates = 64
+	contract := pickValidatorSetBeacon{}
+	contractAbi := *unmarshalledABIs[PickValidatorSetBeacon]
+
+	rawBeacon := crypto.Keccak256([]byte("bbb"))
+	beacon := new(big.Int).SetBytes(rawBeacon)
+	period := common.Big1
+	numGovernanceValidator := big.NewInt(12)
+	numStandardValidator := big.NewInt(5)
+	numRotatingValidator := big.NewInt(5)
+
+	consensusAddrs := make([]common.Address, 0, maxCandidates)
+	stakedAmount := make([]*big.Int, 0, maxCandidates)
+	isGovernanceValidators := make([]*big.Int, 0, maxCandidates)
+	for i := range consensusAddrs {
+		consensusAddrs = append(consensusAddrs, common.BigToAddress(big.NewInt(int64(i))))
+		stakedAmount = append(stakedAmount, big.NewInt(rand.Int63()))
+		if i < int(numGovernanceValidator.Int64()) {
+			isGovernanceValidators = append(isGovernanceValidators, common.Big1)
+		} else {
+			isGovernanceValidators = append(isGovernanceValidators, common.Big0)
+		}
+	}
+
+	input, err := contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+
+	gas := contract.RequiredGas(input)
+	var expectedGas uint64 = 3_600_000
+	if gas != expectedGas {
+		t.Fatalf("Expect to have gas: %d, got: %d", expectedGas, gas)
+	}
+
+	numStandardValidator = common.Big0
+	numRotatingValidator = big.NewInt(10)
+	input, err = contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		t.Fatalf("Failed to pack input")
+	}
+
+	gas = contract.RequiredGas(input)
+	expectedGas = 7_200_000
+	if gas != expectedGas {
+		t.Fatalf("Expect to have gas: %d, got: %d", expectedGas, gas)
+	}
+}
+
+func BenchmarkRequestSortValidator(b *testing.B) {
+	const maxCandidates = 64
+
+	contractAbi := *unmarshalledABIs[PickValidatorSetBeacon]
+	rawBeacon := crypto.Keccak256([]byte("bbb"))
+	beacon := new(big.Int).SetBytes(rawBeacon)
+	period := common.Big1
+	numGovernanceValidator := big.NewInt(12)
+	numStandardValidator := big.NewInt(5)
+	numRotatingValidator := big.NewInt(5)
+
+	consensusAddrs := make([]common.Address, 0, maxCandidates)
+	stakedAmount := make([]*big.Int, 0, maxCandidates)
+	isGovernanceValidators := make([]*big.Int, 0, maxCandidates)
+	for i := range consensusAddrs {
+		consensusAddrs = append(consensusAddrs, common.BigToAddress(big.NewInt(int64(i))))
+		stakedAmount = append(stakedAmount, big.NewInt(rand.Int63()))
+		if i < int(numGovernanceValidator.Int64()) {
+			isGovernanceValidators = append(isGovernanceValidators, common.Big1)
+		} else {
+			isGovernanceValidators = append(isGovernanceValidators, common.Big0)
+		}
+	}
+
+	input, err := contractAbi.Pack(
+		requestSortValidatorSet,
+		beacon,
+		period,
+		numGovernanceValidator,
+		numStandardValidator,
+		numRotatingValidator,
+		consensusAddrs,
+		stakedAmount,
+		isGovernanceValidators,
+	)
+	if err != nil {
+		b.Fatalf("Failed to pack input")
+	}
+
+	test := precompiledTest{
+		Input:    common.Bytes2Hex(input),
+		Expected: "",
+		Name:     "request-sort-validator",
+	}
+	benchmarkPrecompiled("6b", test, b)
 }

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -46,6 +48,16 @@ type precompiledFailureTest struct {
 	Input         string
 	ExpectedError string
 	Name          string
+}
+
+func init() {
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	allPrecompiles[common.BytesToAddress([]byte{107})] = &pickValidatorSetBeacon{
+		evm: &EVM{
+			StateDB: statedb,
+		},
+		skipPeriodCheck: true,
+	}
 }
 
 // allPrecompiles does not map to the actual set of precompiles, as it also contains

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -87,9 +87,12 @@ func (evm *EVM) precompile(caller ContractRef, addr common.Address) (Precompiled
 
 	// add consortium precompiled contracts to list
 	var consortiumContracts map[common.Address]PrecompiledContract
-	if evm.chainRules.IsMiko {
+	switch {
+	case evm.chainRules.IsTripp:
+		consortiumContracts = PrecompiledContractsConsortiumTripp(caller, evm)
+	case evm.chainRules.IsMiko:
 		consortiumContracts = PrecompiledContractsConsortiumMiko(caller, evm)
-	} else {
+	default:
 		consortiumContracts = PrecompiledContractsConsortium(caller, evm)
 	}
 	for address, contract := range consortiumContracts {

--- a/params/config.go
+++ b/params/config.go
@@ -1059,7 +1059,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsOdysseusFork, IsFenix, IsConsortiumV2, IsAntenna      bool
-	IsMiko                                                  bool
+	IsMiko, IsTripp                                         bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1085,5 +1085,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsConsortiumV2:   c.IsConsortiumV2(num),
 		IsAntenna:        c.IsAntenna(num),
 		IsMiko:           c.IsMiko(num),
+		IsTripp:          c.IsTripp(num),
 	}
 }


### PR DESCRIPTION
- precompiled: add contract for sorting validator with random beacon

This new precompiled contract provides requestSortValidatorSet and
pickValidatorSet function. The requestSortValidatorSet receives the list of all
validator candidates, pick non-rotating validators based on staked amounts and
rotating validators based on weight derived from random beacon. The list of
validators for all epoch of that period is stored in precompiled contract's
storage. The pickValidatorSet supports query the validator set of an epoch in
that period.

- consortium-v2: enable pick validator with beacon at Tripp hardfork - 1

Since precompiled contract has no code, it can be marked as empty account if
nonce and balance is 0 too. If the account is empty, the account node is deleted
so writing to storage of that account has no effect. We avoid this by setting
nonce of precompiled contract to 1 at Tripp hardfork block - 1 before the
WrapUpEpoch system transaction.