### PR TITLE
core/rawdb, consensus: add api for snapshot consortium storage

### DIFF
--- a/consensus/consortium/v1/snapshot.go
+++ b/consensus/consortium/v1/snapshot.go
@@ -66,7 +66,7 @@ func newSnapshot(config *params.ConsortiumConfig, sigcache *lru.ARCCache, number
 
 // loadSnapshot loads an existing snapshot from the database.
 func loadSnapshot(config *params.ConsortiumConfig, sigcache *lru.ARCCache, db ethdb.Database, hash common.Hash) (*Snapshot, error) {
-	blob, err := db.Get(append(rawdb.ConsortiumSnapshotPrefix, hash[:]...))
+	blob, err := rawdb.ReadSnapshotConsortium(db, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *Snapshot) store(db ethdb.Database) error {
 	if err != nil {
 		return err
 	}
-	return db.Put(append([]byte("consortium-"), s.Hash[:]...), blob)
+	return rawdb.WriteSnapshotConsortium(db, s.Hash, blob)
 }
 
 // copy creates a deep copy of the snapshot, though not the individual votes.

--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -96,7 +96,7 @@ func loadSnapshot(
 	ethAPI *ethapi.PublicBlockChainAPI,
 	chainConfig *params.ChainConfig,
 ) (*Snapshot, error) {
-	blob, err := db.Get(append([]byte("consortium-"), hash[:]...))
+	blob, err := rawdb.ReadSnapshotConsortium(db, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (s *Snapshot) store(db ethdb.Database) error {
 	if err != nil {
 		return err
 	}
-	return db.Put(append(rawdb.ConsortiumSnapshotPrefix, s.Hash[:]...), blob)
+	return rawdb.WriteSnapshotConsortium(db, s.Hash, blob)
 }
 
 // copy creates a deep copy of the snapshot.

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -216,3 +216,18 @@ func DeleteSnapshotSyncStatus(db ethdb.KeyValueWriter) {
 		log.Crit("Failed to remove snapshot sync status", "err", err)
 	}
 }
+
+// ReadSnapshotConsortium retrieves the snapshot consortium of a given block
+func ReadSnapshotConsortium(db ethdb.KeyValueReader, hash common.Hash) ([]byte, error) {
+	return db.Get(snapshotConsortiumKey(hash))
+}
+
+// WriteSnapshotConsortium stores the snapshot consortium of a block
+func WriteSnapshotConsortium(db ethdb.KeyValueWriter, hash common.Hash, snapshot []byte) error {
+	return db.Put(snapshotConsortiumKey(hash), snapshot)
+}
+
+// DeleteSnapshotConsortium deletes the snapshot consortium of a given block
+func DeleteSnapshotConsortium(db ethdb.KeyValueWriter, hash common.Hash) error {
+	return db.Delete(snapshotConsortiumKey(hash))
+}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -467,7 +467,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			bloomBits.Add(size)
 		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
 			cliqueSnaps.Add(size)
-		case bytes.HasPrefix(key, ConsortiumSnapshotPrefix) && len(key) == len(ConsortiumSnapshotPrefix)+common.HashLength:
+		case bytes.HasPrefix(key, snapshotConsortiumPrefix) && len(key) == len(snapshotConsortiumPrefix)+common.HashLength:
 			consortiumSnaps.Add(size)
 		case bytes.HasPrefix(key, []byte("cht-")) ||
 			bytes.HasPrefix(key, []byte("chtIndexV2-")) ||

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -81,7 +81,7 @@ var (
 	// lastFinalityVoteKey tracks the highest finality vote
 	highestFinalityVoteKey = []byte("HighestFinalityVote")
 
-	ConsortiumSnapshotPrefix = []byte("consortium-") // key = ConsortiumSnapshotPrefix + block hash
+	snapshotConsortiumPrefix = []byte("consortium-") // key = ConsortiumSnapshotPrefix + block hash
 
 	// Data item prefixes (use single byte to avoid mixing data types, avoid `i`, used for indexes).
 	headerPrefix       = []byte("h") // headerPrefix + num (uint64 big endian) + hash -> header
@@ -245,4 +245,8 @@ func IsCodeKey(key []byte) (bool, []byte) {
 // configKey = configPrefix + hash
 func configKey(hash common.Hash) []byte {
 	return append(configPrefix, hash.Bytes()...)
+}
+
+func snapshotConsortiumKey(hash common.Hash) []byte {
+	return append(snapshotConsortiumPrefix, hash.Bytes()...)
 }


### PR DESCRIPTION
Currently, snapshot consortium storage operation is handled by directly interacting with database. This pr groups these operations and provides api interface to interact with snapshot consortium database. 