### PR TITLE
consortium-v2: increase the nonce of sender before transaction execution

### DIFF
--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -347,6 +347,7 @@ func ApplyTransaction(msg types.Message, opts *ApplyTransactOpts) (err error) {
 		*receivedTxs = (*receivedTxs)[1:]
 	}
 	opts.State.Prepare(expectedTx.Hash(), len(*txs))
+	opts.State.SetNonce(msg.From(), nonce+1)
 	gasUsed, err := applyMessage(opts.ApplyMessageOpts, expectedTx)
 	if err != nil {
 		failed = true
@@ -376,7 +377,6 @@ func ApplyTransaction(msg types.Message, opts *ApplyTransactOpts) (err error) {
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(opts.State.TxIndex())
 	*receipts = append(*receipts, receipt)
-	opts.State.SetNonce(msg.From(), nonce+1)
 	return nil
 }
 


### PR DESCRIPTION
Currently, in system transaction we increase nonce after transaction execution
which is not consistent with normal transaction. This change does not require a
hardfork as:
- Nonce is not used when executing transaction in virtual machine
- Consortium-v2 is after Byzantium so we don't fall through the path to
  calculate root hash after transaction execution

Reference: https://github.com/bnb-chain/bsc/pull/2185