### PR TITLE
consensus, miner: set the basefee to 0 after London fork

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -30,12 +28,7 @@ import (
 // - gas limit check
 // - basefee check
 func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Header) error {
-	// Verify that the gas limit remains within allowed bounds
-	parentGasLimit := parent.GasLimit
-	if !config.IsLondon(parent.Number) {
-		parentGasLimit = parent.GasLimit * params.ElasticityMultiplier
-	}
-	if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
+	if err := VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
 		return err
 	}
 	// Verify the header is not malformed
@@ -53,41 +46,48 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 
 // CalcBaseFee calculates the basefee of the header.
 func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
-	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
-	if !config.IsLondon(parent.Number) {
-		return new(big.Int).SetUint64(params.InitialBaseFee)
-	}
+	return big.NewInt(0)
 
-	var (
-		parentGasTarget          = parent.GasLimit / params.ElasticityMultiplier
-		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
-		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
-	)
-	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
-	if parent.GasUsed == parentGasTarget {
-		return new(big.Int).Set(parent.BaseFee)
-	}
-	if parent.GasUsed > parentGasTarget {
-		// If the parent block used more gas than its target, the baseFee should increase.
-		gasUsedDelta := new(big.Int).SetUint64(parent.GasUsed - parentGasTarget)
-		x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
-		y := x.Div(x, parentGasTargetBig)
-		baseFeeDelta := math.BigMax(
-			x.Div(y, baseFeeChangeDenominator),
-			common.Big1,
+	/*
+		We temporarily set the base fee to 0, the following logic may be enabled in
+		the future hardfork.
+
+		// If the current block is the first EIP-1559 block, return the InitialBaseFee.
+		if !config.IsLondon(parent.Number) {
+			return new(big.Int).SetUint64(params.InitialBaseFee)
+		}
+
+		var (
+			parentGasTarget          = parent.GasLimit / params.ElasticityMultiplier
+			parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
+			baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
 		)
+		// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
+		if parent.GasUsed == parentGasTarget {
+			return new(big.Int).Set(parent.BaseFee)
+		}
+		if parent.GasUsed > parentGasTarget {
+			// If the parent block used more gas than its target, the baseFee should increase.
+			gasUsedDelta := new(big.Int).SetUint64(parent.GasUsed - parentGasTarget)
+			x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
+			y := x.Div(x, parentGasTargetBig)
+			baseFeeDelta := math.BigMax(
+				x.Div(y, baseFeeChangeDenominator),
+				common.Big1,
+			)
 
-		return x.Add(parent.BaseFee, baseFeeDelta)
-	} else {
-		// Otherwise if the parent block used less gas than its target, the baseFee should decrease.
-		gasUsedDelta := new(big.Int).SetUint64(parentGasTarget - parent.GasUsed)
-		x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
-		y := x.Div(x, parentGasTargetBig)
-		baseFeeDelta := x.Div(y, baseFeeChangeDenominator)
+			return x.Add(parent.BaseFee, baseFeeDelta)
+		} else {
+			// Otherwise if the parent block used less gas than its target, the baseFee should decrease.
+			gasUsedDelta := new(big.Int).SetUint64(parentGasTarget - parent.GasUsed)
+			x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
+			y := x.Div(x, parentGasTargetBig)
+			baseFeeDelta := x.Div(y, baseFeeChangeDenominator)
 
-		return math.BigMax(
-			x.Sub(parent.BaseFee, baseFeeDelta),
-			common.Big0,
-		)
-	}
+			return math.BigMax(
+				x.Sub(parent.BaseFee, baseFeeDelta),
+				common.Big0,
+			)
+		}
+	*/
 }

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -59,8 +59,6 @@ func config() *params.ChainConfig {
 // TestBlockGasLimits tests the gasLimit checks for blocks both across
 // the EIP-1559 boundary and post-1559 blocks
 func TestBlockGasLimits(t *testing.T) {
-	initial := new(big.Int).SetUint64(params.InitialBaseFee)
-
 	for i, tc := range []struct {
 		pGasLimit uint64
 		pNum      int64
@@ -68,11 +66,11 @@ func TestBlockGasLimits(t *testing.T) {
 		ok        bool
 	}{
 		// Transitions from non-london to london
-		{10000000, 4, 20000000, true},  // No change
-		{10000000, 4, 20019530, true},  // Upper limit
-		{10000000, 4, 20019531, false}, // Upper +1
-		{10000000, 4, 19980470, true},  // Lower limit
-		{10000000, 4, 19980469, false}, // Lower limit -1
+		{10000000, 4, 10000000, true},  // No change
+		{10000000, 4, 10009764, true},  // Upper limit
+		{10000000, 4, 10009765, false}, // Upper +1
+		{10000000, 4, 9990236, true},   // Lower limit
+		{10000000, 4, 9990235, false},  // Lower limit -1
 		// London to London
 		{20000000, 5, 20000000, true},
 		{20000000, 5, 20019530, true},  // Upper limit
@@ -87,13 +85,13 @@ func TestBlockGasLimits(t *testing.T) {
 		parent := &types.Header{
 			GasUsed:  tc.pGasLimit / 2,
 			GasLimit: tc.pGasLimit,
-			BaseFee:  initial,
+			BaseFee:  common.Big0,
 			Number:   big.NewInt(tc.pNum),
 		}
 		header := &types.Header{
 			GasUsed:  tc.gasLimit / 2,
 			GasLimit: tc.gasLimit,
-			BaseFee:  initial,
+			BaseFee:  common.Big0,
 			Number:   big.NewInt(tc.pNum + 1),
 		}
 		err := VerifyEip1559Header(config(), parent, header)
@@ -105,6 +103,9 @@ func TestBlockGasLimits(t *testing.T) {
 		}
 	}
 }
+
+/*
+TODO: Enable this test when the basefee calculation logic is enabled again
 
 // TestCalcBaseFee assumes all blocks are 1559-blocks
 func TestCalcBaseFee(t *testing.T) {
@@ -130,3 +131,4 @@ func TestCalcBaseFee(t *testing.T) {
 		}
 	}
 }
+*/

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -361,8 +361,7 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	if chain.Config().IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(chain.Config(), parent.Header())
 		if !chain.Config().IsLondon(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
+			header.GasLimit = CalcGasLimit(parent.GasLimit(), parent.GasLimit())
 		}
 	}
 	return header

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -155,12 +155,14 @@ func TestStateProcessorErrors(t *testing.T) {
 				},
 				want: "could not apply tx 0 [0xbd49d8dadfd47fb846986695f7d4da3f7b2c48c8da82dbc211a26eb124883de9]: gas limit reached",
 			},
-			{ // ErrFeeCapTooLow
-				txs: []*types.Transaction{
-					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(0), big.NewInt(0)),
+			/*
+				{ // ErrFeeCapTooLow
+					txs: []*types.Transaction{
+						mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(0), big.NewInt(0)),
+					},
+					want: "could not apply tx 0 [0xc4ab868fef0c82ae0387b742aee87907f2d0fc528fc6ea0a021459fb0fc4a4a8]: max fee per gas less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, maxFeePerGas: 0 baseFee: 875000000",
 				},
-				want: "could not apply tx 0 [0xc4ab868fef0c82ae0387b742aee87907f2d0fc528fc6ea0a021459fb0fc4a4a8]: max fee per gas less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, maxFeePerGas: 0 baseFee: 875000000",
-			},
+			*/
 			{ // ErrTipVeryHigh
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas, tooBigNumber, big.NewInt(1)),

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -503,14 +503,14 @@ func TestTraceInternalsAndAccounts_BatchTransferAccounts(t *testing.T) {
 			// Batch send to this account:
 			// - "0x05ba56c60ceb54f53294bf60d606a919eea4282e"
 			data1 := common.FromHex("0x876e586100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000100000000000000000000000005ba56c60ceb54f53294bf60d606a919eea4282e")
-			tx1, _ := types.SignTx(types.NewTransaction(uint64(0), accounts[0].addr, big.NewInt(0), 4*params.TxGas, b.BaseFee(), data1), signer, accounts[1].key)
+			tx1, _ := types.SignTx(types.NewTransaction(uint64(0), accounts[0].addr, big.NewInt(0), 4*params.TxGas, big.NewInt(0), data1), signer, accounts[1].key)
 			b.AddTx(tx1)
 
 			// Batch send to these accounts:
 			// - "0x359aef78ffa9807889258d0dd398172ca3b77eb1"
 			// - "0x45f60b415111e3e7abb4c79fc659d3dee430dff5"
 			data2 := common.FromHex("0x876e5861000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000359aef78ffa9807889258d0dd398172ca3b77eb100000000000000000000000045f60b415111e3e7abb4c79fc659d3dee430dff5")
-			tx2, _ := types.SignTx(types.NewTransaction(uint64(1), accounts[0].addr, big.NewInt(0), 10*params.TxGas, b.BaseFee(), data2), signer, accounts[1].key)
+			tx2, _ := types.SignTx(types.NewTransaction(uint64(1), accounts[0].addr, big.NewInt(0), 10*params.TxGas, big.NewInt(0), data2), signer, accounts[1].key)
 			b.AddTx(tx2)
 		}
 	}))
@@ -565,7 +565,7 @@ func TestTraceInternalsAndAccounts_BatchTransferAccounts(t *testing.T) {
 	expectedDirtyAccounts[common.HexToAddress("0x05bA56C60ceb54f53294bF60d606a919eeA4282E")] = big.NewInt(1)
 	expectedDirtyAccounts[common.HexToAddress("0x359aEf78fFa9807889258D0DD398172CA3B77eB1")] = big.NewInt(1)
 	expectedDirtyAccounts[common.HexToAddress("0x45F60B415111e3E7aBB4c79FC659d3DeE430dfF5")] = big.NewInt(1)
-	expectedDirtyAccounts[accounts[1].addr] = big.NewInt(999879458468750000)
+	expectedDirtyAccounts[accounts[1].addr] = big.NewInt(1000000000000000000)
 	expectedDirtyAccounts[accounts[0].addr] = big.NewInt(999999999999999997)
 
 	for _, actual := range result.DirtyAccounts {
@@ -607,12 +607,12 @@ func TestTraceInternalsAndAccounts_CreateContract(t *testing.T) {
 		if i == 1 {
 			// Call `deploy` method to create a new contract
 			data1 := common.FromHex("0x775c300c")
-			tx1, _ := types.SignTx(types.NewTransaction(uint64(0), accounts[0].addr, big.NewInt(0), 100*params.TxGas, b.BaseFee(), data1), signer, accounts[1].key)
+			tx1, _ := types.SignTx(types.NewTransaction(uint64(0), accounts[0].addr, big.NewInt(0), 100*params.TxGas, big.NewInt(0), data1), signer, accounts[1].key)
 			b.AddTx(tx1)
 
 			// Call `deploy` method to create a new contract
 			data2 := common.FromHex("0x775c300c")
-			tx2, _ := types.SignTx(types.NewTransaction(uint64(1), accounts[0].addr, big.NewInt(0), 100*params.TxGas, b.BaseFee(), data2), signer, accounts[1].key)
+			tx2, _ := types.SignTx(types.NewTransaction(uint64(1), accounts[0].addr, big.NewInt(0), 100*params.TxGas, big.NewInt(0), data2), signer, accounts[1].key)
 			b.AddTx(tx2)
 		}
 	})
@@ -671,7 +671,7 @@ func TestTraceInternalsAndAccounts_CreateContract(t *testing.T) {
 	}
 
 	expectedDirtyAccounts := map[common.Address]*big.Int{}
-	expectedDirtyAccounts[accounts[1].addr] = big.NewInt(999898971187500000)
+	expectedDirtyAccounts[accounts[1].addr] = big.NewInt(1000000000000000000)
 	expectedDirtyAccounts[accounts[0].addr] = big.NewInt(1000000000000000000)
 
 	for _, actual := range result.DirtyAccounts {
@@ -713,12 +713,12 @@ func TestTraceInternalsAndAccounts_Create2Contract(t *testing.T) {
 		if i == 1 {
 			// Call `deploy` method to create a new contract
 			data1 := common.FromHex("0x2b85ba3800000000000000000000000000000000000000000000000000000000686f6c61")
-			tx1, _ := types.SignTx(types.NewTransaction(uint64(0), accounts[0].addr, big.NewInt(0), 100*params.TxGas, b.BaseFee(), data1), signer, accounts[1].key)
+			tx1, _ := types.SignTx(types.NewTransaction(uint64(0), accounts[0].addr, big.NewInt(0), 100*params.TxGas, big.NewInt(0), data1), signer, accounts[1].key)
 			b.AddTx(tx1)
 
 			// Call `deploy` method to create a new contract
 			data2 := common.FromHex("0x2b85ba3800000000000000000000000000000000000000000000000000000000686f6c62")
-			tx2, _ := types.SignTx(types.NewTransaction(uint64(1), accounts[0].addr, big.NewInt(0), 100*params.TxGas, b.BaseFee(), data2), signer, accounts[1].key)
+			tx2, _ := types.SignTx(types.NewTransaction(uint64(1), accounts[0].addr, big.NewInt(0), 100*params.TxGas, big.NewInt(0), data2), signer, accounts[1].key)
 			b.AddTx(tx2)
 		}
 	})
@@ -777,7 +777,7 @@ func TestTraceInternalsAndAccounts_Create2Contract(t *testing.T) {
 	}
 
 	expectedDirtyAccounts := map[common.Address]*big.Int{}
-	expectedDirtyAccounts[accounts[1].addr] = big.NewInt(999897929937500000)
+	expectedDirtyAccounts[accounts[1].addr] = big.NewInt(1000000000000000000)
 	expectedDirtyAccounts[accounts[0].addr] = big.NewInt(1000000000000000000)
 
 	for _, actual := range result.DirtyAccounts {

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -300,6 +300,8 @@ func TestEthClient(t *testing.T) {
 }
 
 func testHeader(t *testing.T, chain []*types.Block, client *rpc.Client) {
+	firstBlockHeader := chain[1].Header()
+	firstBlockHeader.BaseFee = big.NewInt(1).SetUint64(0)
 	tests := map[string]struct {
 		block   *big.Int
 		want    *types.Header
@@ -311,7 +313,7 @@ func testHeader(t *testing.T, chain []*types.Block, client *rpc.Client) {
 		},
 		"first_block": {
 			block: big.NewInt(1),
-			want:  chain[1].Header(),
+			want:  firstBlockHeader,
 		},
 		"future_block": {
 			block:   big.NewInt(1000000000),
@@ -502,9 +504,14 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gasTipCap.Cmp(big.NewInt(234375000)) != 0 {
+	if gasTipCap.Cmp(big.NewInt(1000000000)) != 0 {
 		t.Fatalf("unexpected gas tip cap: %v", gasTipCap)
 	}
+	/*
+		if gasTipCap.Cmp(big.NewInt(234375000)) != 0 {
+			t.Fatalf("unexpected gas tip cap: %v", gasTipCap)
+		}
+	*/
 }
 
 func testCallContract(t *testing.T, client *rpc.Client) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1066,13 +1066,9 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		Extra:      w.extra,
 		Time:       uint64(timestamp),
 	}
-	// Set baseFee and GasLimit if we are on an EIP-1559 chain
+	// Set baseFee if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
-		if !w.chainConfig.IsLondon(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
-		}
 	}
 	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
 	if w.isRunning() {


### PR DESCRIPTION
Currently, we choose to set basefee to 0 after London fork on Ronin, the basefee logic can be changed in future fork. Besides, at the London fork, we don't double the block gas limit.