### PR TITLE
p2p,eth: add dial, eth handshakes and traffic metrics

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
@@ -408,6 +409,13 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 
 	if err := h.peers.registerSnapExtension(peer); err != nil {
 		peer.Log().Info("Snapshot extension registration failed", "err", err)
+		if metrics.Enabled {
+			if peer.Inbound() {
+				snap.IngressRegistrationErrorMeter.Mark(1)
+			} else {
+				snap.EgressRegistrationErrorMeter.Mark(1)
+			}
+		}
 		return err
 	}
 	return handler(peer)

--- a/eth/protocols/eth/handshake.go
+++ b/eth/protocols/eth/handshake.go
@@ -17,12 +17,14 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
@@ -59,9 +61,11 @@ func (p *Peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 		select {
 		case err := <-errc:
 			if err != nil {
+				markError(p, err)
 				return err
 			}
 		case <-timeout.C:
+			markError(p, p2p.DiscReadTimeout)
 			return p2p.DiscReadTimeout
 		}
 	}
@@ -104,4 +108,27 @@ func (p *Peer) readStatus(network uint64, status *StatusPacket, genesis common.H
 		return fmt.Errorf("%w: %v", errForkIDRejected, err)
 	}
 	return nil
+}
+
+// markError registers the error with the corresponding metric.
+func markError(p *Peer, err error) {
+	if !metrics.Enabled {
+		return
+	}
+	m := meters.get(p.Inbound())
+
+	switch errors.Unwrap(err) {
+	case errNetworkIDMismatch:
+		m.networkIDMismatch.Mark(1)
+	case errProtocolVersionMismatch:
+		m.protocolVersionMismatch.Mark(1)
+	case errGenesisMismatch:
+		m.genesisMismatch.Mark(1)
+	case errForkIDRejected:
+		m.forkidRejected.Mark(1)
+	case p2p.DiscReadTimeout:
+		m.timeoutError.Mark(1)
+	default:
+		m.peerError.Mark(1)
+	}
 }

--- a/eth/protocols/eth/metrics.go
+++ b/eth/protocols/eth/metrics.go
@@ -1,0 +1,60 @@
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+// meters stores ingress and egress handshake meters.
+var meters bidirectionalMeters
+
+// bidirectionalMeters stores ingress and egress handshake meters.
+
+type bidirectionalMeters struct {
+	ingress *hsMeters
+	egress  *hsMeters
+}
+
+// get returns the corresponding meter depending if ingress or egress is desired
+func (h *bidirectionalMeters) get(ingress bool) *hsMeters {
+	if ingress {
+		return h.ingress
+	}
+	return h.egress
+}
+
+// hsMeters is a collection of meters which track metrics related to the eth subprotocol handshake.
+type hsMeters struct {
+	// peerError measures the number of errorrs related to incorrect peer behaviour, such as invalid message code, size, encoding, etc.
+	peerError metrics.Meter
+	// timeoutError measures the number of timeouts.
+	timeoutError metrics.Meter
+	// networkIDMismatch measures the number of network ID mismatches.
+	networkIDMismatch metrics.Meter
+	// protocolVersionMismatch measures the number of differing protocol versions.
+	protocolVersionMismatch metrics.Meter
+	// genesisMismatch measures the number of differing genesies.
+	genesisMismatch metrics.Meter
+
+	// forkidRejected measures the number of rejected fork IDs.
+	forkidRejected metrics.Meter
+}
+
+// newHandshakeMeters registers and returns handshake meters for the given base.
+func newHandshakeMeters(base string) *hsMeters {
+	return &hsMeters{
+		peerError:               metrics.NewRegisteredMeter(base+"error/peer", nil),
+		timeoutError:            metrics.NewRegisteredMeter(base+"error/timeout", nil),
+		networkIDMismatch:       metrics.NewRegisteredMeter(base+"error/network", nil),
+		protocolVersionMismatch: metrics.NewRegisteredMeter(base+"error/version", nil),
+		genesisMismatch:         metrics.NewRegisteredMeter(base+"error/genesis", nil),
+		forkidRejected:          metrics.NewRegisteredMeter(base+"error/forkid", nil),
+	}
+}
+
+func init() {
+	// Init meters for eth handshakeMeters.
+	meters = bidirectionalMeters{
+		ingress: newHandshakeMeters("eth/protocols/eth/ingress/handshake/"),
+		egress:  newHandshakeMeters("eth/protocols/eth/egress/handshake/"),
+	}
+}

--- a/eth/protocols/snap/metrics.go
+++ b/eth/protocols/snap/metrics.go
@@ -1,0 +1,11 @@
+package snap
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+var (
+	ingressRegistrationErrorName = "eth/protocols/snap/ingress/registration/error"
+	egressRegistrationErrorName  = "eth/protocols/snap/egress/registration/error"
+
+	IngressRegistrationErrorMeter = metrics.NewRegisteredMeter(ingressRegistrationErrorName, nil)
+	EgressRegistrationErrorMeter  = metrics.NewRegisteredMeter(egressRegistrationErrorName, nil)
+)

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -84,13 +84,12 @@ var (
 // dialer creates outbound connections and submits them into Server.
 // Two types of peer connections can be created:
 //
-//  - static dials are pre-configured connections. The dialer attempts
-//    keep these nodes connected at all times.
+//   - static dials are pre-configured connections. The dialer attempts
+//     keep these nodes connected at all times.
 //
-//  - dynamic dials are created from node discovery results. The dialer
-//    continuously reads candidate nodes from its input iterator and attempts
-//    to create peer connections to nodes arriving through the iterator.
-//
+//   - dynamic dials are created from node discovery results. The dialer
+//     continuously reads candidate nodes from its input iterator and attempts
+//     to create peer connections to nodes arriving through the iterator.
 type dialScheduler struct {
 	dialConfig
 	setupFunc   dialSetupFunc
@@ -535,13 +534,14 @@ func (t *dialTask) resolve(d *dialScheduler) bool {
 
 // dial performs the actual connection attempt.
 func (t *dialTask) dial(d *dialScheduler, dest *enode.Node) error {
+	dialMeter.Mark(1)
 	fd, err := d.dialer.Dial(d.ctx, t.dest)
 	if err != nil {
 		d.log.Trace("Dial error", "id", t.dest.ID(), "addr", nodeAddr(t.dest), "conn", t.flags, "err", cleanupDialErr(err))
+		dialConnectionError.Mark(1)
 		return &dialError{err}
 	}
-	mfd := newMeteredConn(fd, false, &net.TCPAddr{IP: dest.IP(), Port: dest.TCP()})
-	return d.setupFunc(mfd, t.flags, dest)
+	return d.setupFunc(newMeteredConn(fd), t.flags, dest)
 }
 
 func (t *dialTask) String() string {

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -1,0 +1,32 @@
+package discover
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+const (
+	moduleName = "discover"
+
+	// ingressMeterName is the prefix of the per-packet inbound metrics
+	ingressMeterName = moduleName + "/ingress"
+
+	// egressMeterName is the prefix of the per-packet outbound metrics
+	egressMeterName = moduleName + "/egress"
+)
+
+var (
+	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
+)
+
+type meteredUdpConn struct {
+	UDPConn
+}
+
+func newMeteredConn(conn UDPConn) UDPConn {
+	// Short circuit if metrics are disabled
+	if !metrics.Enabled {
+		return conn
+	}
+	return &meteredUdpConn{UDPConn: conn}
+}
+
+// Read delegates a network read to the underlying connection, bumpding the 

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -17,14 +17,14 @@ const (
 )
 
 var (
-	bucketGauge         []metrics.Gauge
+	bucketsCounter      []metrics.Counter
 	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
 	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
 )
 
 func init() {
 	for i := 0; i < nBuckets; i++ {
-		bucketGauge = append(bucketGauge, metrics.NewRegisteredGauge(fmt.Sprintf("%s/bucket/%d/count", moduleName, i), nil))
+		bucketsCounter = append(bucketsCounter, metrics.NewRegisteredCounter(fmt.Sprintf("%s/bucket/%d/count", moduleName, i), nil))
 	}
 }
 

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -1,6 +1,10 @@
 package discover
 
-import "github.com/ethereum/go-ethereum/metrics"
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/metrics"
+)
 
 const (
 	moduleName = "discover"
@@ -13,9 +17,16 @@ const (
 )
 
 var (
+	bucketGauge         []metrics.Gauge
 	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
 	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
 )
+
+func init() {
+	for i := 0; i < nBuckets; i++ {
+		bucketGauge = append(bucketGauge, metrics.NewRegisteredGauge(fmt.Sprintf("%s/bucket/%d/count", moduleName, i), nil))
+	}
+}
 
 type meteredUdpConn struct {
 	UDPConn
@@ -29,4 +40,4 @@ func newMeteredConn(conn UDPConn) UDPConn {
 	return &meteredUdpConn{UDPConn: conn}
 }
 
-// Read delegates a network read to the underlying connection, bumpding the 
+// Read delegates a network read to the underlying connection, bumpding the

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -1,18 +1,34 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package discover
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/ethereum/go-ethereum/metrics"
 )
 
 const (
 	moduleName = "discover"
-
-	// ingressMeterName is the prefix of the per-packet inbound metrics
+	// ingressMeterName is the prefix of the per-packet inbound metrics.
 	ingressMeterName = moduleName + "/ingress"
 
-	// egressMeterName is the prefix of the per-packet outbound metrics
+	// egressMeterName is the prefix of the per-packet outbound metrics.
 	egressMeterName = moduleName + "/egress"
 )
 
@@ -40,4 +56,16 @@ func newMeteredConn(conn UDPConn) UDPConn {
 	return &meteredUdpConn{UDPConn: conn}
 }
 
-// Read delegates a network read to the underlying connection, bumpding the
+// Read delegates a network read to the underlying connection, bumping the udp ingress traffic meter along the way.
+func (c *meteredUdpConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
+	n, addr, err = c.UDPConn.ReadFromUDP(b)
+	ingressTrafficMeter.Mark(int64(n))
+	return n, addr, err
+}
+
+// Write delegates a network write to the underlying connection, bumping the udp egress traffic meter along the way.
+func (c *meteredUdpConn) WriteToUDP(b []byte, addr *net.UDPAddr) (n int, err error) {
+	n, err = c.UDPConn.WriteToUDP(b, addr)
+	egressTrafficMeter.Mark(int64(n))
+	return n, err
+}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -492,7 +492,7 @@ func (tab *Table) addSeenNode(n *node) {
 		tab.nodeAddedHook(n)
 	}
 	if metrics.Enabled {
-		bucketGauge[b.index].Inc(1)
+		bucketsCounter[b.index].Inc(1)
 	}
 }
 
@@ -537,7 +537,7 @@ func (tab *Table) addVerifiedNode(n *node) {
 		tab.nodeAddedHook(n)
 	}
 	if metrics.Enabled {
-		bucketGauge[b.index].Inc(1)
+		bucketsCounter[b.index].Inc(1)
 	}
 }
 
@@ -637,7 +637,7 @@ func (tab *Table) bumpInBucket(b *bucket, n *node) bool {
 
 func (tab *Table) deleteInBucket(b *bucket, n *node) {
 	if metrics.Enabled {
-		bucketGauge[b.index].Dec(1)
+		bucketsCounter[b.index].Dec(1)
 	}
 	b.entries = deleteNode(b.entries, n)
 	tab.removeIP(b, n.IP())

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -80,7 +80,8 @@ type Table struct {
 	closeReq   chan struct{}
 	closed     chan struct{}
 
-	nodeAddedHook func(*node) // for testing
+	nodeAddedHook   func(*bucket, *node)
+	nodeRemovedHook func(*bucket, *node)
 }
 
 // transport is implemented by the UDP transports.
@@ -125,6 +126,22 @@ func newTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger
 	tab.seedRand()
 	tab.loadSeedNodes()
 
+	return tab, nil
+}
+
+func newMeteredTable(t transport, db *enode.DB, bootnodes []*enode.Node, log log.Logger) (*Table, error) {
+	tab, err := newTable(t, db, bootnodes, log)
+	if err != nil {
+		return nil, err
+	}
+	if metrics.Enabled {
+		tab.nodeAddedHook = func(b *bucket, n *node) {
+			bucketsCounter[b.index].Inc(1)
+		}
+		tab.nodeRemovedHook = func(b *bucket, n *node) {
+			bucketsCounter[b.index].Dec(1)
+		}
+	}
 	return tab, nil
 }
 
@@ -489,10 +506,7 @@ func (tab *Table) addSeenNode(n *node) {
 	b.replacements = deleteNode(b.replacements, n)
 	n.addedAt = time.Now()
 	if tab.nodeAddedHook != nil {
-		tab.nodeAddedHook(n)
-	}
-	if metrics.Enabled {
-		bucketsCounter[b.index].Inc(1)
+		tab.nodeAddedHook(b, n)
 	}
 }
 
@@ -534,10 +548,7 @@ func (tab *Table) addVerifiedNode(n *node) {
 	b.replacements = deleteNode(b.replacements, n)
 	n.addedAt = time.Now()
 	if tab.nodeAddedHook != nil {
-		tab.nodeAddedHook(n)
-	}
-	if metrics.Enabled {
-		bucketsCounter[b.index].Inc(1)
+		tab.nodeAddedHook(b, n)
 	}
 }
 
@@ -636,11 +647,17 @@ func (tab *Table) bumpInBucket(b *bucket, n *node) bool {
 }
 
 func (tab *Table) deleteInBucket(b *bucket, n *node) {
-	if metrics.Enabled {
-		bucketsCounter[b.index].Dec(1)
+	// Check if node is actually in the bucket so the removed hook
+	// isn't called multipled for the same node.
+	if !contains(b.entries, n.ID()) {
+		return
 	}
+
 	b.entries = deleteNode(b.entries, n)
 	tab.removeIP(b, n.IP())
+	if tab.nodeRemovedHook != nil {
+		tab.nodeRemovedHook(b, n)
+	}
 }
 
 func contains(ns []*node, id enode.ID) bool {

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -130,7 +130,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 	cfg = cfg.withDefaults()
 	closeCtx, cancel := context.WithCancel(context.Background())
 	t := &UDPv4{
-		conn:            c,
+		conn:            newMeteredConn(c),
 		priv:            cfg.PrivateKey,
 		netrestrict:     cfg.NetRestrict,
 		localNode:       ln,

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -142,7 +142,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		log:             cfg.Log,
 	}
 
-	tab, err := newTable(t, ln.Database(), cfg.Bootnodes, t.log)
+	tab, err := newMeteredTable(t, ln.Database(), cfg.Bootnodes, t.log)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -394,7 +394,7 @@ func TestUDPv4_pingMatchIP(t *testing.T) {
 func TestUDPv4_successfulPing(t *testing.T) {
 	test := newUDPTest(t)
 	added := make(chan *node, 1)
-	test.table.nodeAddedHook = func(n *node) { added <- n }
+	test.table.nodeAddedHook = func(b *bucket, n *node) { added <- n }
 	defer test.close()
 
 	// The remote side sends a ping packet to initiate the exchange.

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -140,7 +140,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 	cfg = cfg.withDefaults()
 	t := &UDPv5{
 		// static fields
-		conn:         conn,
+		conn:         newMeteredConn(conn),
 		localNode:    ln,
 		db:           ln.Database(),
 		netrestrict:  cfg.NetRestrict,

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -164,7 +164,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newTable(t, t.db, cfg.Bootnodes, cfg.Log)
+	tab, err := newMeteredTable(t, t.db, cfg.Bootnodes, cfg.Log)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -19,6 +19,8 @@
 package p2p
 
 import (
+	"errors"
+	"fmt"
 	"net"
 
 	"github.com/ethereum/go-ethereum/metrics"
@@ -33,15 +35,74 @@ const (
 
 	// HandleHistName is the prefix of the per-packet serving time histograms.
 	HandleHistName = "p2p/handle"
+
+	// dialErrorMeterName is the prefix of the dial error metrics.
+	dialErrorMeterName = "p2p/dials/error"
 )
 
 var (
-	ingressConnectMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
-	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
-	egressConnectMeter  = metrics.NewRegisteredMeter("p2p/dials", nil)
-	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
-	activePeerGauge     = metrics.NewRegisteredGauge("p2p/peers", nil)
+	activePeerGauge     metrics.Gauge = metrics.NilGauge{}
+	ingressTrafficMeter               = metrics.NewRegisteredMeter(ingressMeterName, nil)
+	egressTrafficMeter                = metrics.NewRegisteredMeter(egressMeterName, nil)
+
+	// general ingress/egress connection meters
+	serveMeter          metrics.Meter = metrics.NilMeter{}
+	serveSuccessMeter   metrics.Meter = metrics.NilMeter{}
+	dialMeter           metrics.Meter = metrics.NilMeter{}
+	dialSuccessMeter    metrics.Meter = metrics.NilMeter{}
+	dialConnectionError metrics.Meter = metrics.NilMeter{}
+
+	// Handshake error meters
+	dialTooManyPeers        = metrics.NewRegisteredMeter(fmt.Sprintf("%s/saturated", dialErrorMeterName), nil)
+	dialAlreadyConnected    = metrics.NewRegisteredMeter(fmt.Sprintf("%s/known", dialErrorMeterName), nil)
+	dialSelf                = metrics.NewRegisteredMeter(fmt.Sprintf("%s/self", dialErrorMeterName), nil)
+	dialUselessPeer         = metrics.NewRegisteredMeter(fmt.Sprintf("%s/useless", dialErrorMeterName), nil)
+	dialUnexpectedIdentity  = metrics.NewRegisteredMeter(fmt.Sprintf("%s/id/unexpected", dialErrorMeterName), nil)
+	dialEncHandshakeError   = metrics.NewRegisteredMeter(fmt.Sprintf("%s/rlpx/enc", dialErrorMeterName), nil)
+	dialProtoHandshakeError = metrics.NewRegisteredMeter(fmt.Sprintf("%s/rlpx/proto", dialErrorMeterName), nil)
 )
+
+func init() {
+	if !metrics.Enabled {
+		return
+	}
+
+	activePeerGauge = metrics.NewRegisteredGauge("p2p/peers", nil)
+	serveMeter = metrics.NewRegisteredMeter("p2p/serves", nil)
+	serveSuccessMeter = metrics.NewRegisteredMeter("p2p/serves/success", nil)
+	dialMeter = metrics.NewRegisteredMeter("p2p/dials", nil)
+	dialSuccessMeter = metrics.NewRegisteredMeter("p2p/dials/success", nil)
+	dialConnectionError = metrics.NewRegisteredMeter(fmt.Sprintf("%s/connection", dialErrorMeterName), nil)
+}
+
+// markDialError matches error that occur while setting up a dial connection
+// to the coressponding error meter.
+func markDialError(err error) {
+	if !metrics.Enabled {
+		return
+	}
+
+	if err2 := errors.Unwrap(err); err2 != nil {
+		err = err2
+	}
+
+	switch err {
+	case DiscTooManyPeers:
+		dialTooManyPeers.Mark(1)
+	case DiscAlreadyConnected:
+		dialAlreadyConnected.Mark(1)
+	case DiscSelf:
+		dialSelf.Mark(1)
+	case DiscUselessPeer:
+		dialUselessPeer.Mark(1)
+	case DiscUnexpectedIdentity:
+		dialUnexpectedIdentity.Mark(1)
+	case errEncHandshakeError:
+		dialEncHandshakeError.Mark(1)
+	case errProtoHandshakeError:
+		dialProtoHandshakeError.Mark(1)
+	}
+}
 
 // meteredConn is a wrapper around a net.Conn that meters both the
 // inbound and outbound network traffic.
@@ -52,18 +113,12 @@ type meteredConn struct {
 // newMeteredConn creates a new metered connection, bumps the ingress or egress
 // connection meter and also increases the metered peer count. If the metrics
 // system is disabled, function returns the original connection.
-func newMeteredConn(conn net.Conn, ingress bool, addr *net.TCPAddr) net.Conn {
+func newMeteredConn(conn net.Conn) net.Conn {
 	// Short circuit if metrics are disabled
 	if !metrics.Enabled {
 		return conn
 	}
-	// Bump the connection counters and wrap the connection
-	if ingress {
-		ingressConnectMeter.Mark(1)
-	} else {
-		egressConnectMeter.Mark(1)
-	}
-	activePeerGauge.Inc(1)
+
 	return &meteredConn{Conn: conn}
 }
 
@@ -81,14 +136,4 @@ func (c *meteredConn) Write(b []byte) (n int, err error) {
 	n, err = c.Conn.Write(b)
 	egressTrafficMeter.Mark(int64(n))
 	return n, err
-}
-
-// Close delegates a close operation to the underlying connection, unregisters
-// the peer from the traffic registries and emits close event.
-func (c *meteredConn) Close() error {
-	err := c.Conn.Close()
-	if err == nil {
-		activePeerGauge.Dec(1)
-	}
-	return err
 }

--- a/p2p/server_test.go
+++ b/p2p/server_test.go
@@ -370,8 +370,6 @@ func TestServerSetupConn(t *testing.T) {
 		clientkey, srvkey = newkey(), newkey()
 		clientpub         = &clientkey.PublicKey
 		srvpub            = &srvkey.PublicKey
-		fooErr            = errors.New("foo")
-		readErr           = errors.New("read error")
 	)
 	tests := []struct {
 		dontstart bool
@@ -389,10 +387,10 @@ func TestServerSetupConn(t *testing.T) {
 			wantCloseErr: errServerStopped,
 		},
 		{
-			tt:           &setupTransport{pubkey: clientpub, encHandshakeErr: readErr},
+			tt:           &setupTransport{pubkey: clientpub, encHandshakeErr: errEncHandshakeError},
 			flags:        inboundConn,
 			wantCalls:    "doEncHandshake,close,",
-			wantCloseErr: readErr,
+			wantCloseErr: errEncHandshakeError,
 		},
 		{
 			tt:           &setupTransport{pubkey: clientpub, phs: protoHandshake{ID: randomID().Bytes()}},
@@ -402,11 +400,11 @@ func TestServerSetupConn(t *testing.T) {
 			wantCloseErr: DiscUnexpectedIdentity,
 		},
 		{
-			tt:           &setupTransport{pubkey: clientpub, protoHandshakeErr: fooErr},
+			tt:           &setupTransport{pubkey: clientpub, protoHandshakeErr: errProtoHandshakeError},
 			dialDest:     enode.NewV4(clientpub, nil, 0, 0),
 			flags:        dynDialedConn,
 			wantCalls:    "doEncHandshake,doProtoHandshake,close,",
-			wantCloseErr: fooErr,
+			wantCloseErr: errProtoHandshakeError,
 		},
 		{
 			tt:           &setupTransport{pubkey: srvpub, phs: protoHandshake{ID: crypto.FromECDSAPub(srvpub)[1:]}},


### PR DESCRIPTION
Referenced by https://github.com/ethereum/go-ethereum/pull/27621 and https://github.com/ethereum/go-ethereum/pull/27008 

**Description** 
This PR adds metrics for
*  The p2p dialer, which gives us visibility into the quality of the dial candidates given to us by our discovery methods ( Healthy of dial connections for showing failure related to multitude of reasons: wrong chain, too many peers, etc.) 
*  Trafic metrics for  discV4 and discV5 related to network usage. 

**Added Metrics**
* discover/bucket/{index}/count - the number of nodes in bucket index
* eth/protocols/eth/{ingress|egress}/handshake/error/peer - unexpected peer behavior
* eth/protocols/eth/{ingress|egress}/handshake/error/timeout - handshake timeout
* eth/protocols/eth/{ingress|egress}/handshake/error/network - wrong network id
* eth/protocols/eth/{ingress|egress}/handshake/error/version - wrong protocol version
* eth/protocols/eth/{ingress|egress}/handshake/error/genesis - wrong genesis
* eth/protocols/eth/{ingress|egress}/handshake/error/forkid - wrong forkid
* eth/protocols/snap/{ingress|egress}/registration/error - error registering snap protocol (usually snap, but no eth)
* p2p/dials/success - the total number of dials that result in a peer being added to the peerset
* p2p/dials/error/connection - unable to initiate TCP connection to target
* p2p/dials/error/saturated - local client is already connected to its maximum number of peers
* p2p/dials/error/known - dialing an already connected peer
* p2p/dials/error/self - dialing the local node's id
* p2p/dials/error/useless - dialing a peer that doesn't share an capabilities with the local node
* p2p/dials/error/id/unexpected - dialed peer repsoned with different id than expected
* p2p/dials/error/rlpx/enc - error negotiating the rlpx encryption during dial
* p2p/dials/error/rlpx/proto - error during rlpx protocol handshake`

**discv4 only** (Example)
![image](https://github.com/axieinfinity/ronin/assets/17699212/af359d96-1499-48b5-ab68-fd31d705632d)


