### PR TITLE
core/types: add Cancun signer to MakeSigner

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -43,6 +43,8 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
+	case config.IsCancun(blockNumber):
+		signer = NewCancunSigner(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
 	case config.IsBerlin(blockNumber):


### PR DESCRIPTION
If the blockNumber is Cancun already, create and return the Cancun signer in MakeSigner.