### PR TITLE
entrypoint: remove deprecated unused miner.gastarget

### DIFF
--- a/docker/chainnode/entrypoint.sh
+++ b/docker/chainnode/entrypoint.sh
@@ -347,6 +347,5 @@ exec ronin $params \
   --ws.port $ws_port \
   --ws.origins "*" \
   --allow-insecure-unlock \
-  --miner.gastarget "100000000" \
   $blsParams \
   "$@"


### PR DESCRIPTION
The miner.gastarget is deprecated and has no effect now. This commit removes this flag from the entrypoint.sh.