### PR TITLE
github/workflows: bump action/setup-go to v5

### DIFF
--- a/.github/workflows/evm-benchmark.yml
+++ b/.github/workflows/evm-benchmark.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Setup Go'
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.3.0
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20.10'
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
 
       - name: 'Setup Go'
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.3.0
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20.10'
 


### PR DESCRIPTION
This will enable dependency and build output cache by default.