### PR TITLE
core/vm: change Consortium precompiled mapping into global variable

### DIFF
--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -84,23 +84,15 @@ func init() {
 	}
 }
 
-func PrecompiledContractsConsortium(caller ContractRef, evm *EVM) map[common.Address]PrecompiledContract {
-	return map[common.Address]PrecompiledContract{
-		common.BytesToAddress([]byte{101}): &consortiumLog{},
-		common.BytesToAddress([]byte{102}): &consortiumValidatorSorting{caller: caller, evm: evm},
-		common.BytesToAddress([]byte{103}): &consortiumVerifyHeaders{caller: caller, evm: evm},
-		common.BytesToAddress([]byte{104}): &consortiumPickValidatorSet{caller: caller, evm: evm},
-		common.BytesToAddress([]byte{105}): &consortiumValidateFinalityProof{caller: caller, evm: evm},
-	}
-}
-
-func PrecompiledContractsConsortiumMiko(caller ContractRef, evm *EVM) map[common.Address]PrecompiledContract {
-	contracts := PrecompiledContractsConsortium(caller, evm)
-	contracts[common.BytesToAddress([]byte{106})] = &consortiumValidateProofOfPossession{caller: caller, evm: evm}
-	return contracts
+type PrecompiledContractWithInit interface {
+	PrecompiledContract
+	Init(caller ContractRef, evm *EVM)
 }
 
 type consortiumLog struct{}
+
+func (c *consortiumLog) Init(_ ContractRef, _ *EVM) {
+}
 
 func (c *consortiumLog) RequiredGas(_ []byte) uint64 {
 	return 0
@@ -143,6 +135,11 @@ func isSystemContractCaller(caller ContractRef, evm *EVM) error {
 type consortiumPickValidatorSet struct {
 	caller ContractRef
 	evm    *EVM
+}
+
+func (c *consortiumPickValidatorSet) Init(caller ContractRef, evm *EVM) {
+	c.caller = caller
+	c.evm = evm
 }
 
 func (c *consortiumPickValidatorSet) RequiredGas(input []byte) uint64 {
@@ -276,6 +273,11 @@ func arrangeValidatorCandidates(candidates []common.Address, newValidatorCount u
 type consortiumValidatorSorting struct {
 	caller ContractRef
 	evm    *EVM
+}
+
+func (c *consortiumValidatorSorting) Init(caller ContractRef, evm *EVM) {
+	c.caller = caller
+	c.evm = evm
 }
 
 func (c *consortiumValidatorSorting) RequiredGas(input []byte) uint64 {
@@ -433,6 +435,11 @@ type consortiumVerifyHeaders struct {
 	evm    *EVM
 
 	test bool
+}
+
+func (c *consortiumVerifyHeaders) Init(caller ContractRef, evm *EVM) {
+	c.caller = caller
+	c.evm = evm
 }
 
 func (c *consortiumVerifyHeaders) RequiredGas(_ []byte) uint64 {
@@ -616,6 +623,11 @@ type consortiumValidateFinalityProof struct {
 	evm    *EVM
 }
 
+func (c *consortiumValidateFinalityProof) Init(caller ContractRef, evm *EVM) {
+	c.caller = caller
+	c.evm = evm
+}
+
 func (contract *consortiumValidateFinalityProof) RequiredGas(input []byte) uint64 {
 	return params.ValidateFinalityProofGas
 }
@@ -726,6 +738,11 @@ func (contract *consortiumValidateFinalityProof) Run(input []byte) ([]byte, erro
 type consortiumValidateProofOfPossession struct {
 	caller ContractRef
 	evm    *EVM
+}
+
+func (c *consortiumValidateProofOfPossession) Init(caller ContractRef, evm *EVM) {
+	c.caller = caller
+	c.evm = evm
 }
 
 func (contract *consortiumValidateProofOfPossession) RequiredGas(input []byte) uint64 {

--- a/core/vm/consortium_precompiled_contracts_test.go
+++ b/core/vm/consortium_precompiled_contracts_test.go
@@ -1840,7 +1840,7 @@ func newEVM(caller common.Address, statedb StateDB) (*EVM, error) {
 		},
 		chainConfig: params.TestChainConfig,
 		StateDB:     statedb,
-		chainRules:  params.Rules{IsIstanbul: true, IsEIP150: true},
+		chainRules:  params.Rules{IsIstanbul: true, IsEIP150: true, IsConsortiumV2: true},
 	}
 	evm.chainConfig.ConsortiumV2Block = common.Big1
 	evm.interpreter = NewEVMInterpreter(evm, Config{NoBaseFee: true})

--- a/core/vm/evm_test.go
+++ b/core/vm/evm_test.go
@@ -740,3 +740,72 @@ func TestInternalTransactionOrderDelegateCalls(t *testing.T) {
 		}
 	}
 }
+
+func TestConsortiumPrecompileQuery(t *testing.T) {
+	evm := EVM{
+		chainConfig: &params.ChainConfig{},
+		chainRules: params.Rules{
+			IsMiko: true,
+		},
+	}
+	caller := AccountRef(common.Address{0x1})
+	precompiledContract, ok := evm.precompile(caller, common.BytesToAddress([]byte{106}))
+	if !ok {
+		t.Fatal("Failed to get Miko precompiled contract")
+	}
+
+	p, ok := precompiledContract.(*consortiumValidateProofOfPossession)
+	if !ok {
+		t.Fatal("Incorrect precompiled contract")
+	}
+
+	if p.evm != &evm {
+		t.Fatal("Incorrect evm in precompiled contract")
+	}
+
+	if p.caller != caller {
+		t.Fatal("Incorrect caller in precompiled contract")
+	}
+
+	precompiledContract, ok = evm.precompile(caller, common.BytesToAddress([]byte{1}))
+	if !ok {
+		t.Fatal("Failed to get ecrecover precompiled contract")
+	}
+	if _, ok := precompiledContract.(*ecrecover); !ok {
+		t.Fatal("Wrong ecrecover contract")
+	}
+
+	// Check precompiled contract after Berlin
+	evm.chainRules.IsBerlin = true
+	precompiledContract, ok = evm.precompile(caller, common.BytesToAddress([]byte{106}))
+	if !ok {
+		t.Fatal("Failed to get Miko precompiled contract")
+	}
+	p, ok = precompiledContract.(*consortiumValidateProofOfPossession)
+	if !ok {
+		t.Fatal("Incorrect precompiled contract")
+	}
+
+	if p.evm != &evm {
+		t.Fatal("Incorrect evm in precompiled contract")
+	}
+
+	if p.caller != caller {
+		t.Fatal("Incorrect caller in precompiled contract")
+	}
+}
+
+func BenchmarkConsortiumPrecompileQuery(b *testing.B) {
+	evm := EVM{
+		chainConfig: &params.ChainConfig{},
+		chainRules: params.Rules{
+			IsMiko: true,
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		evm.precompile(nil, common.BytesToAddress([]byte{106}))
+	}
+}


### PR DESCRIPTION
precompile query is a hot function which is called in every call related opcode.
This commit tries to optimize this function by making the Consortium precompiled
contract mapping into global variable so that precompile query does not need to
dynamically allocate the mapping every time it is called.

~ go test -bench=BenchmarkConsortiumPrecompileQuery -benchtime=5s -tags=blst_enabled

Before:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkConsortiumPrecompileQuery-8     4216357              2402 ns/op            1166 B/op          9 allocs/op
```
After:
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkConsortiumPrecompileQuery-8    100000000               50.40 ns/op           24 B/op          1 allocs/op
```