### PR TITLE
accountcmd: return error instead of exit in loadBlsSecretKey

### DIFF
--- a/cmd/ronin/accountcmd.go
+++ b/cmd/ronin/accountcmd.go
@@ -516,7 +516,7 @@ func loadKeyManager(ctx *cli.Context) (*bls.KeyManager, []blsCommon.PublicKey, e
 
 func loadBlsSecretKey(ctx *cli.Context) (blsCommon.SecretKey, error) {
 	if ctx.Args().Len() != 1 {
-		utils.Fatalf("keyfile must be given as the only argument")
+		return nil, fmt.Errorf("keyfile must be given as the only argument")
 	}
 	keyfile := ctx.Args().First()
 	if len(keyfile) == 0 {


### PR DESCRIPTION
loadBlsSecretKey is called in `account generate-bls-proof` to support loading BLS secret key from file. But this command also supports loading secret key from keystore. In that case, no keyfile is given and this function should return error so the command can handle the error and switch to load secret key from keystore instead of exit.