### PR TITLE
consortium-v2: add parent list parameter to IsPeriodBlock

### DIFF
--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -2237,19 +2237,19 @@ func TestIsPeriodBlock(t *testing.T) {
 	// header of block 0
 	// this must not a period block
 	header = genesis.Header()
-	if c.IsPeriodBlock(chain, header) {
+	if c.IsPeriodBlock(chain, header, nil) {
 		t.Errorf("wrong period block")
 	}
 
 	// header of block 200
 	// this must not a period block
 	header = bs[199].Header()
-	if c.IsPeriodBlock(chain, header) {
+	if c.IsPeriodBlock(chain, header, nil) {
 		t.Error("wrong period block")
 	}
 
 	header = bs[351].Header()
-	if c.IsPeriodBlock(chain, header) {
+	if c.IsPeriodBlock(chain, header, nil) {
 		t.Error("wrong period block")
 	}
 
@@ -2270,14 +2270,14 @@ func TestIsPeriodBlock(t *testing.T) {
 	// this must be a period block
 	header = bs[399].Header()
 	// this header must be period header
-	if !c.IsPeriodBlock(chain, header) {
+	if !c.IsPeriodBlock(chain, header, nil) {
 		t.Errorf("wrong period block")
 	}
 
 	// header of block 500
 	// this must not be a period block
 	header = bs[499].Header()
-	if c.IsPeriodBlock(chain, header) {
+	if c.IsPeriodBlock(chain, header, nil) {
 		t.Errorf("wrong period block")
 	}
 }
@@ -2409,7 +2409,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 			{},
 		},
 	}
-	err := c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err := c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if !errors.Is(err, consortiumCommon.ErrNonEpochExtraData) {
 		t.Fatalf("Expect err: %v got: %v", consortiumCommon.ErrNonEpochExtraData, err)
 	}
@@ -2420,7 +2420,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 			{},
 		},
 	}
-	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if !errors.Is(err, consortiumCommon.ErrNonEpochExtraData) {
 		t.Fatalf("Expect err: %v got: %v", consortiumCommon.ErrNonEpochExtraData, err)
 	}
@@ -2429,7 +2429,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 	extraData = finality.HeaderExtraData{
 		BlockProducersBitSet: 10,
 	}
-	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if !errors.Is(err, consortiumCommon.ErrNonEpochExtraData) {
 		t.Fatalf("Expect err: %v got: %v", consortiumCommon.ErrNonEpochExtraData, err)
 	}
@@ -2444,7 +2444,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 			{},
 		},
 	}
-	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if !errors.Is(err, consortiumCommon.ErrNonPeriodBlockExtraData) {
 		t.Fatalf("Expect err: %v got: %v", consortiumCommon.ErrNonPeriodBlockExtraData, err)
 	}
@@ -2460,7 +2460,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 			{},
 		},
 	}
-	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if !errors.Is(err, consortiumCommon.ErrPreTrippEpochProducerExtraData) {
 		t.Fatalf("Expect err: %v got: %v", consortiumCommon.ErrPreTrippEpochProducerExtraData, err)
 	}
@@ -2472,7 +2472,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 		},
 		BlockProducersBitSet: 5,
 	}
-	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if !errors.Is(err, consortiumCommon.ErrPreTrippEpochProducerExtraData) {
 		t.Fatalf("Expect err: %v got: %v", consortiumCommon.ErrPreTrippEpochProducerExtraData, err)
 	}
@@ -2484,7 +2484,7 @@ func TestHeaderExtraDataCheck(t *testing.T) {
 	extraData = finality.HeaderExtraData{
 		BlockProducersBitSet: 5,
 	}
-	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header)
+	err = c.verifyValidatorFieldsInExtraData(nil, &extraData, &header, nil)
 	if err != nil {
 		t.Fatalf("Expect no error, got: %v", err)
 	}


### PR DESCRIPTION
We get this warning and error log
```
WARN [07-08|04:18:15.866] Fail to get snapshot at                  blockNumber=36,192,799 blockHash=c19608..2c657b err="unknown ancestor"
ERROR[07-08|04:18:15.866] Failed to get block                      number=36,192,799 hash=0xc19608d700837c8ab4c184791bc3522766a48efb5f2e7734b827b3f9382c657b
```
IsPeriodBlock can be called in verifyHeader path. In that path, the parents of currently verifying block may not be inserted into chain yet so querying the parent may fail. In some functions like snapshot which IsPeriodBlock uses have the parent list parameter to query parent blocks when they are not inserted into chain. This commit adds a new parent list parameter to IsPeriodBlock and passes the parent list when it is called in verifyHeader path.