### PR TITLE
tracers/prestate: fix the balance track of payer and sender

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -334,7 +334,12 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	if tracer := st.evm.Config.Tracer; tracer != nil {
-		tracer.CaptureTxStart(st.initialGas)
+		var payer *common.Address
+		if st.msg.From() != st.msg.Payer() {
+			payerAddr := st.msg.Payer()
+			payer = &payerAddr
+		}
+		tracer.CaptureTxStart(st.initialGas, payer)
 		defer func() {
 			tracer.CaptureTxEnd(st.gas)
 		}()

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -29,7 +29,7 @@ import (
 // if you need to retain them beyond the current call.
 type EVMLogger interface {
 	// Transaction level
-	CaptureTxStart(gasLimit uint64)
+	CaptureTxStart(gasLimit uint64, payer *common.Address)
 	CaptureTxEnd(restGas uint64)
 	// Top call frame
 	CaptureStart(env *EVM, from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int)

--- a/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/sponsored_tx.json
+++ b/eth/tracers/internal/tracetest/testdata/prestate_tracer_with_diff_mode/sponsored_tx.json
@@ -1,0 +1,75 @@
+{
+  "context": {
+    "difficulty": "3502894804",
+    "gasLimit": "4722976",
+    "miner": "0x1585936b53834b021f68cc13eeefdec2efc8e724",
+    "number": "2289806",
+    "timestamp": "1513601314"
+  },
+  "genesis": {
+    "alloc": {
+      "0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
+        "balance": "0x0",
+        "code": "0x",
+        "nonce": "0",
+        "storage": {}
+      },
+      "0xd24d87ddc1917165435b306aac68d99e0f49a3fa": {
+        "balance": "0x221b262dd8000",
+        "code": "0x",
+        "storage": {}
+      }
+    },
+    "config": {
+      "byzantiumBlock": 0,
+      "chainId": 2021,
+      "daoForkSupport": true,
+      "eip150Block": 0,
+      "eip150Hash": "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d",
+      "eip155Block": 10,
+      "eip158Block": 10,
+      "ethash": {},
+      "homesteadBlock": 0,
+      "mikoBlock": 0
+    },
+    "difficulty": "3509749784",
+    "extraData": "0x4554482e45544846414e532e4f52472d4641313738394444",
+    "gasLimit": "4727564",
+    "hash": "0x609948ac3bd3c00b7736b933248891d6c901ee28f066241bddb28f4e00a9f440",
+    "miner": "0xbbf5029fd710d227630c8b7d338051b8e76d50b3",
+    "mixHash": "0xb131e4507c93c7377de00e7c271bf409ec7492767142ff0f45c882f8068c2ada",
+    "nonce": "0x4eb12e19c16d43da",
+    "number": "2289805",
+    "stateRoot": "0xc7f10f352bff82fac3c2999d3085093d12652e19c7fd32591de49dc5d91b4f1f",
+    "timestamp": "1513601261",
+    "totalDifficulty": "7143276353481064"
+  },
+  "input": "0x64f8b18207e5808504a817c8008504a817c80082753094c89e2d7e38eb36d5213c2c505edd2d8974cd871880808001a0484c556ab155ce61fe4cc4876f998b6886261a5c1f75354136bf136f4dcfed3aa018e119d421dcef662cff0c48bcd56eb44bb1c0cbb3712417a7e0d2da6ee8e37780a0672848fad8bc2693f1abebecba7084a541fa895da32317c8dd8e955994bb4537a00ebdfe731eb375c7281c7ad087299bfff270d0dac4bf20a8528991d001743614",
+  "tracerConfig": {
+    "diffMode": true
+  },
+  "result": {
+    "pre": {
+      "0x1585936b53834b021f68cc13eeefdec2efc8e724": {
+        "balance": "0x0"
+      },
+      "0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
+        "balance": "0x0"
+      },
+      "0xd24d87ddc1917165435b306aac68d99e0f49a3fa": {
+        "balance": "0x221b262dd8000"
+      }
+    },
+    "post": {
+      "0x1585936b53834b021f68cc13eeefdec2efc8e724": {
+        "balance": "0x17dfcdece4000"
+      },
+      "0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
+        "nonce": 1
+      },
+      "0xd24d87ddc1917165435b306aac68d99e0f49a3fa": {
+        "balance": "0xa3b5840f4000"
+      }
+    }
+  }
+}

--- a/eth/tracers/js/goja.go
+++ b/eth/tracers/js/goja.go
@@ -212,7 +212,7 @@ func newJsTracer(code string, ctx *tracers.Context, cfg json.RawMessage) (tracer
 
 // CaptureTxStart implements the Tracer interface and is invoked at the beginning of
 // transaction processing.
-func (t *jsTracer) CaptureTxStart(gasLimit uint64) {
+func (t *jsTracer) CaptureTxStart(gasLimit uint64, payer *common.Address) {
 	t.gasLimit = gasLimit
 }
 

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -73,7 +73,7 @@ func runTrace(tracer tracers.Tracer, vmctx *vmContext, chaincfg *params.ChainCon
 		contract.Code = contractCode
 	}
 
-	tracer.CaptureTxStart(gasLimit)
+	tracer.CaptureTxStart(gasLimit, nil)
 	tracer.CaptureStart(env, contract.Caller(), contract.Address(), false, []byte{}, startGas, value)
 	ret, err := env.Interpreter().Run(contract, []byte{}, false)
 	tracer.CaptureEnd(ret, startGas-contract.Gas, err)

--- a/eth/tracers/logger/access_list_tracer.go
+++ b/eth/tracers/logger/access_list_tracer.go
@@ -168,7 +168,7 @@ func (*AccessListTracer) CaptureEnter(typ vm.OpCode, from common.Address, to com
 
 func (*AccessListTracer) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*AccessListTracer) CaptureTxStart(gasLimit uint64) {}
+func (*AccessListTracer) CaptureTxStart(gasLimit uint64, payer *common.Address) {}
 
 func (*AccessListTracer) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -261,7 +261,7 @@ func (l *StructLogger) Stop(err error) {
 	l.interrupt.Store(true)
 }
 
-func (l *StructLogger) CaptureTxStart(gasLimit uint64) {
+func (l *StructLogger) CaptureTxStart(gasLimit uint64, payer *common.Address) {
 	l.gasLimit = gasLimit
 }
 
@@ -394,7 +394,7 @@ func (t *mdLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.Ad
 
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (*mdLogger) CaptureTxStart(gasLimit uint64) {}
+func (*mdLogger) CaptureTxStart(gasLimit uint64, payer *common.Address) {}
 
 func (*mdLogger) CaptureTxEnd(restGas uint64) {}
 

--- a/eth/tracers/logger/logger_json.go
+++ b/eth/tracers/logger/logger_json.go
@@ -97,6 +97,6 @@ func (l *JSONLogger) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 
 func (l *JSONLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
-func (l *JSONLogger) CaptureTxStart(gasLimit uint64) {}
+func (l *JSONLogger) CaptureTxStart(gasLimit uint64, payer *common.Address) {}
 
 func (l *JSONLogger) CaptureTxEnd(restGas uint64) {}

--- a/eth/tracers/native/call.go
+++ b/eth/tracers/native/call.go
@@ -233,7 +233,7 @@ func (t *callTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	t.callstack[size-1].Calls = append(t.callstack[size-1].Calls, call)
 }
 
-func (t *callTracer) CaptureTxStart(gasLimit uint64) {
+func (t *callTracer) CaptureTxStart(gasLimit uint64, payer *common.Address) {
 	t.gasLimit = gasLimit
 }
 

--- a/eth/tracers/native/call_flat.go
+++ b/eth/tracers/native/call_flat.go
@@ -201,8 +201,8 @@ func (t *flatCallTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *flatCallTracer) CaptureTxStart(gasLimit uint64) {
-	t.tracer.CaptureTxStart(gasLimit)
+func (t *flatCallTracer) CaptureTxStart(gasLimit uint64, payer *common.Address) {
+	t.tracer.CaptureTxStart(gasLimit, payer)
 }
 
 func (t *flatCallTracer) CaptureTxEnd(restGas uint64) {

--- a/eth/tracers/native/mux.go
+++ b/eth/tracers/native/mux.go
@@ -101,9 +101,9 @@ func (t *muxTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 	}
 }
 
-func (t *muxTracer) CaptureTxStart(gasLimit uint64) {
+func (t *muxTracer) CaptureTxStart(gasLimit uint64, payer *common.Address) {
 	for _, t := range t.tracers {
-		t.CaptureTxStart(gasLimit)
+		t.CaptureTxStart(gasLimit, payer)
 	}
 }
 

--- a/eth/tracers/native/noop.go
+++ b/eth/tracers/native/noop.go
@@ -63,7 +63,7 @@ func (t *noopTracer) CaptureEnter(typ vm.OpCode, from common.Address, to common.
 func (t *noopTracer) CaptureExit(output []byte, gasUsed uint64, err error) {
 }
 
-func (*noopTracer) CaptureTxStart(gasLimit uint64) {}
+func (*noopTracer) CaptureTxStart(gasLimit uint64, payer *common.Address) {}
 
 func (*noopTracer) CaptureTxEnd(restGas uint64) {}
 


### PR DESCRIPTION
In sponsored transaction, payer of gas fee can be different from sender. This commit fixes the prestate tracer to correctly track the balance of payer and sender in sponsored transaction.

Test with a sponsored transaction:
```
	{
		"from": "0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718",
		"to": "0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718",
		"payer": "0xd24d87ddc1917165435b306aac68d99e0f49a3fa",
		"value": "0x0",
		"gas": "0x7530",
		"gasPrice": "0x4a817c800",
	}
```

Request:
```
	{
		"jsonrpc": "2.0",
		"method": "debug_traceTransaction",
		"params": [
			"0xf4794f0301f3235bdbe6d68a775ec3191cae02e8125e3a43b7cbe8457cfc5287",
			{
				"tracer": "prestateTracer",
				"tracerConfig": {
					"diffMode": true
				}
			}
		],
		"id": 1
	}
```

Before:
```
	{
		"jsonrpc": "2.0",
		"id": 1,
		"result": {
			"post": {
				"0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
					"balance": "0x0",
					"nonce": 1
				}
			},
			"pre": {
				"0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
					"balance": "0x221b262dd8000"
				}
			}
		}
	}
```

After:
```
	{
		"jsonrpc": "2.0",
		"id": 1,
		"result": {
			"post": {
				"0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
					"nonce": 1
				},
				"0xd24d87ddc1917165435b306aac68d99e0f49a3fa": {
					"balance": "0xd2c58d581b3cbfd4e553"
				}
			},
			"pre": {
				"0xc89e2d7e38eb36d5213c2c505edd2d8974cd8718": {
					"balance": "0x0"
				},
				"0xd24d87ddc1917165435b306aac68d99e0f49a3fa": {
					"balance": "0xd2c58d5999399ea32553",
					"nonce": 610
				}
			}
		}
	}
```