### PR TITLE
consortium-v2: fix wrong parenthesis placement in non-epoch block check

### DIFF
--- a/consensus/consortium/common/constants.go
+++ b/consensus/consortium/common/constants.go
@@ -53,4 +53,18 @@ var (
 	// ErrWrongDifficulty is returned if the difficulty of a block doesn't match the
 	// turn of the signer.
 	ErrWrongDifficulty = errors.New("wrong difficulty")
+
+	ErrNonEpochExtraData = errors.New("non epoch block contains invalid validator fields")
+
+	ErrAaronEpochExtraData = errors.New("aaron epoch block contains invalid validator fields")
+
+	ErrTrippEpochExtraData = errors.New("tripp epoch block contains invalid validator fields")
+
+	ErrPeriodBlockExtraData = errors.New("period block contains empty checkpoint validator fields")
+
+	ErrNonPeriodBlockExtraData = errors.New("non-period block contains non-empty checkpoint validator fields")
+
+	ErrPreTrippEpochExtraData = errors.New("pre-tripp epoch block contains empty checkpoint validator fields")
+
+	ErrPreTrippEpochProducerExtraData = errors.New("pre-tripp epoch block contains invalid block producer fields")
 )

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -1802,10 +1802,6 @@ func (c *Consortium) IsTrippEffective(chain consensus.ChainHeaderReader, header 
 		return c.testTrippEffective
 	}
 	if c.chainConfig.IsTripp(header.Number) {
-		if c.testTrippEffective {
-			return true
-		}
-
 		// When Tripp has been effective for long enough, we return true without any additional checks.
 		if header.Number.Uint64() > c.chainConfig.TrippBlock.Uint64()+28800 {
 			return true

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -361,14 +361,16 @@ func (c *Consortium) verifyValidatorFieldsInExtraData(
 	header *types.Header,
 ) error {
 	isEpoch := header.Number.Uint64()%c.config.EpochV2 == 0 || c.chainConfig.IsOnConsortiumV2(header.Number)
-	if !isEpoch && (len(extraData.CheckpointValidators) != 0 || len(extraData.BlockProducers) != 0) || extraData.BlockProducersBitSet != 0 {
-		return fmt.Errorf(
-			"%w: checkpoint validator: %v, block producer: %v, block producer bitset: %v",
-			consortiumCommon.ErrNonEpochExtraData,
-			extraData.CheckpointValidators,
-			extraData.BlockProducers,
-			extraData.BlockProducersBitSet,
-		)
+	if !isEpoch {
+		if len(extraData.CheckpointValidators) != 0 || len(extraData.BlockProducers) != 0 || extraData.BlockProducersBitSet != 0 {
+			return fmt.Errorf(
+				"%w: checkpoint validator: %v, block producer: %v, block producer bitset: %v",
+				consortiumCommon.ErrNonEpochExtraData,
+				extraData.CheckpointValidators,
+				extraData.BlockProducers,
+				extraData.BlockProducersBitSet,
+			)
+		}
 	}
 
 	if c.IsTrippEffective(chain, header) {


### PR DESCRIPTION
Fix wrong parenthesis placement in non-epoch block check in verifyValidatorFieldsInExtraData which leads to incorrect check result.