### PR TITLE
consortium-v2: query contract based on block hash

### DIFF
--- a/consensus/consortium/common/mock_contract.go
+++ b/consensus/consortium/common/mock_contract.go
@@ -53,11 +53,11 @@ func (m *MockValidators) GetPublicKey(addr common.Address) (blsCommon.PublicKey,
 type MockContract struct {
 }
 
-func (contract *MockContract) GetBlockProducers(*big.Int) ([]common.Address, error) {
+func (contract *MockContract) GetBlockProducers(blockHash common.Hash, blockNumber *big.Int) ([]common.Address, error) {
 	return Validators.GetValidators(), nil
 }
 
-func (contract *MockContract) GetValidatorCandidates(*big.Int) ([]common.Address, error) {
+func (contract *MockContract) GetValidatorCandidates(blockHash common.Hash, blockNumber *big.Int) ([]common.Address, error) {
 	return nil, nil
 }
 
@@ -81,10 +81,10 @@ func (contract *MockContract) FinalityReward(*ApplyTransactOpts, []common.Addres
 	return nil
 }
 
-func (contract *MockContract) GetBlsPublicKey(_ *big.Int, addr common.Address) (blsCommon.PublicKey, error) {
+func (contract *MockContract) GetBlsPublicKey(blockHash common.Hash, blockNumber *big.Int, addr common.Address) (blsCommon.PublicKey, error) {
 	return Validators.GetPublicKey(addr)
 }
 
-func (contract *MockContract) GetStakedAmount(_ *big.Int, _ []common.Address) ([]*big.Int, error) {
+func (contract *MockContract) GetStakedAmount(blockHash common.Hash, blockNumber *big.Int, addr []common.Address) ([]*big.Int, error) {
 	return nil, nil
 }

--- a/consensus/consortium/v1/consortium.go
+++ b/consensus/consortium/v1/consortium.go
@@ -788,7 +788,7 @@ func (c *Consortium) signerInTurn(signer common.Address, number uint64, validato
 
 func (c *Consortium) initContract(coinbase common.Address, signTxFn consortiumCommon.SignerTxFn) error {
 	if c.chainConfig.ConsortiumV2Block != nil && c.chainConfig.ConsortiumV2Contracts != nil {
-		contract, err := consortiumCommon.NewContractIntegrator(c.chainConfig, consortiumCommon.NewConsortiumBackend(c.ethAPI), signTxFn, coinbase)
+		contract, err := consortiumCommon.NewContractIntegrator(c.chainConfig, consortiumCommon.NewConsortiumBackend(c.ethAPI), signTxFn, coinbase, c.ethAPI)
 		if err != nil {
 			return err
 		}

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -49,7 +49,7 @@ const (
 
 	finalityRatio                  float64 = 2.0 / 3
 	assemblingFinalityVoteDuration         = 1 * time.Second
-	MaxValidatorCandidates                 = 64 // Maximum number of validator candidates (aka voters for a block).
+	MaxValidatorCandidates                 = 64 // Maximum number of validator candidates.
 	dayInSeconds                           = uint64(86400)
 )
 
@@ -466,7 +466,7 @@ func (c *Consortium) snapshot(chain consensus.ChainHeaderReader, number uint64, 
 
 		// this case is only happened in mock mode
 		if number == 0 {
-			validators, err := c.contract.GetBlockProducers(common.Big0)
+			validators, err := c.contract.GetBlockProducers(common.Hash{}, common.Big0)
 			if err != nil {
 				return nil, err
 			}
@@ -485,9 +485,8 @@ func (c *Consortium) snapshot(chain consensus.ChainHeaderReader, number uint64, 
 				break
 			}
 
-			// get validators set from number
 			_, _, _, contract := c.readSignerAndContract()
-			validators, err := contract.GetBlockProducers(big.NewInt(0).SetUint64(number))
+			validators, err := contract.GetBlockProducers(common.Hash{}, new(big.Int).SetUint64(number))
 			if err != nil {
 				log.Error("Load validators at the beginning failed", "err", err)
 				return nil, err
@@ -703,41 +702,35 @@ func (c *Consortium) getCheckpointValidatorsFromContract(
 	header *types.Header,
 ) ([]finality.ValidatorWithBlsPub, []common.Address, error) {
 	parentBlockNumber := new(big.Int).Sub(header.Number, common.Big1)
+	parentHash := header.ParentHash
 	_, _, _, contract := c.readSignerAndContract()
 
-	blockProducers, err := contract.GetBlockProducers(parentBlockNumber)
+	blockProducers, err := contract.GetBlockProducers(parentHash, parentBlockNumber)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var checkpointValidators []finality.ValidatorWithBlsPub
 
-	// After Tripp, bls key and staked amount are read only once at
-	// the start of new period, whereas block producer address is read
-	// at the start of every epoch.
 	if c.IsTrippEffective(chain, header) {
 		sort.Sort(validatorsAscending(blockProducers))
 		if !isPeriodBlock {
 			return nil, blockProducers, nil
 		}
-		validatorCandidates, err := contract.GetValidatorCandidates(parentBlockNumber)
+		validatorCandidates, err := contract.GetValidatorCandidates(parentHash, parentBlockNumber)
 		if err != nil {
 			return nil, nil, err
 		}
-		// After Tripp, there is a upper bound for the number of validator candidates
-		// (aka voters for blocks) during a period, which is ensured by the contract.
-		// However, we add additional check here to ensure that the field FinalityVoteBitSet
-		// (of type uint64) works in proper manner.
 		if len(validatorCandidates) > MaxValidatorCandidates {
 			validatorCandidates = validatorCandidates[:MaxValidatorCandidates]
 		}
-		stakedAmounts, err := c.contract.GetStakedAmount(header.Number, validatorCandidates)
+		stakedAmounts, err := c.contract.GetStakedAmount(parentHash, parentBlockNumber, validatorCandidates)
 		if err != nil {
 			return nil, nil, err
 		}
 		weights := consortiumCommon.NormalizeFinalityVoteWeight(stakedAmounts)
 		for i, candidate := range validatorCandidates {
-			blsPublicKey, err := contract.GetBlsPublicKey(parentBlockNumber, candidate)
+			blsPublicKey, err := contract.GetBlsPublicKey(parentHash, parentBlockNumber, candidate)
 			if err == nil {
 				checkpointValidators = append(checkpointValidators, finality.ValidatorWithBlsPub{
 					Address:      candidate,
@@ -759,7 +752,7 @@ func (c *Consortium) getCheckpointValidatorsFromContract(
 		// See more: https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 		filteredValidators = filteredValidators[:0]
 		for _, validator := range blockProducers {
-			blsPublicKey, err := contract.GetBlsPublicKey(parentBlockNumber, validator)
+			blsPublicKey, err := contract.GetBlsPublicKey(parentHash, parentBlockNumber, validator)
 			if err == nil {
 				filteredValidators = append(filteredValidators, validator)
 				blsPublicKeys = append(blsPublicKeys, blsPublicKey)
@@ -1288,7 +1281,7 @@ func (c *Consortium) initContract(coinbase common.Address, signTxFn consortiumCo
 		return nil
 	}
 	var err error
-	c.contract, err = consortiumCommon.NewContractIntegrator(c.chainConfig, consortiumCommon.NewConsortiumBackend(c.ethAPI), signTxFn, coinbase)
+	c.contract, err = consortiumCommon.NewContractIntegrator(c.chainConfig, consortiumCommon.NewConsortiumBackend(c.ethAPI), signTxFn, coinbase, c.ethAPI)
 	return err
 }
 

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -1009,7 +1009,7 @@ func (contract *mockContract) FinalityReward(opts *consortiumCommon.ApplyTransac
 	return nil
 }
 
-func (contract *mockContract) GetBlockProducers(*big.Int) ([]common.Address, error) {
+func (contract *mockContract) GetBlockProducers(_ common.Hash, _ *big.Int) ([]common.Address, error) {
 	var validatorAddresses []common.Address
 	for address := range contract.validators {
 		validatorAddresses = append(validatorAddresses, address)
@@ -1017,11 +1017,11 @@ func (contract *mockContract) GetBlockProducers(*big.Int) ([]common.Address, err
 	return validatorAddresses, nil
 }
 
-func (contract *mockContract) GetValidatorCandidates(blockNumber *big.Int) ([]common.Address, error) {
+func (contract *mockContract) GetValidatorCandidates(_ common.Hash, _ *big.Int) ([]common.Address, error) {
 	return nil, nil
 }
 
-func (contract *mockContract) GetBlsPublicKey(_ *big.Int, address common.Address) (blsCommon.PublicKey, error) {
+func (contract *mockContract) GetBlsPublicKey(_ common.Hash, _ *big.Int, address common.Address) (blsCommon.PublicKey, error) {
 	if key, ok := contract.validators[address]; ok {
 		if key != nil {
 			return key, nil
@@ -1033,7 +1033,7 @@ func (contract *mockContract) GetBlsPublicKey(_ *big.Int, address common.Address
 	}
 }
 
-func (contract *mockContract) GetStakedAmount(_ *big.Int, _ []common.Address) ([]*big.Int, error) {
+func (contract *mockContract) GetStakedAmount(_ common.Hash, _ *big.Int, _ []common.Address) ([]*big.Int, error) {
 	return nil, nil
 }
 

--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -172,8 +172,8 @@ type HeaderExtraData struct {
 	HasFinalityVote         uint8                 // determine if the header extra has the finality vote
 	FinalityVotedValidators FinalityVoteBitSet    // the bit set of validators that vote for finality
 	AggregatedFinalityVotes blsCommon.Signature   // aggregated BLS signatures for finality vote
-	CheckpointValidators    []ValidatorWithBlsPub // validator addresses and BLS public key appended at period checkpoint block
-	BlockProducers          []common.Address      // block producer addresses at epoch checkpoint block
+	CheckpointValidators    []ValidatorWithBlsPub // validator addresses and BLS public key updated at period block
+	BlockProducers          []common.Address      // block producer addresses updated at epoch block
 	Seal                    [ExtraSeal]byte       // the sealing block signature
 }
 


### PR DESCRIPTION
* To tackle reorg-based attack, this PR changes contract query to using block hash.
* Minor fix: newLimit would be updated with new rule after Tripp effective 