### PR TITLE
genesis: update Aaron hardfork on testnet

### DIFF
--- a/genesis/testnet.json
+++ b/genesis/testnet.json
@@ -36,7 +36,7 @@
     "londonBlock": 27580600,
     "trippBlock": 27580600,
     "trippPeriod": 19866,
-    "aaronBlock": 28174200,
+    "aaronBlock": 28231200,
     "whiteListDeployerContractV2Address": "0x50a7e07Aa75eB9C04281713224f50403cA79851F",
     "roninTrustedOrgUpgrade": {
       "proxyAddress": "0x7507dc433a98E1fE105d69f19f3B40E4315A4F32",

--- a/params/config.go
+++ b/params/config.go
@@ -344,7 +344,7 @@ var (
 		BerlinBlock: big.NewInt(27580600),
 		TrippBlock:  big.NewInt(27580600),
 		TrippPeriod: big.NewInt(19866),
-		AaronBlock:  big.NewInt(28174200),
+		AaronBlock:  big.NewInt(28231200),
 	}
 
 	// GoerliTrustedCheckpoint contains the light client trusted checkpoint for the Görli test network.

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 2  // Major version component of the current release
 	VersionMinor = 8  // Minor version component of the current release
-	VersionPatch = 1  // Patch version component of the current release
+	VersionPatch = 2  // Patch version component of the current release
 	VersionMeta  = "" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
The hardfork is scheduled around 7:00 UTC June 15th, 2024 at block 28231200
(https://saigon-app.roninchain.com/block/28231200).