### PR TITLE
eth/filters: return error when getLogs on not found block

### DIFF
--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -19,6 +19,7 @@ package filters
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"os"
@@ -243,7 +244,9 @@ func (f *Filter) unindexedLogs(ctx context.Context, end uint64) ([]*types.Log, e
 
 	for ; f.begin <= int64(end); f.begin++ {
 		header, err := f.backend.HeaderByNumber(ctx, rpc.BlockNumber(f.begin))
-		if header == nil || err != nil {
+		if header == nil {
+			return logs, fmt.Errorf("block %d not found", f.begin)
+		} else if err != nil {
 			return logs, err
 		}
 		found, err := f.blockLogs(ctx, header)


### PR DESCRIPTION
Currently, when calling eth_getLogs on not found block, RPC does not return error but returns empty log. As a result, the user cannot differentiate between not found block and block with no logs. This commit makes eth_getLogs return an error when the queried block is not found.

Example of error response after this commit

	{
		"jsonrpc": "2.0",
		"id": 1,
		"error": {
			"code": -32000,
			"message": "block 36077340 not found"
		}
	}