### PR TITLE
core/vm: optimize the mstore opcode with loop unrolling

### DIFF
--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -55,8 +55,6 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 	if offset+32 > uint64(len(m.store)) {
 		panic("invalid memory: store empty")
 	}
-	// Zero the memory area
-	copy(m.store[offset:offset+32], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
 	// Fill in relevant bits
 	val.WriteToSlice(m.store[offset:])
 }

--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -56,7 +56,49 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 		panic("invalid memory: store empty")
 	}
 	// Fill in relevant bits
-	val.WriteToSlice(m.store[offset:])
+	fastWriteToArray32((*[32]byte)(m.store[offset:offset+32]), val)
+}
+
+// fastWriteToArray32 is the same as WriteToArray32 in uint256 package
+// but with the loop unrolling manually for reducing branch instructions
+func fastWriteToArray32(dest *[32]byte, val *uint256.Int) {
+	// Unroll this loop manually
+	//
+	// for i := 0; i < 32; i++ {
+	//     dest[31-i] = byte(val[i/8] >> uint64(8*(i%8)))
+	// }
+	dest[31] = byte(val[0] >> uint64(0))
+	dest[30] = byte(val[0] >> uint64(8))
+	dest[29] = byte(val[0] >> uint64(16))
+	dest[28] = byte(val[0] >> uint64(24))
+	dest[27] = byte(val[0] >> uint64(32))
+	dest[26] = byte(val[0] >> uint64(40))
+	dest[25] = byte(val[0] >> uint64(48))
+	dest[24] = byte(val[0] >> uint64(56))
+	dest[23] = byte(val[1] >> uint64(0))
+	dest[22] = byte(val[1] >> uint64(8))
+	dest[21] = byte(val[1] >> uint64(16))
+	dest[20] = byte(val[1] >> uint64(24))
+	dest[19] = byte(val[1] >> uint64(32))
+	dest[18] = byte(val[1] >> uint64(40))
+	dest[17] = byte(val[1] >> uint64(48))
+	dest[16] = byte(val[1] >> uint64(56))
+	dest[15] = byte(val[2] >> uint64(0))
+	dest[14] = byte(val[2] >> uint64(8))
+	dest[13] = byte(val[2] >> uint64(16))
+	dest[12] = byte(val[2] >> uint64(24))
+	dest[11] = byte(val[2] >> uint64(32))
+	dest[10] = byte(val[2] >> uint64(40))
+	dest[9] = byte(val[2] >> uint64(48))
+	dest[8] = byte(val[2] >> uint64(56))
+	dest[7] = byte(val[3] >> uint64(0))
+	dest[6] = byte(val[3] >> uint64(8))
+	dest[5] = byte(val[3] >> uint64(16))
+	dest[4] = byte(val[3] >> uint64(24))
+	dest[3] = byte(val[3] >> uint64(32))
+	dest[2] = byte(val[3] >> uint64(40))
+	dest[1] = byte(val[3] >> uint64(48))
+	dest[0] = byte(val[3] >> uint64(56))
 }
 
 // Resize resizes the memory to size


### PR DESCRIPTION
- core/vm: remove unnecessary zero out memory

In Set32, the slice passed to WriteToSlice is guaranteed to be larger or equal
to 32 bytes. The WriteToSlice ensures to fill the first 32 bytes so it's
unnecessary to zero out first 32 bytes before passing to WriteToSlice.

- core/vm: optimize the mstore opcode with loop unrolling

Unroll the loop in WriteToArray32 manually to speed up the mstore opcode.

Benchmark with insertion sort

Machine information:
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz

~ perf stat go test -test.v -run=^$ -bench=BenchmarkInsertionSort -benchtime=100x

Before
```
BenchmarkInsertionSort
BenchmarkInsertionSort-8             100          72793386 ns/op
PASS
ok      github.com/ethereum/go-ethereum/core/vm 7.368s

 Performance counter stats for 'go test -test.v -run=^$ -bench=BenchmarkInsertionSort -benchtime=100x':

          8.433,38 msec task-clock                #    1,069 CPUs utilized
             4.463      context-switches          #  529,206 /sec
               446      cpu-migrations            #   52,885 /sec
            82.439      page-faults               #    9,775 K/sec
    36.119.625.206      cycles                    #    4,283 GHz
   127.498.724.623      instructions              #    3,53  insn per cycle
    22.194.992.920      branches                  #    2,632 G/sec
        42.121.383      branch-misses             #    0,19% of all branches
   175.263.808.230      slots                     #   20,782 G/sec
   121.989.373.351      topdown-retiring          #     62,4% retiring
    30.377.705.361      topdown-bad-spec          #     15,5% bad speculation
    10.337.693.104      topdown-fe-bound          #      5,3% frontend bound
    32.691.242.757      topdown-be-bound          #     16,7% backend bound

       7,887598146 seconds time elapsed

       8,222264000 seconds user
       0,237086000 seconds sys
```

After
```
BenchmarkInsertionSort
BenchmarkInsertionSort-8             100          60344587 ns/op
PASS
ok      github.com/ethereum/go-ethereum/core/vm 6.110s

 Performance counter stats for 'go test -test.v -run=^$ -bench=BenchmarkInsertionSort -benchtime=100x':

          7.143,06 msec task-clock                #    1,078 CPUs utilized
             4.433      context-switches          #  620,602 /sec
               448      cpu-migrations            #   62,718 /sec
            80.867      page-faults               #   11,321 K/sec
    28.995.367.330      cycles                    #    4,059 GHz
   102.778.094.969      instructions              #    3,54  insn per cycle
    19.293.661.260      branches                  #    2,701 G/sec
        16.767.179      branch-misses             #    0,09% of all branches
   139.420.266.760      slots                     #   19,518 G/sec
    98.857.898.738      topdown-retiring          #     68,2% retiring
    13.741.309.667      topdown-bad-spec          #      9,5% bad speculation
     8.494.075.060      topdown-fe-bound          #      5,9% frontend bound
    23.840.797.855      topdown-be-bound          #     16,4% backend bound

       6,628393702 seconds time elapsed

       6,970335000 seconds user
       0,198183000 seconds sys
```

~ perf stat go test -test.v -run=^$ -bench=BenchmarkOpMstore -benchtime=300000000x

Before
```
BenchmarkOpMstore
BenchmarkOpMstore-8     300000000               70.11 ns/op
PASS
ok      github.com/ethereum/go-ethereum/core/vm 21.048s

 Performance counter stats for 'go test -test.v -run=^$ -bench=BenchmarkOpMstore -benchtime=300000000x':

         22.109,55 msec task-clock                #    1,025 CPUs utilized
             6.028      context-switches          #  272,642 /sec
               557      cpu-migrations            #   25,193 /sec
            80.495      page-faults               #    3,641 K/sec
    99.285.697.133      cycles                    #    4,491 GHz
   346.575.732.070      instructions              #    3,49  insn per cycle
    37.792.770.164      branches                  #    1,709 G/sec
       315.291.142      branch-misses             #    0,83% of all branches
   483.943.055.760      slots                     #   21,888 G/sec
   315.983.571.358      topdown-retiring          #     63,5% retiring
    80.459.247.506      topdown-bad-spec          #     16,2% bad speculation
    27.796.507.388      topdown-fe-bound          #      5,6% frontend bound
    72.986.466.772      topdown-be-bound          #     14,7% backend bound

      21,566046098 seconds time elapsed

      21,866713000 seconds user
       0,298857000 seconds sys
```
After
```
BenchmarkOpMstore
BenchmarkOpMstore-8     300000000               17.15 ns/op
PASS
ok      github.com/ethereum/go-ethereum/core/vm 5.165s

 Performance counter stats for 'go test -test.v -run=^$ -bench=BenchmarkOpMstore -benchtime=300000000x':

          6.220,59 msec task-clock                #    1,097 CPUs utilized
             4.900      context-switches          #  787,707 /sec
               520      cpu-migrations            #   83,593 /sec
            81.386      page-faults               #   13,083 K/sec
    27.407.221.011      cycles                    #    4,406 GHz
    83.759.970.262      instructions              #    3,06  insn per cycle
     8.990.158.401      branches                  #    1,445 G/sec
        14.924.264      branch-misses             #    0,17% of all branches
   129.441.537.400      slots                     #   20,809 G/sec
    76.996.593.273      topdown-retiring          #     56,3% retiring
    24.947.582.656      topdown-bad-spec          #     18,2% bad speculation
     9.213.916.089      topdown-fe-bound          #      6,7% frontend bound
    25.596.883.932      topdown-be-bound          #     18,7% backend bound

       5,672569386 seconds time elapsed

       5,960127000 seconds user
       0,283422000 seconds sys
```
The commit helps to reduce the number of instructions, branches and branch
mispredictions.