### PR TITLE
genesis: update Tripp hardfork on testnet

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -32,9 +32,9 @@
     "shillinBlock": 20268000,
     "antennaBlock": 20737258,
     "mikoBlock": 23694400,
-    "berlinBlock": 34871800,
-    "londonBlock": 34871800,
-    "trippBlock": 34871800,
+    "berlinBlock": 27580600,
+    "londonBlock": 27580600,
+    "trippBlock": 27580600,
     "trippPeriod": 19866,
     "whiteListDeployerContractV2Address": "0x50a7e07Aa75eB9C04281713224f50403cA79851F",
     "roninTrustedOrgUpgrade": {


### PR DESCRIPTION
The hardfork is scheduled around 7:00 UTC May 23rd, 2024 at block 27580600 (https://saigon-app.roninchain.com/block/27580600).