### PR TITLE
consortium-v2: add missing weight field to our customized json marshal

### DIFF
--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -110,7 +110,7 @@ func (validator *ValidatorWithBlsPub) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (validator *ValidatorWithBlsPub) MarshalJSON() ([]byte, error) {
+func (validator ValidatorWithBlsPub) MarshalJSON() ([]byte, error) {
 	savedValidator := savedValidatorWithBlsPub{
 		Address: validator.Address,
 	}

--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -107,12 +107,14 @@ func (validator *ValidatorWithBlsPub) UnmarshalJSON(input []byte) error {
 	if err != nil {
 		return err
 	}
+	validator.Weight = savedValidator.Weight
 	return nil
 }
 
 func (validator ValidatorWithBlsPub) MarshalJSON() ([]byte, error) {
 	savedValidator := savedValidatorWithBlsPub{
 		Address: validator.Address,
+		Weight:  validator.Weight,
 	}
 
 	if validator.BlsPublicKey != nil {

--- a/consensus/consortium/v2/finality/consortium_header_test.go
+++ b/consensus/consortium/v2/finality/consortium_header_test.go
@@ -1,6 +1,13 @@
 package finality
 
-import "testing"
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/bls/blst"
+)
 
 func TestFinalityVoteBitSet(t *testing.T) {
 	var bitSet FinalityVoteBitSet
@@ -35,5 +42,36 @@ func TestFinalityVoteBitSet(t *testing.T) {
 	// index >= 64 returns 0
 	if bitSet.GetBit(70) != 0 {
 		t.Fatalf("Wrong bit, exp %d got %d", 0, bitSet.GetBit(70))
+	}
+}
+
+func TestMarshallJsonValidatorWithPub(t *testing.T) {
+	blsPubkey, err := blst.PublicKeyFromBytes(common.Hex2Bytes("affe116dad1eb59bda4dc6a6442a891c1b19502c07acff7304a070a5d53b7bf89c01d6985a1ad0d86b009b39e5cd7a9e"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	validator := ValidatorWithBlsPub{
+		Address:      common.BigToAddress(big.NewInt(1)),
+		BlsPublicKey: blsPubkey,
+		Weight:       100,
+	}
+	marshalled, err := json.Marshal(validator)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var unmarshalledValidator ValidatorWithBlsPub
+	err = json.Unmarshal(marshalled, &unmarshalledValidator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if validator.Address != unmarshalledValidator.Address {
+		t.Fatalf("Address mismatches, got %v expect %v", unmarshalledValidator.Address, validator.Address)
+	}
+	if !validator.BlsPublicKey.Equals(unmarshalledValidator.BlsPublicKey) {
+		t.Fatalf("BLS public key mismatches, got %v expect %v", unmarshalledValidator.BlsPublicKey, validator.BlsPublicKey)
+	}
+	if validator.Weight != unmarshalledValidator.Weight {
+		t.Fatalf("Weight mismatches, got %d expect %d", unmarshalledValidator.Weight, validator.Weight)
 	}
 }


### PR DESCRIPTION
- consortium-v2: define MarshalJSON on a non-pointer ValidatorWithBlsPub

We want json.Marshal to invoke our custom MarshalJSON when be called with
non-pointer ValidatorWithBlsPub. In order to do that, we need to define
MarshalJSON on a non-pointer receiver.

- consortium-v2: add missing weight field to our customized json marshal