### PR TITLE
Dockerfile: upgrade alpine version to fix CVE-2023-5363

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /opt
 RUN cd /opt && make ronin
 
 # Pull Geth into a second stage deploy alpine container
-FROM alpine:3.18@sha256:48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86
+FROM alpine:3.18@sha256:5292533eb4efd4b5cf35e93b5a2b7d0e07ea193224c49446c7802c19ee4f2da5
 
 RUN apk add --no-cache ca-certificates
 WORKDIR "/opt"


### PR DESCRIPTION
There is tag change to use [the latest alpine 3.18](https://hub.docker.com/layers/library/alpine/3.18/images/sha256-b12c7d46bc14b4260b9e42714688e2dbf5dee973b291a4c12e0e1539404d9f1d?context=explore) available at the moment. Previous 3.18 image requires openssl libs update to mitigate openssl [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363)
Here is what I see in the latest ronin container `ronin:v2.8.3-d27eb42`
```
/opt # apk upgrade libcrypto3 libssl3
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
(1/2) Upgrading libcrypto3 (3.1.3-r0 -> 3.1.6-r0)
(2/2) Upgrading libssl3 (3.1.3-r0 -> 3.1.6-r0)
Executing ca-certificates-20240226-r0.trigger
OK: 8 MiB in 16 packages
```