### PR TITLE
genesis: add Tripp hardfork on testnet

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -32,6 +32,10 @@
     "shillinBlock": 20268000,
     "antennaBlock": 20737258,
     "mikoBlock": 23694400,
+    "berlinBlock": 34871800,
+    "londonBlock": 34871800,
+    "trippBlock": 34871800,
+    "trippPeriod": 19866,
     "whiteListDeployerContractV2Address": "0x50a7e07Aa75eB9C04281713224f50403cA79851F",
     "roninTrustedOrgUpgrade": {
       "proxyAddress": "0x7507dc433a98E1fE105d69f19f3B40E4315A4F32",

--- a/params/version.go
+++ b/params/version.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	VersionMajor = 2  // Major version component of the current release
-	VersionMinor = 7  // Minor version component of the current release
-	VersionPatch = 1  // Patch version component of the current release
+	VersionMinor = 8  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
The hardfork is scheduled around 7:00 UTC May 23rd, 2024 at block 34871800 (https://app.roninchain.com/block/34871800)