### PR TITLE
p2p/discover: apply enr filtering in discovery phase, fix minor logic in doRevalidate

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -35,19 +35,21 @@ import (
 
 func main() {
 	var (
-		listenAddr  = flag.String("addr", ":30301", "listen address")
-		genKey      = flag.String("genkey", "", "generate a node key")
-		writeAddr   = flag.Bool("writeaddress", false, "write out the node's public key and quit")
-		nodeKeyFile = flag.String("nodekey", "", "private key filename")
-		nodeKeyHex  = flag.String("nodekeyhex", "", "private key as hex (for testing)")
-		natdesc     = flag.String("nat", "none", "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
-		netrestrict = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
-		runv5       = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
-		verbosity   = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")
-		vmodule     = flag.String("vmodule", "", "log verbosity pattern")
+		listenAddr    = flag.String("addr", ":30301", "listen address")
+		genKey        = flag.String("genkey", "", "generate a node key")
+		writeAddr     = flag.Bool("writeaddress", false, "write out the node's public key and quit")
+		nodeKeyFile   = flag.String("nodekey", "", "private key filename")
+		nodeKeyHex    = flag.String("nodekeyhex", "", "private key as hex (for testing)")
+		natdesc       = flag.String("nat", "none", "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
+		netrestrict   = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
+		runv5         = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
+		verbosity     = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-5)")
+		vmodule       = flag.String("vmodule", "", "log verbosity pattern")
+		networkFilter = flag.String("network", "", "<ronin-mainnet/ronin-testnet> filters nodes by eth ENR entry")
 
-		nodeKey *ecdsa.PrivateKey
-		err     error
+		nodeKey        *ecdsa.PrivateKey
+		filterFunction discover.NodeFilterFunc
+		err            error
 	)
 	flag.Parse()
 
@@ -83,6 +85,12 @@ func main() {
 	case *nodeKeyHex != "":
 		if nodeKey, err = crypto.HexToECDSA(*nodeKeyHex); err != nil {
 			utils.Fatalf("-nodekeyhex: %v", err)
+		}
+	}
+
+	if *networkFilter != "" {
+		if filterFunction, err = discover.ParseEthFilter(*networkFilter); err != nil {
+			utils.Fatalf("-network: %v", err)
 		}
 	}
 
@@ -123,8 +131,9 @@ func main() {
 	db, _ := enode.OpenDB("")
 	ln := enode.NewLocalNode(db, nodeKey)
 	cfg := discover.Config{
-		PrivateKey:  nodeKey,
-		NetRestrict: restrictList,
+		PrivateKey:     nodeKey,
+		NetRestrict:    restrictList,
+		FilterFunction: filterFunction,
 	}
 	if *runv5 {
 		if _, err := discover.ListenV5(conn, ln, cfg); err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -639,6 +639,7 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 // Start implements node.Lifecycle, starting all internal goroutines needed by the
 // Ethereum protocol implementation.
 func (s *Ethereum) Start() error {
+	eth.StartENRFilter(s.blockchain, s.p2pServer)
 	eth.StartENRUpdater(s.blockchain, s.p2pServer.LocalNode())
 
 	// Start the bloom bits servicing goroutines

--- a/eth/protocols/eth/discovery.go
+++ b/eth/protocols/eth/discovery.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -55,6 +56,11 @@ func StartENRUpdater(chain *core.BlockChain, ln *enode.LocalNode) {
 			}
 		}
 	}()
+}
+
+func StartENRFilter(chain *core.BlockChain, p2p *p2p.Server) {
+	forkFilter := forkid.NewFilter(chain)
+	p2p.SetFilter(forkFilter)
 }
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -18,13 +18,17 @@ package discover
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"net"
 
 	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // UDPConn is a network connection on which discovery can operate.
@@ -35,18 +39,45 @@ type UDPConn interface {
 	LocalAddr() net.Addr
 }
 
+type NodeFilterFunc func(*enr.Record) bool
+
+func ParseEthFilter(chain string) (NodeFilterFunc, error) {
+	var filter forkid.Filter
+	switch chain {
+	case "ronin-mainnet":
+		filter = forkid.NewStaticFilter(params.RoninMainnetChainConfig, params.RoninMainnetGenesisHash)
+	case "ronin-testnet":
+		filter = forkid.NewStaticFilter(params.RoninTestnetChainConfig, params.RoninTestnetGenesisHash)
+	default:
+		return nil, fmt.Errorf("unknown network %q", chain)
+	}
+
+	f := func(r *enr.Record) bool {
+		var eth struct {
+			ForkID forkid.ID
+			Tail   []rlp.RawValue `rlp:"tail"`
+		}
+		if r.Load(enr.WithEntry("eth", &eth)) != nil {
+			return false
+		}
+		return filter(eth.ForkID) == nil
+	}
+	return f, nil
+}
+
 // Config holds settings for the discovery listener.
 type Config struct {
 	// These settings are required and configure the UDP listener:
 	PrivateKey *ecdsa.PrivateKey
 
 	// These settings are optional:
-	NetRestrict  *netutil.Netlist   // list of allowed IP networks
-	Bootnodes    []*enode.Node      // list of bootstrap nodes
-	Unhandled    chan<- ReadPacket  // unhandled packets are sent on this channel
-	Log          log.Logger         // if set, log messages go here
-	ValidSchemes enr.IdentityScheme // allowed identity schemes
-	Clock        mclock.Clock
+	NetRestrict    *netutil.Netlist   // list of allowed IP networks
+	Bootnodes      []*enode.Node      // list of bootstrap nodes
+	Unhandled      chan<- ReadPacket  // unhandled packets are sent on this channel
+	Log            log.Logger         // if set, log messages go here
+	ValidSchemes   enr.IdentityScheme // allowed identity schemes
+	Clock          mclock.Clock
+	FilterFunction NodeFilterFunc // function for filtering ENR entries
 }
 
 func (cfg Config) withDefaults() Config {

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -30,12 +30,17 @@ const (
 
 	// egressMeterName is the prefix of the per-packet outbound metrics.
 	egressMeterName = moduleName + "/egress"
+
+	// filterENRName is the prefix of the per-packet filter ENR metrics.
+	filterEnrName = moduleName + "/filter/enr"
 )
 
 var (
-	bucketsCounter      []metrics.Counter
-	ingressTrafficMeter = metrics.NewRegisteredMeter(ingressMeterName, nil)
-	egressTrafficMeter  = metrics.NewRegisteredMeter(egressMeterName, nil)
+	bucketsCounter          []metrics.Counter
+	ingressTrafficMeter     = metrics.NewRegisteredMeter(ingressMeterName, nil)
+	egressTrafficMeter      = metrics.NewRegisteredMeter(egressMeterName, nil)
+	filterEnrTotalCounter   = metrics.NewRegisteredCounter(fmt.Sprintf("%s/total", filterEnrName), nil)
+	filterEnrSuccessCounter = metrics.NewRegisteredCounter(fmt.Sprintf("%s/success", filterEnrName), nil)
 )
 
 func init() {

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -43,7 +43,7 @@ const (
 	alpha                  = 3               // Kademlia concurrency factor
 	bucketSize             = 16              // Kademlia bucket size
 	maxReplacements        = 10              // Size of per-bucket replacement list
-	maxWorkerTask          = 60              // Maximum number of worker tasks
+	maxWorkerTask          = 90              // Maximum number of worker tasks
 	timeoutWorkerTaskClose = 1 * time.Second // Timeout for waiting workerPoolTask is refill full
 	// We keep buckets for the upper 1/15 of distances because
 	// it's very unlikely we'll ever encounter a node that's closer.

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -497,7 +497,10 @@ func (tab *Table) addSeenNodeSync(n *node) {
 		return
 	}
 
+	filterEnrTotalCounter.Inc(1)
+
 	if tab.filterNode(n) {
+		filterEnrSuccessCounter.Inc(1)
 		return
 	}
 
@@ -561,7 +564,11 @@ func (tab *Table) addVerifiedNodeSync(n *node) {
 	if n.ID() == tab.self().ID() {
 		return
 	}
+
+	filterEnrTotalCounter.Inc(1)
+
 	if tab.filterNode(n) {
+		filterEnrSuccessCounter.Inc(1)
 		return
 	}
 	tab.mutex.Lock()

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -343,20 +343,25 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 		// No non-empty bucket found.
 		return
 	}
-
+	var errHandle error
 	// Ping the selected node and wait for a pong.
 	remoteSeq, err := tab.net.ping(unwrapNode(last))
 
+	if err != nil {
+		errHandle = err
+	}
+
 	// Also fetch record if the node replied and returned a higher sequence number.
 	if last.Seq() < remoteSeq {
-		n, enrErr := tab.net.RequestENR(unwrapNode(last))
-		if enrErr != nil {
-			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", enrErr)
+		n, err := tab.net.RequestENR(unwrapNode(last))
+		if err != nil {
+			tab.log.Debug("ENR request failed", "id", last.ID(), "addr", last.addr(), "err", err)
+			errHandle = err
 		} else {
 			if tab.enrFilter != nil {
 				if !tab.enrFilter(n.Record()) {
 					tab.log.Trace("ENR record filter out", "id", last.ID(), "addr", last.addr())
-					err = fmt.Errorf("filtered node")
+					errHandle = fmt.Errorf("filtered node")
 				}
 			}
 			last = &node{Node: *n, addedAt: last.addedAt, livenessChecks: last.livenessChecks}
@@ -366,7 +371,7 @@ func (tab *Table) doRevalidate(done chan<- struct{}) {
 	tab.mutex.Lock()
 	defer tab.mutex.Unlock()
 	b := tab.buckets[bi]
-	if err == nil {
+	if errHandle == nil {
 		// The node responded, move it to the front.
 		last.livenessChecks++
 		tab.log.Debug("Revalidated node", "b", bi, "id", last.ID(), "checks", last.livenessChecks)

--- a/p2p/discover/table_test.go
+++ b/p2p/discover/table_test.go
@@ -27,10 +27,13 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 func TestTable_pingReplace(t *testing.T) {
@@ -65,7 +68,7 @@ func testPingReplace(t *testing.T, newNodeIsResponding, lastInBucketIsResponding
 	// its bucket if it is unresponsive. Revalidate again to ensure that
 	transport.dead[last.ID()] = !lastInBucketIsResponding
 	transport.dead[pingSender.ID()] = !newNodeIsResponding
-	tab.addSeenNode(pingSender)
+	tab.addSeenNodeSync(pingSender)
 	tab.doRevalidate(make(chan struct{}, 1))
 	tab.doRevalidate(make(chan struct{}, 1))
 
@@ -148,7 +151,7 @@ func TestTable_IPLimit(t *testing.T) {
 
 	for i := 0; i < tableIPLimit+1; i++ {
 		n := nodeAtDistance(tab.self().ID(), i, net.IP{172, 0, 1, byte(i)})
-		tab.addSeenNode(n)
+		tab.addSeenNodeSync(n)
 	}
 	if tab.len() > tableIPLimit {
 		t.Errorf("too many nodes in table")
@@ -314,8 +317,8 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNode(n1)
-	tab.addSeenNode(n2)
+	tab.addSeenNodeSync(n1)
+	tab.addSeenNodeSync(n2)
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
@@ -327,7 +330,7 @@ func TestTable_addVerifiedNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addVerifiedNode(newn2)
+	tab.addVerifiedNodeSync(newn2)
 
 	// Check that bucket is updated correctly.
 	newBcontent := []*node{newn2, n1}
@@ -346,8 +349,8 @@ func TestTable_addSeenNode(t *testing.T) {
 	// Insert two nodes.
 	n1 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 1})
 	n2 := nodeAtDistance(tab.self().ID(), 256, net.IP{88, 77, 66, 2})
-	tab.addSeenNode(n1)
-	tab.addSeenNode(n2)
+	tab.addSeenNodeSync(n1)
+	tab.addSeenNodeSync(n2)
 
 	// Verify bucket content:
 	bcontent := []*node{n1, n2}
@@ -359,7 +362,7 @@ func TestTable_addSeenNode(t *testing.T) {
 	newrec := n2.Record()
 	newrec.Set(enr.IP{99, 99, 99, 99})
 	newn2 := wrapNode(enode.SignNull(newrec, n2.ID()))
-	tab.addSeenNode(newn2)
+	tab.addSeenNodeSync(newn2)
 
 	// Check that bucket content is unchanged.
 	if !reflect.DeepEqual(tab.bucket(n1.ID()).entries, bcontent) {
@@ -382,7 +385,7 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	r.Set(enr.IP(net.IP{127, 0, 0, 1}))
 	id := enode.ID{1}
 	n1 := wrapNode(enode.SignNull(&r, id))
-	tab.addSeenNode(n1)
+	tab.addSeenNodeSync(n1)
 
 	// Update the node record.
 	r.Set(enr.WithEntry("foo", "bar"))
@@ -394,6 +397,41 @@ func TestTable_revalidateSyncRecord(t *testing.T) {
 	if !reflect.DeepEqual(intable, n2) {
 		t.Fatalf("table contains old record with seq %d, want seq %d", intable.Seq(), n2.Seq())
 	}
+}
+
+// This test checks that ENR filtering is working properly
+func TestTable_filterNode(t *testing.T) {
+	// Create ENR filter
+	type eth struct {
+		ForkID forkid.ID
+		Tail   []rlp.RawValue `rlp:"tail"`
+	}
+
+	enrFilter, _ := ParseEthFilter("ronin-mainnet")
+
+	// Check test ENR record
+	var r1 enr.Record
+	r1.Set(enr.WithEntry("foo", "bar"))
+	if enrFilter(&r1) {
+		t.Fatalf("filterNode doesn't work correctly for entry")
+	}
+	t.Logf("Check test ENR record - passed")
+
+	// Check wrong genesis ENR record
+	var r2 enr.Record
+	r2.Set(enr.WithEntry("eth", eth{ForkID: forkid.NewID(params.RoninMainnetChainConfig, params.RoninTestnetGenesisHash, uint64(0))}))
+	if enrFilter(&r2) {
+		t.Fatalf("filterNode doesn't work correctly for wrong genesis entry")
+	}
+	t.Logf("Check wrong genesis ENR record - passed")
+
+	// Check correct genesis ENR record
+	var r3 enr.Record
+	r3.Set(enr.WithEntry("eth", eth{ForkID: forkid.NewID(params.RoninMainnetChainConfig, params.RoninMainnetGenesisHash, uint64(0))}))
+	if !enrFilter(&r3) {
+		t.Fatalf("filterNode doesn't work correctly for correct genesis entry")
+	}
+	t.Logf("Check correct genesis ENR record - passed")
 }
 
 // gen wraps quick.Value so it's easier to use.

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -43,7 +43,7 @@ func init() {
 
 func newTestTable(t transport) (*Table, *enode.DB) {
 	db, _ := enode.OpenDB("")
-	tab, _ := newTable(t, db, nil, log.Root())
+	tab, _ := newTable(t, db, nil, log.Root(), nil)
 	go tab.loop()
 	return tab, db
 }
@@ -110,7 +110,7 @@ func fillBucket(tab *Table, n *node) (last *node) {
 // if the bucket is not full. The caller must not hold tab.mutex.
 func fillTable(tab *Table, nodes []*node) {
 	for _, n := range nodes {
-		tab.addSeenNode(n)
+		tab.addSeenNodeSync(n)
 	}
 }
 

--- a/p2p/discover/v4_udp.go
+++ b/p2p/discover/v4_udp.go
@@ -41,7 +41,7 @@ var (
 	errExpired          = errors.New("expired")
 	errUnsolicitedReply = errors.New("unsolicited reply")
 	errUnknownNode      = errors.New("unknown node")
-	errTimeout          = errors.New("RPC timeout")
+	errTimeout          = errors.New("udp timeout")
 	errClockWarp        = errors.New("reply deadline too far in the future")
 	errClosed           = errors.New("socket closed")
 	errLowPort          = errors.New("low port")
@@ -142,7 +142,7 @@ func ListenV4(c UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv4, error) {
 		log:             cfg.Log,
 	}
 
-	tab, err := newMeteredTable(t, ln.Database(), cfg.Bootnodes, t.log)
+	tab, err := newMeteredTable(t, ln.Database(), cfg.Bootnodes, t.log, cfg.FilterFunction)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp.go
+++ b/p2p/discover/v5_udp.go
@@ -164,7 +164,7 @@ func newUDPv5(conn UDPConn, ln *enode.LocalNode, cfg Config) (*UDPv5, error) {
 		closeCtx:       closeCtx,
 		cancelCloseCtx: cancelCloseCtx,
 	}
-	tab, err := newMeteredTable(t, t.db, cfg.Bootnodes, cfg.Log)
+	tab, err := newMeteredTable(t, t.db, cfg.Bootnodes, cfg.Log, cfg.FilterFunction)
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -145,7 +145,7 @@ func TestUDPv5_unknownPacket(t *testing.T) {
 
 	// Make node known.
 	n := test.getNode(test.remotekey, test.remoteaddr).Node()
-	test.table.addSeenNode(wrapNode(n))
+	test.table.addSeenNodeSync(wrapNode(n))
 
 	test.packetIn(&v5wire.Unknown{Nonce: nonce})
 	test.waitPacketOut(func(p *v5wire.Whoareyou, addr *net.UDPAddr, _ v5wire.Nonce) {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -39,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 const (
@@ -194,6 +196,8 @@ type Server struct {
 	DiscV5    *discover.UDPv5
 	discmix   *enode.FairMix
 	dialsched *dialScheduler
+
+	forkFilter forkid.Filter
 
 	// Channels into the run loop.
 	quit                    chan struct{}
@@ -596,6 +600,21 @@ func (srv *Server) setupDiscovery() error {
 	}
 	srv.localnode.SetFallbackUDP(realaddr.Port)
 
+	// ENR filter function
+	f := func(r *enr.Record) bool {
+		if srv.forkFilter == nil {
+			return true
+		}
+		var eth struct {
+			ForkID forkid.ID
+			Tail   []rlp.RawValue `rlp:"tail"`
+		}
+		if r.Load(enr.WithEntry("eth", &eth)) != nil {
+			return false
+		}
+		return srv.forkFilter(eth.ForkID) == nil
+	}
+
 	// Discovery V4
 	var unhandled chan discover.ReadPacket
 	var sconn *sharedUDPConn
@@ -605,11 +624,12 @@ func (srv *Server) setupDiscovery() error {
 			sconn = &sharedUDPConn{conn, unhandled}
 		}
 		cfg := discover.Config{
-			PrivateKey:  srv.PrivateKey,
-			NetRestrict: srv.NetRestrict,
-			Bootnodes:   srv.BootstrapNodes,
-			Unhandled:   unhandled,
-			Log:         srv.log,
+			PrivateKey:     srv.PrivateKey,
+			NetRestrict:    srv.NetRestrict,
+			Bootnodes:      srv.BootstrapNodes,
+			Unhandled:      unhandled,
+			Log:            srv.log,
+			FilterFunction: f,
 		}
 		ntab, err := discover.ListenV4(conn, srv.localnode, cfg)
 		if err != nil {
@@ -622,10 +642,11 @@ func (srv *Server) setupDiscovery() error {
 	// Discovery V5
 	if srv.DiscoveryV5 {
 		cfg := discover.Config{
-			PrivateKey:  srv.PrivateKey,
-			NetRestrict: srv.NetRestrict,
-			Bootnodes:   srv.BootstrapNodesV5,
-			Log:         srv.log,
+			PrivateKey:     srv.PrivateKey,
+			NetRestrict:    srv.NetRestrict,
+			Bootnodes:      srv.BootstrapNodesV5,
+			Log:            srv.log,
+			FilterFunction: f,
 		}
 		var err error
 		if sconn != nil {
@@ -664,6 +685,10 @@ func (srv *Server) setupDialScheduler() {
 
 func (srv *Server) maxInboundConns() int {
 	return srv.MaxPeers - srv.maxDialedConns()
+}
+
+func (srv *Server) SetFilter(f forkid.Filter) {
+	srv.forkFilter = f
 }
 
 func (srv *Server) maxDialedConns() (limit int) {


### PR DESCRIPTION
**Description**  

Node discovery filtering based on ENR records for Ronin Network

Current implementation of discovery protocol is chain agnostic and does not differentiate between different chains (ETH, Ronin, ...). The discover protocol currently gossips peers from networks with different chain ids. This causes a pretty significant slowdown during peer discovery.

- [x] Apply ENR filter Metrics in the discovery phase
- [x] Build ENR filter success result metrics  

Reference by  https://github.com/bnb-chain/bsc/pull/1320

Dial and Enr Filter ratio metrics for an RPC node in the recent 3 hour metrics 

Before 


<img width="470" alt="Screenshot 2024-06-24 at 4 14 24 PM" src="https://github.com/axieinfinity/ronin/assets/17699212/8e11cd9a-0e7c-4147-8ce6-95ec16dd8e44">

<img width="1186" alt="Screenshot 2024-06-24 at 4 17 57 PM" src="https://github.com/axieinfinity/ronin/assets/17699212/7963d629-b925-4e2c-a435-586c0677340f">


After 
<img width="462" alt="Screenshot 2024-06-24 at 4 14 14 PM" src="https://github.com/axieinfinity/ronin/assets/17699212/c783056a-6413-440e-85ff-d639ea13033d">


<img width="1193" alt="Screenshot 2024-06-24 at 4 18 06 PM" src="https://github.com/axieinfinity/ronin/assets/17699212/2b869215-5fe2-44b6-b64c-845fd49d62d8">

The filtering ratio is ~9x now. 

For the Dial Result 
The formula is 

```
sum(rate(p2p_dials_success{statefulset_kubernetes_io_pod_name=~"$pod"}[1m]) - rate(eth_protocols_eth_egress_handshake_error_forkid{statefulset_kubernetes_io_pod_name=~"$pod"}[1m]) - rate(eth_protocols_eth_egress_handshake_error_genesis{statefulset_kubernetes_io_pod_name=~"$pod"}[1m]) - rate(eth_protocols_eth_egress_handshake_error_network{statefulset_kubernetes_io_pod_name=~"$pod"}[1m]) - rate(eth_protocols_eth_egress_handshake_error_peer{statefulset_kubernetes_io_pod_name=~"$pod"}[1m]) - rate(eth_protocols_eth_egress_handshake_error_timeout{statefulset_kubernetes_io_pod_name=~"$pod"}[1m]) - rate(eth_protocols_eth_egress_handshake_error_version{statefulset_kubernetes_io_pod_name=~"$pod"}[1m])) by (statefulset_kubernetes_io_pod_name)  / sum(rate(p2p_dials{statefulset_kubernetes_io_pod_name=~"$pod"}[1m])) by (statefulset_kubernetes_io_pod_name)
```
It will show the dial success ratio based on 1 m interval.

For the Dial Result (1h)

It's the summarization of the total of dialing including failed/passed error codes. Overall the number of calling dial and dial results seem to improve after applying. Let us monitor that node for more days to get more metrics.

