### PR TITLE
core/types: add blob transaction type

### DIFF
--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -107,6 +107,10 @@ func (tx *AccessListTx) nonce() uint64          { return tx.Nonce }
 func (tx *AccessListTx) to() *common.Address    { return tx.To }
 func (tx *AccessListTx) expiredTime() uint64    { return 0 }
 
+func (tx *AccessListTx) blobGas() uint64           { return 0 }
+func (tx *AccessListTx) blobGasFeeCap() *big.Int   { return nil }
+func (tx *AccessListTx) blobHashes() []common.Hash { return nil }
+
 func (tx *AccessListTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -17,9 +17,11 @@
 package types
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 //go:generate gencodec -type AccessTuple -out gen_access_tuple.go
@@ -117,4 +119,12 @@ func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 
 func (tx *AccessListTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
+}
+
+func (tx *AccessListTx) encode(b *bytes.Buffer) error {
+	return rlp.Encode(b, tx)
+}
+
+func (tx *AccessListTx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
 }

--- a/core/types/access_list_tx.go
+++ b/core/types/access_list_tx.go
@@ -107,10 +107,6 @@ func (tx *AccessListTx) nonce() uint64          { return tx.Nonce }
 func (tx *AccessListTx) to() *common.Address    { return tx.To }
 func (tx *AccessListTx) expiredTime() uint64    { return 0 }
 
-func (tx *AccessListTx) blobGas() uint64           { return 0 }
-func (tx *AccessListTx) blobGasFeeCap() *big.Int   { return nil }
-func (tx *AccessListTx) blobHashes() []common.Hash { return nil }
-
 func (tx *AccessListTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// BlobTx represents an EIP-4844 transaction.
+type BlobTx struct {
+	ChainID    *uint256.Int
+	Nonce      uint64
+	GasTipCap  *uint256.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap  *uint256.Int // a.k.a. maxFeePerGas
+	Gas        uint64
+	To         *common.Address // `rlp:"nil"` // nil means contract creation
+	Value      *uint256.Int
+	Data       []byte
+	AccessList AccessList
+	BlobFeeCap *uint256.Int // a.k.a. maxFeePerDataGas
+	BlobHashes []common.Hash
+	// Signature values
+	V *uint256.Int `json:"v" gencodec:"required"`
+	R *uint256.Int `json:"r" gencodec:"required"`
+	S *uint256.Int `json:"s" gencodec:"required"`
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *BlobTx) copy() TxData {
+	cpy := &BlobTx{
+		Nonce: tx.Nonce,
+		To:    tx.To, //copyAddressPtr(tx.To),
+		Data:  common.CopyBytes(tx.Data),
+		Gas:   tx.Gas,
+		// These are copied below.
+		AccessList: make(AccessList, len(tx.AccessList)),
+		BlobHashes: make([]common.Hash, len(tx.BlobHashes)),
+		Value:      new(uint256.Int),
+		ChainID:    new(uint256.Int),
+		GasTipCap:  new(uint256.Int),
+		GasFeeCap:  new(uint256.Int),
+		BlobFeeCap: new(uint256.Int),
+		V:          new(uint256.Int),
+		R:          new(uint256.Int),
+		S:          new(uint256.Int),
+	}
+	copy(cpy.AccessList, tx.AccessList)
+	copy(cpy.BlobHashes, tx.BlobHashes)
+
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	if tx.ChainID != nil {
+		cpy.ChainID.Set(tx.ChainID)
+	}
+	if tx.GasTipCap != nil {
+		cpy.GasTipCap.Set(tx.GasTipCap)
+	}
+	if tx.GasFeeCap != nil {
+		cpy.GasFeeCap.Set(tx.GasFeeCap)
+	}
+	if tx.BlobFeeCap != nil {
+		cpy.BlobFeeCap.Set(tx.BlobFeeCap)
+	}
+	if tx.V != nil {
+		cpy.V.Set(tx.V)
+	}
+	if tx.R != nil {
+		cpy.R.Set(tx.R)
+	}
+	if tx.S != nil {
+		cpy.S.Set(tx.S)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *BlobTx) txType() byte           { return BlobTxType }
+func (tx *BlobTx) chainID() *big.Int      { return tx.ChainID.ToBig() }
+func (tx *BlobTx) accessList() AccessList { return nil /*tx.AccessList*/ }
+func (tx *BlobTx) data() []byte           { return tx.Data }
+func (tx *BlobTx) gas() uint64            { return tx.Gas }
+func (tx *BlobTx) gasFeeCap() *big.Int    { return tx.GasFeeCap.ToBig() }
+func (tx *BlobTx) gasTipCap() *big.Int    { return tx.GasTipCap.ToBig() }
+func (tx *BlobTx) gasPrice() *big.Int     { return tx.GasFeeCap.ToBig() }
+func (tx *BlobTx) value() *big.Int        { return tx.Value.ToBig() }
+func (tx *BlobTx) nonce() uint64          { return tx.Nonce }
+func (tx *BlobTx) to() *common.Address    { return tx.To }
+func (tx *BlobTx) expiredTime() uint64    { return 0 }
+
+func (tx *BlobTx) blobGas() uint64           { return params.BlobTxDataGasPerBlob * uint64(len(tx.BlobHashes)) }
+func (tx *BlobTx) blobGasFeeCap() *big.Int   { return tx.BlobFeeCap.ToBig() }
+func (tx *BlobTx) blobHashes() []common.Hash { return tx.BlobHashes }
+
+func (tx *BlobTx) rawPayerSignatureValues() (v, r, s *big.Int) {
+	return nil, nil, nil
+}
+
+func (tx *BlobTx) rawSignatureValues() (v, r, s *big.Int) {
+	return tx.V.ToBig(), tx.R.ToBig(), tx.S.ToBig()
+}
+
+func (tx *BlobTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	tx.ChainID.SetFromBig(chainID)
+	tx.V.SetFromBig(v)
+	tx.R.SetFromBig(r)
+	tx.S.SetFromBig(s)
+}

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -34,7 +34,7 @@ type BlobTx struct {
 	GasTipCap  *uint256.Int // a.k.a. maxPriorityFeePerGas
 	GasFeeCap  *uint256.Int // a.k.a. maxFeePerGas
 	Gas        uint64
-	To         *common.Address // `rlp:"nil"` // nil means contract creation
+	To         common.Address // In EIP4844, to value must be non-nil
 	Value      *uint256.Int
 	Data       []byte
 	AccessList AccessList
@@ -70,7 +70,7 @@ type blobTxWithBlobs struct {
 func (tx *BlobTx) copy() TxData {
 	cpy := &BlobTx{
 		Nonce: tx.Nonce,
-		To:    copyAddressPtr(tx.To),
+		To:    tx.To,
 		Data:  common.CopyBytes(tx.Data),
 		Gas:   tx.Gas,
 		// These are copied below.
@@ -133,7 +133,7 @@ func (tx *BlobTx) gasTipCap() *big.Int    { return tx.GasTipCap.ToBig() }
 func (tx *BlobTx) gasPrice() *big.Int     { return tx.GasFeeCap.ToBig() }
 func (tx *BlobTx) value() *big.Int        { return tx.Value.ToBig() }
 func (tx *BlobTx) nonce() uint64          { return tx.Nonce }
-func (tx *BlobTx) to() *common.Address    { return tx.To }
+func (tx *BlobTx) to() *common.Address    { to := tx.To; return &to }
 func (tx *BlobTx) expiredTime() uint64    { return 0 }
 
 func (tx *BlobTx) blobGas() uint64 { return params.BlobTxBlobGasPerBlob * uint64(len(tx.BlobHashes)) }

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -106,9 +106,8 @@ func (tx *BlobTx) nonce() uint64          { return tx.Nonce }
 func (tx *BlobTx) to() *common.Address    { return tx.To }
 func (tx *BlobTx) expiredTime() uint64    { return 0 }
 
-func (tx *BlobTx) blobGas() uint64           { return params.BlobTxDataGasPerBlob * uint64(len(tx.BlobHashes)) }
-func (tx *BlobTx) blobGasFeeCap() *big.Int   { return tx.BlobFeeCap.ToBig() }
-func (tx *BlobTx) blobHashes() []common.Hash { return tx.BlobHashes }
+func (tx *BlobTx) blobGas() uint64         { return params.BlobTxBlobGasPerBlob * uint64(len(tx.BlobHashes)) }
+func (tx *BlobTx) blobGasFeeCap() *big.Int { return tx.BlobFeeCap.ToBig() }
 
 func (tx *BlobTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -47,7 +47,7 @@ type BlobTx struct {
 func (tx *BlobTx) copy() TxData {
 	cpy := &BlobTx{
 		Nonce: tx.Nonce,
-		To:    tx.To, //copyAddressPtr(tx.To),
+		To:    copyAddressPtr(tx.To),
 		Data:  common.CopyBytes(tx.Data),
 		Gas:   tx.Gas,
 		// These are copied below.
@@ -95,7 +95,7 @@ func (tx *BlobTx) copy() TxData {
 // accessors for innerTx.
 func (tx *BlobTx) txType() byte           { return BlobTxType }
 func (tx *BlobTx) chainID() *big.Int      { return tx.ChainID.ToBig() }
-func (tx *BlobTx) accessList() AccessList { return nil /*tx.AccessList*/ }
+func (tx *BlobTx) accessList() AccessList { return tx.AccessList }
 func (tx *BlobTx) data() []byte           { return tx.Data }
 func (tx *BlobTx) gas() uint64            { return tx.Gas }
 func (tx *BlobTx) gasFeeCap() *big.Int    { return tx.GasFeeCap.ToBig() }

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -43,7 +43,7 @@ type BlobTx struct {
 
 	// A blob transaction can optionally contain blobs. This field must be set when BlobTx
 	// is used to create a transaction for sigining.
-	Sidecar *BlobSidecar `rlp:"-"`
+	Sidecar *BlobTxSidecar `rlp:"-"`
 
 	// Signature values
 	V *uint256.Int `json:"v" gencodec:"required"`
@@ -51,8 +51,8 @@ type BlobTx struct {
 	S *uint256.Int `json:"s" gencodec:"required"`
 }
 
-// BlobSidecar contains the blobs of a blob transaction.
-type BlobSidecar struct {
+// BlobTxSidecar contains the blobs of a blob transaction.
+type BlobTxSidecar struct {
 	Blobs       []kzg4844.Blob       // Blobs needed by the blob pool
 	Commitments []kzg4844.Commitment // Commitments needed by the blob pool
 	Proofs      []kzg4844.Proof      // Proofs needed by the blob pool
@@ -113,7 +113,7 @@ func (tx *BlobTx) copy() TxData {
 		cpy.S.Set(tx.S)
 	}
 	if tx.Sidecar != nil {
-		cpy.Sidecar = &BlobSidecar{
+		cpy.Sidecar = &BlobTxSidecar{
 			Blobs:       append([]kzg4844.Blob(nil), tx.Sidecar.Blobs...),
 			Commitments: append([]kzg4844.Commitment(nil), tx.Sidecar.Commitments...),
 			Proofs:      append([]kzg4844.Proof(nil), tx.Sidecar.Proofs...),
@@ -191,7 +191,7 @@ func (tx *BlobTx) decode(input []byte) error {
 		return err
 	}
 	*tx = *inner.BlobTx
-	tx.Sidecar = &BlobSidecar{
+	tx.Sidecar = &BlobTxSidecar{
 		Blobs:       inner.Blobs,
 		Commitments: inner.Commitments,
 		Proofs:      inner.Proofs,

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -17,10 +17,13 @@
 package types
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 )
 
@@ -37,10 +40,30 @@ type BlobTx struct {
 	AccessList AccessList
 	BlobFeeCap *uint256.Int // a.k.a. maxFeePerDataGas
 	BlobHashes []common.Hash
+
+	// A blob transaction can optionally contain blobs. This field must be set when BlobTx
+	// is used to create a transaction for sigining.
+	Sidecar *BlobSidecar `rlp:"-"`
+
 	// Signature values
 	V *uint256.Int `json:"v" gencodec:"required"`
 	R *uint256.Int `json:"r" gencodec:"required"`
 	S *uint256.Int `json:"s" gencodec:"required"`
+}
+
+// BlobSidecar contains the blobs of a blob transaction.
+type BlobSidecar struct {
+	Blobs       []kzg4844.Blob       // Blobs needed by the blob pool
+	Commitments []kzg4844.Commitment // Commitments needed by the blob pool
+	Proofs      []kzg4844.Proof      // Proofs needed by the blob pool
+}
+
+// blobTxWithBlobs is used for encoding of transactions when blobs are present.
+type blobTxWithBlobs struct {
+	BlobTx      *BlobTx
+	Blobs       []kzg4844.Blob
+	Commitments []kzg4844.Commitment
+	Proofs      []kzg4844.Proof
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
@@ -89,6 +112,13 @@ func (tx *BlobTx) copy() TxData {
 	if tx.S != nil {
 		cpy.S.Set(tx.S)
 	}
+	if tx.Sidecar != nil {
+		cpy.Sidecar = &BlobSidecar{
+			Blobs:       append([]kzg4844.Blob(nil), tx.Sidecar.Blobs...),
+			Commitments: append([]kzg4844.Commitment(nil), tx.Sidecar.Commitments...),
+			Proofs:      append([]kzg4844.Proof(nil), tx.Sidecar.Proofs...),
+		}
+	}
 	return cpy
 }
 
@@ -106,8 +136,7 @@ func (tx *BlobTx) nonce() uint64          { return tx.Nonce }
 func (tx *BlobTx) to() *common.Address    { return tx.To }
 func (tx *BlobTx) expiredTime() uint64    { return 0 }
 
-func (tx *BlobTx) blobGas() uint64         { return params.BlobTxBlobGasPerBlob * uint64(len(tx.BlobHashes)) }
-func (tx *BlobTx) blobGasFeeCap() *big.Int { return tx.BlobFeeCap.ToBig() }
+func (tx *BlobTx) blobGas() uint64 { return params.BlobTxBlobGasPerBlob * uint64(len(tx.BlobHashes)) }
 
 func (tx *BlobTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
@@ -122,4 +151,50 @@ func (tx *BlobTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.V.SetFromBig(v)
 	tx.R.SetFromBig(r)
 	tx.S.SetFromBig(s)
+}
+
+func (tx *BlobTx) encode(b *bytes.Buffer) error {
+	if tx.Sidecar == nil {
+		return rlp.Encode(b, tx)
+	}
+	inner := &blobTxWithBlobs{
+		BlobTx:      tx,
+		Blobs:       tx.Sidecar.Blobs,
+		Commitments: tx.Sidecar.Commitments,
+		Proofs:      tx.Sidecar.Proofs,
+	}
+	return rlp.Encode(b, inner)
+}
+
+func (tx *BlobTx) decode(input []byte) error {
+	// Here we need to support two formats: the network protocol encoding of the tx (with
+	// blobs) or the canonical encoding without blobs.
+	//
+	// The two encodings can be distinguished by checking whether the first element of the
+	// input list is itself a list.
+
+	outerList, _, err := rlp.SplitList(input)
+	if err != nil {
+		return err
+	}
+	firstElemKind, _, _, err := rlp.Split(outerList)
+	if err != nil {
+		return err
+	}
+
+	if firstElemKind != rlp.List {
+		return rlp.DecodeBytes(input, tx)
+	}
+	// It's a tx with blobs.
+	var inner blobTxWithBlobs
+	if err := rlp.DecodeBytes(input, &inner); err != nil {
+		return err
+	}
+	*tx = *inner.BlobTx
+	tx.Sidecar = &BlobSidecar{
+		Blobs:       inner.Blobs,
+		Commitments: inner.Commitments,
+		Proofs:      inner.Proofs,
+	}
+	return nil
 }

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -69,6 +69,22 @@ func (sc *BlobTxSidecar) BlobHashes() []common.Hash {
 	return h
 }
 
+// encodedSize computes the RLP size of the sidecar elements. This does NOT return the
+// encoded size of the BlobTxSidecar, it's just a helper for tx.Size().
+func (sc *BlobTxSidecar) encodedSize() uint64 {
+	var blobs, commitments, proofs uint64
+	for i := range sc.Blobs {
+		blobs += rlp.BytesSize(sc.Blobs[i][:])
+	}
+	for i := range sc.Commitments {
+		commitments += rlp.BytesSize(sc.Commitments[i][:])
+	}
+	for i := range sc.Proofs {
+		proofs += rlp.BytesSize(sc.Proofs[i][:])
+	}
+	return rlp.ListSize(blobs) + rlp.ListSize(commitments) + rlp.ListSize(proofs)
+}
+
 // blobTxWithBlobs is used for encoding of transactions when blobs are present.
 type blobTxWithBlobs struct {
 	BlobTx      *BlobTx

--- a/core/types/blob_tx_test.go
+++ b/core/types/blob_tx_test.go
@@ -1,0 +1,65 @@
+package types
+
+import (
+	"crypto/ecdsa"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+	"github.com/holiman/uint256"
+)
+
+// This test verifies that tx.Hash() is not affected by presence of a BlobTxSidecar.
+func TestBlobTxHashing(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	withBlobs := createEmptyBlobTx(key, true)
+	withBlobsStripped := withBlobs.WithoutBlobTxSidecar()
+	withoutBlobs := createEmptyBlobTx(key, false)
+
+	hash := withBlobs.Hash()
+	t.Log("tx hash:", hash)
+
+	if h := withBlobsStripped.Hash(); h != hash {
+		t.Fatal("wrong tx hash after WithoutBlobTxSidecar:", h)
+	}
+	if h := withoutBlobs.Hash(); h != hash {
+		t.Fatal("wrong tx hash on tx created without sidecar:", h)
+	}
+}
+
+var (
+	emptyBlob          = kzg4844.Blob{}
+	emptyBlobCommit, _ = kzg4844.BlobToCommitment(&emptyBlob)
+	emptyBlobProof, _  = kzg4844.ComputeBlobProof(&emptyBlob, emptyBlobCommit)
+)
+
+func createEmptyBlobTx(key *ecdsa.PrivateKey, withSidecar bool) *Transaction {
+	blobtx := createEmptyBlobTxInner(withSidecar)
+	signer := NewCancunSigner(blobtx.ChainID.ToBig())
+	return MustSignNewTx(key, signer, blobtx)
+}
+
+func createEmptyBlobTxInner(withSidecar bool) *BlobTx {
+	sidecar := &BlobTxSidecar{
+		Blobs:       []kzg4844.Blob{emptyBlob},
+		Commitments: []kzg4844.Commitment{emptyBlobCommit},
+		Proofs:      []kzg4844.Proof{emptyBlobProof},
+	}
+	blobtx := &BlobTx{
+		ChainID:    uint256.NewInt(1),
+		Nonce:      5,
+		GasTipCap:  uint256.NewInt(22),
+		GasFeeCap:  uint256.NewInt(5),
+		Gas:        25000,
+		To:         common.Address{0x03, 0x04, 0x05},
+		Value:      uint256.NewInt(99),
+		Data:       make([]byte, 50),
+		BlobFeeCap: uint256.NewInt(15),
+		BlobHashes: sidecar.BlobHashes(),
+	}
+	if withSidecar {
+		blobtx.Sidecar = sidecar
+	}
+	return blobtx
+}

--- a/core/types/blob_tx_test.go
+++ b/core/types/blob_tx_test.go
@@ -28,6 +28,36 @@ func TestBlobTxHashing(t *testing.T) {
 	}
 }
 
+// This test verifies that tx.Size() takes BlobTxSidecar into account.
+func TestBlobTxSize(t *testing.T) {
+	key, _ := crypto.GenerateKey()
+	withBlobs := createEmptyBlobTx(key, true)
+	withBlobsStripped := withBlobs.WithoutBlobTxSidecar()
+	withoutBlobs := createEmptyBlobTx(key, false)
+
+	withBlobsEnc, _ := withBlobs.MarshalBinary()
+	withoutBlobsEnc, _ := withoutBlobs.MarshalBinary()
+
+	size := withBlobs.Size()
+	t.Log("size with blobs:", size)
+
+	sizeNoBlobs := withoutBlobs.Size()
+	t.Log("size without blobs:", sizeNoBlobs)
+
+	if uint64(size) != uint64(len(withBlobsEnc)) {
+		t.Error("wrong size with blobs:", size, "encoded length:", len(withBlobsEnc))
+	}
+	if uint64(sizeNoBlobs) != uint64(len(withoutBlobsEnc)) {
+		t.Error("wrong size without blobs:", sizeNoBlobs, "encoded length:", len(withoutBlobsEnc))
+	}
+	if sizeNoBlobs >= size {
+		t.Error("size without blobs >= size with blobs")
+	}
+	if sz := withBlobsStripped.Size(); sz != sizeNoBlobs {
+		t.Fatal("wrong size on tx after WithoutBlobTxSidecar:", sz)
+	}
+}
+
 var (
 	emptyBlob          = kzg4844.Blob{}
 	emptyBlobCommit, _ = kzg4844.BlobToCommitment(&emptyBlob)

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -96,10 +96,6 @@ func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
 func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
 func (tx *DynamicFeeTx) expiredTime() uint64    { return 0 }
 
-func (tx *DynamicFeeTx) blobGas() uint64           { return 0 }
-func (tx *DynamicFeeTx) blobGasFeeCap() *big.Int   { return nil }
-func (tx *DynamicFeeTx) blobHashes() []common.Hash { return nil }
-
 func (tx *DynamicFeeTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// DynamicFeeTx represents an EIP-1559 transaction.
 type DynamicFeeTx struct {
 	ChainID    *big.Int
 	Nonce      uint64
@@ -94,6 +95,10 @@ func (tx *DynamicFeeTx) value() *big.Int        { return tx.Value }
 func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
 func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
 func (tx *DynamicFeeTx) expiredTime() uint64    { return 0 }
+
+func (tx *DynamicFeeTx) blobGas() uint64           { return 0 }
+func (tx *DynamicFeeTx) blobGasFeeCap() *big.Int   { return nil }
+func (tx *DynamicFeeTx) blobHashes() []common.Hash { return nil }
 
 func (tx *DynamicFeeTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil

--- a/core/types/dynamic_fee_tx.go
+++ b/core/types/dynamic_fee_tx.go
@@ -17,9 +17,11 @@
 package types
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // DynamicFeeTx represents an EIP-1559 transaction.
@@ -106,4 +108,12 @@ func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 
 func (tx *DynamicFeeTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
+}
+
+func (tx *DynamicFeeTx) encode(b *bytes.Buffer) error {
+	return rlp.Encode(b, tx)
+}
+
+func (tx *DynamicFeeTx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
 }

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -17,6 +17,7 @@
 package types
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -114,4 +115,12 @@ func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 
 func (tx *LegacyTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.V, tx.R, tx.S = v, r, s
+}
+
+func (tx *LegacyTx) encode(*bytes.Buffer) error {
+	panic("encode called on LegacyTx")
+}
+
+func (tx *LegacyTx) decode([]byte) error {
+	panic("decode called on LegacyTx)")
 }

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// LegacyTx is the transaction data of regular Ethereum transactions.
+// LegacyTx is the transaction data of the original Ethereum transactions.
 type LegacyTx struct {
 	Nonce    uint64          // nonce of sender account
 	GasPrice *big.Int        // wei per gas
@@ -103,6 +103,10 @@ func (tx *LegacyTx) value() *big.Int        { return tx.Value }
 func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
 func (tx *LegacyTx) to() *common.Address    { return tx.To }
 func (tx *LegacyTx) expiredTime() uint64    { return 0 }
+
+func (tx *LegacyTx) blobGas() uint64           { return 0 }
+func (tx *LegacyTx) blobGasFeeCap() *big.Int   { return nil }
+func (tx *LegacyTx) blobHashes() []common.Hash { return nil }
 
 func (tx *LegacyTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil

--- a/core/types/legacy_tx.go
+++ b/core/types/legacy_tx.go
@@ -104,10 +104,6 @@ func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
 func (tx *LegacyTx) to() *common.Address    { return tx.To }
 func (tx *LegacyTx) expiredTime() uint64    { return 0 }
 
-func (tx *LegacyTx) blobGas() uint64           { return 0 }
-func (tx *LegacyTx) blobGasFeeCap() *big.Int   { return nil }
-func (tx *LegacyTx) blobHashes() []common.Hash { return nil }
-
 func (tx *LegacyTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return nil, nil, nil
 }

--- a/core/types/sponsored_tx.go
+++ b/core/types/sponsored_tx.go
@@ -1,9 +1,11 @@
 package types
 
 import (
+	"bytes"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type SponsoredTx struct {
@@ -86,10 +88,6 @@ func (tx *SponsoredTx) nonce() uint64          { return tx.Nonce }
 func (tx *SponsoredTx) to() *common.Address    { return tx.To }
 func (tx *SponsoredTx) expiredTime() uint64    { return tx.ExpiredTime }
 
-func (tx *SponsoredTx) blobGas() uint64           { return 0 }
-func (tx *SponsoredTx) blobGasFeeCap() *big.Int   { return nil }
-func (tx *SponsoredTx) blobHashes() []common.Hash { return nil }
-
 func (tx *SponsoredTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return tx.PayerV, tx.PayerR, tx.PayerS
 }
@@ -100,4 +98,12 @@ func (tx *SponsoredTx) rawSignatureValues() (v, r, s *big.Int) {
 
 func (tx *SponsoredTx) setSignatureValues(chainID, v, r, s *big.Int) {
 	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
+}
+
+func (tx *SponsoredTx) encode(b *bytes.Buffer) error {
+	return rlp.Encode(b, tx)
+}
+
+func (tx *SponsoredTx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
 }

--- a/core/types/sponsored_tx.go
+++ b/core/types/sponsored_tx.go
@@ -86,6 +86,10 @@ func (tx *SponsoredTx) nonce() uint64          { return tx.Nonce }
 func (tx *SponsoredTx) to() *common.Address    { return tx.To }
 func (tx *SponsoredTx) expiredTime() uint64    { return tx.ExpiredTime }
 
+func (tx *SponsoredTx) blobGas() uint64           { return 0 }
+func (tx *SponsoredTx) blobGasFeeCap() *big.Int   { return nil }
+func (tx *SponsoredTx) blobHashes() []common.Hash { return nil }
+
 func (tx *SponsoredTx) rawPayerSignatureValues() (v, r, s *big.Int) {
 	return tx.PayerV, tx.PayerR, tx.PayerS
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -93,8 +93,8 @@ type TxData interface {
 	rawSignatureValues() (v, r, s *big.Int)
 	setSignatureValues(chainID, v, r, s *big.Int)
 
-	encode(b *bytes.Buffer) error
-	decode(b []byte) error
+	encode(*bytes.Buffer) error
+	decode([]byte) error
 }
 
 // EncodeRLP implements rlp.Encoder

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -89,10 +89,6 @@ type TxData interface {
 	to() *common.Address
 	expiredTime() uint64
 
-	blobGas() uint64
-	blobGasFeeCap() *big.Int
-	blobHashes() []common.Hash
-
 	rawPayerSignatureValues() (v, r, s *big.Int)
 	rawSignatureValues() (v, r, s *big.Int)
 	setSignatureValues(chainID, v, r, s *big.Int)
@@ -294,15 +290,6 @@ func (tx *Transaction) GasTipCap() *big.Int { return new(big.Int).Set(tx.inner.g
 // GasFeeCap returns the fee cap per gas of the transaction.
 func (tx *Transaction) GasFeeCap() *big.Int { return new(big.Int).Set(tx.inner.gasFeeCap()) }
 
-// BlobGas returns the data gas limit of the transaction for blob transactions, 0 otherwise.
-func (tx *Transaction) BlobGas() uint64 { return tx.inner.blobGas() }
-
-// BlobGasFeeCap returns the data gas fee cap per data gas of the transaction for blob transactions, nil otherwise.
-func (tx *Transaction) BlobGasFeeCap() *big.Int { return tx.inner.blobGasFeeCap() }
-
-// BlobHashes returns the hases of the blob commitments for blob transactions, nil otherwise.
-func (tx *Transaction) BlobHashes() []common.Hash { return tx.inner.blobHashes() }
-
 // Value returns the ether amount of the transaction.
 func (tx *Transaction) Value() *big.Int { return new(big.Int).Set(tx.inner.value()) }
 
@@ -400,14 +387,38 @@ func (tx *Transaction) EffectiveGasTipIntCmp(other *big.Int, baseFee *big.Int) i
 	return tx.EffectiveGasTipValue(baseFee).Cmp(other)
 }
 
+// BlobGas returns the blob gas limit of the transaction for blob transactions, 0 otherwise.
+func (tx *Transaction) BlobGas() uint64 {
+	if blobtx, ok := tx.inner.(*BlobTx); ok {
+		return blobtx.blobGas()
+	}
+	return 0
+}
+
+// BlobGasFeeCap returns the blob gas fee cap per blob gas of the transaction for blob transactions, nil otherwise.
+func (tx *Transaction) BlobGasFeeCap() *big.Int {
+	if blobtx, ok := tx.inner.(*BlobTx); ok {
+		return blobtx.BlobFeeCap.ToBig()
+	}
+	return nil
+}
+
+// BlobHashes returns the hases of the blob commitments for blob transactions, nil otherwise.
+func (tx *Transaction) BlobHashes() []common.Hash {
+	if blobtx, ok := tx.inner.(*BlobTx); ok {
+		return blobtx.BlobHashes
+	}
+	return nil
+}
+
 // BlobGasFeeCapCmp compares the blob fee cap of two transactions.
 func (tx *Transaction) BlobGasFeeCapCmp(other *Transaction) int {
-	return tx.inner.blobGasFeeCap().Cmp(other.inner.blobGasFeeCap())
+	return tx.BlobGasFeeCap().Cmp(other.BlobGasFeeCap())
 }
 
 // BlobGasFeeCapIntCmp compares the blob fee cap of the transaction against the given blob fee cap.
 func (tx *Transaction) BlobGasFeeCapIntCmp(other *big.Int) int {
-	return tx.inner.blobGasFeeCap().Cmp(other)
+	return tx.BlobGasFeeCap().Cmp(other)
 }
 
 // Hash returns the transaction hash.

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -409,8 +409,8 @@ func (tx *Transaction) BlobHashes() []common.Hash {
 	return nil
 }
 
-// BlobSidecar returns the sidecar of a blob transaction, nil otherwise.
-func (tx *Transaction) BlobSidecar() *BlobSidecar {
+// BlobTxSidecar returns the sidecar of a blob transaction, nil otherwise.
+func (tx *Transaction) BlobTxSidecar() *BlobTxSidecar {
 	if blobtx, ok := tx.inner.(*BlobTx); ok {
 		return blobtx.Sidecar
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -417,6 +417,26 @@ func (tx *Transaction) BlobTxSidecar() *BlobTxSidecar {
 	return nil
 }
 
+// WithoutBlobSidecar returns a copy of tx with the blob sidecar removed.
+func (tx *Transaction) WithoutBlobTxSidecar() *Transaction {
+	blobtx, ok := tx.inner.(*BlobTx)
+	if !ok {
+		return tx
+	}
+	cpy := &Transaction{
+		inner: blobtx.withoutSidecar(),
+		time:  tx.time,
+	}
+	// Note: tx.size cache not carried over because the sidecar is included in size!
+	if h := tx.hash.Load(); h != nil {
+		cpy.hash.Store(h)
+	}
+	if f := tx.from.Load(); f != nil {
+		cpy.from.Store(f)
+	}
+	return cpy
+}
+
 // BlobGasFeeCapCmp compares the blob fee cap of two transactions.
 func (tx *Transaction) BlobGasFeeCapCmp(other *Transaction) int {
 	return tx.BlobGasFeeCap().Cmp(other.BlobGasFeeCap())

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -68,6 +68,9 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
+		if config.CancunBlock != nil {
+			return NewCancunSigner(config.ChainID)
+		}
 		if config.LondonBlock != nil {
 			return NewLondonSigner(config.ChainID)
 		}
@@ -95,7 +98,7 @@ func LatestSignerForChainID(chainID *big.Int) Signer {
 	if chainID == nil {
 		return HomesteadSigner{}
 	}
-	return NewLondonSigner(chainID)
+	return NewCancunSigner(chainID)
 }
 
 // SignTx signs the transaction using the given signer and private key.
@@ -232,6 +235,76 @@ type Signer interface {
 
 	// Payer returns the payer address of sponsored transaction
 	Payer(tx *Transaction) (common.Address, error)
+}
+
+type cancunSigner struct{ londonSigner }
+
+// NewCancunSigner returns a signer that accepts
+// - EIP-4844 blob transactions
+// - EIP-1559 dynamic fee transactions
+// - EIP-2930 access list transactions,
+// - REP-8 sponsored transactions
+// - EIP-155 replay protected transactions, and
+// - legacy Homestead transactions.
+func NewCancunSigner(chainId *big.Int) Signer {
+	return cancunSigner{londonSigner{eip2930Signer{MikoSigner{NewEIP155Signer(chainId)}}}}
+}
+
+func (s cancunSigner) Sender(tx *Transaction) (common.Address, error) {
+	if tx.Type() != BlobTxType {
+		return s.londonSigner.Sender(tx)
+	}
+	V, R, S := tx.RawSignatureValues()
+	// Blob txs are defined to use 0 and 1 as their recovery
+	// id, add 27 to become equivalent to unprotected Homestead signatures.
+	V = new(big.Int).Add(V, big.NewInt(27))
+	if tx.ChainId().Cmp(s.chainId) != 0 {
+		return common.Address{}, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, tx.ChainId(), s.chainId)
+	}
+	return recoverPlain(s.Hash(tx), R, S, V, true)
+}
+
+func (s cancunSigner) Equal(s2 Signer) bool {
+	x, ok := s2.(cancunSigner)
+	return ok && x.chainId.Cmp(s.chainId) == 0
+}
+
+func (s cancunSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
+	txdata, ok := tx.inner.(*BlobTx)
+	if !ok {
+		return s.londonSigner.SignatureValues(tx, sig)
+	}
+	// Check that chain ID of tx matches the signer. We also accept ID zero here,
+	// because it indicates that the chain ID was not specified in the tx.
+	if txdata.ChainID.Sign() != 0 && txdata.ChainID.ToBig().Cmp(s.chainId) != 0 {
+		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
+	}
+	R, S, _ = decodeSignature(sig)
+	V = big.NewInt(int64(sig[64]))
+	return R, S, V, nil
+}
+
+// Hash returns the hash to be signed by the sender.
+// It does not uniquely identify the transaction.
+func (s cancunSigner) Hash(tx *Transaction) common.Hash {
+	if tx.Type() != BlobTxType {
+		return s.londonSigner.Hash(tx)
+	}
+	return prefixedRlpHash(
+		tx.Type(),
+		[]interface{}{
+			s.chainId,
+			tx.Nonce(),
+			tx.GasTipCap(),
+			tx.GasFeeCap(),
+			tx.Gas(),
+			tx.To(),
+			tx.Value(),
+			tx.Data(),
+			tx.AccessList(),
+			tx.BlobGasFeeCap(),
+			tx.BlobHashes(),
+		})
 }
 
 type londonSigner struct{ eip2930Signer }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -166,9 +166,15 @@ const (
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
 
-	BlobTxDataGasPerBlob             = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
-	BlobTxMinDataGasprice            = 1       // Minimum gas price for data blobs
-	BlobTxDataGaspriceUpdateFraction = 2225652 // Controls the maximum rate of change for data gas price
+	BlobTxBytesPerFieldElement         = 32      // Size in bytes of a field element
+	BlobTxFieldElementsPerBlob         = 4096    // Number of field elements stored in a single data blob
+	BlobTxBlobGasPerBlob               = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
+	BlobTxMinBlobGasprice              = 1       // Minimum gas price for data blobs
+	BlobTxBlobGaspriceUpdateFraction   = 3338477 // Controls the maximum rate of change for blob gas price
+	BlobTxPointEvaluationPrecompileGas = 50000   // Gas price for the point evaluation precompile.
+
+	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
+	MaxBlobGasPerBlock          = 6 * BlobTxBlobGasPerBlob // Maximum consumable blob gas for data blobs per block
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -165,6 +165,10 @@ const (
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529
 	RefundQuotient        uint64 = 2
 	RefundQuotientEIP3529 uint64 = 5
+
+	BlobTxDataGasPerBlob             = 1 << 17 // Gas consumption of a single data blob (== blob byte size)
+	BlobTxMinDataGasprice            = 1       // Minimum gas price for data blobs
+	BlobTxDataGaspriceUpdateFraction = 2225652 // Controls the maximum rate of change for data gas price
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/rlp/raw.go
+++ b/rlp/raw.go
@@ -28,6 +28,38 @@ type RawValue []byte
 
 var rawValueType = reflect.TypeOf(RawValue{})
 
+// StringSize returns the encoded size of a string.
+func StringSize(s string) uint64 {
+	switch {
+	case len(s) == 0:
+		return 1
+	case len(s) == 1:
+		if s[0] <= 0x7f {
+			return 1
+		} else {
+			return 2
+		}
+	default:
+		return uint64(headsize(uint64(len(s))) + len(s))
+	}
+}
+
+// BytesSize returns the encoded size of a byte slice.
+func BytesSize(b []byte) uint64 {
+	switch {
+	case len(b) == 0:
+		return 1
+	case len(b) == 1:
+		if b[0] <= 0x7f {
+			return 1
+		} else {
+			return 2
+		}
+	default:
+		return uint64(headsize(uint64(len(b))) + len(b))
+	}
+}
+
 // ListSize returns the encoded size of an RLP list with the given
 // content size.
 func ListSize(contentSize uint64) uint64 {

--- a/rlp/raw_test.go
+++ b/rlp/raw_test.go
@@ -283,3 +283,36 @@ func TestAppendUint64Random(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestBytesSize(t *testing.T) {
+	tests := []struct {
+		v    []byte
+		size uint64
+	}{
+		{v: []byte{}, size: 1},
+		{v: []byte{0x1}, size: 1},
+		{v: []byte{0x7E}, size: 1},
+		{v: []byte{0x7F}, size: 1},
+		{v: []byte{0x80}, size: 2},
+		{v: []byte{0xFF}, size: 2},
+		{v: []byte{0xFF, 0xF0}, size: 3},
+		{v: make([]byte, 55), size: 56},
+		{v: make([]byte, 56), size: 58},
+	}
+
+	for _, test := range tests {
+		s := BytesSize(test.v)
+		if s != test.size {
+			t.Errorf("BytesSize(%#x) -> %d, want %d", test.v, s, test.size)
+		}
+		s = StringSize(string(test.v))
+		if s != test.size {
+			t.Errorf("StringSize(%#x) -> %d, want %d", test.v, s, test.size)
+		}
+		// Sanity check:
+		enc, _ := EncodeToBytes(test.v)
+		if uint64(len(enc)) != test.size {
+			t.Errorf("len(EncodeToBytes(%#x)) -> %d, test says %d", test.v, len(enc), test.size)
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces the blob transaction types as defined in EIP-4844, extending the generic transaction interface. A new signer is included, which incorporates BlobGasFeeCap and BlobHashes into the transaction digest. Additionally, the rlp module has been enhanced with new methods, BytesSize and StringSize, to compute the size of the encoded data. These methods are essential for calculating the RLP encoded data size of blob transactions.