### PR TITLE
eth: add eth/68 and eth/100

### DIFF
--- a/cmd/devp2p/internal/ethtest/types.go
+++ b/cmd/devp2p/internal/ethtest/types.go
@@ -111,7 +111,7 @@ type NewBlock eth.NewBlockPacket
 func (nb NewBlock) Code() int { return 23 }
 
 // NewPooledTransactionHashes is the network packet for the tx hash propagation message.
-type NewPooledTransactionHashes eth.NewPooledTransactionHashesPacket
+type NewPooledTransactionHashes eth.NewPooledTransactionHashesPacket66
 
 func (nb NewPooledTransactionHashes) Code() int { return 24 }
 

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -230,7 +230,7 @@ func (bc *BlockChain) GetBlobSidecarsByNumber(number uint64) types.BlobSidecars 
 	if sidecars, ok := bc.blobSidecarsCache.Get(hash); ok {
 		return sidecars.(types.BlobSidecars)
 	}
-	
+
 	sidecars := rawdb.ReadBlobSidecars(bc.db, hash, number)
 	bc.blobSidecarsCache.Add(hash, sidecars)
 	return sidecars

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1946,7 +1946,7 @@ func (d *Downloader) DeliverHeaders(id string, headers []*types.Header) error {
 }
 
 // DeliverBodies injects a new batch of block bodies received from a remote node.
-func (d *Downloader) DeliverBodies(id string, transactions [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]types.BlobTxSidecar) error {
+func (d *Downloader) DeliverBodies(id string, transactions [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]*types.BlobTxSidecar) error {
 	return d.deliver(d.bodyCh, &bodyPack{id, transactions, uncles, sidecars}, bodyInMeter, bodyDropMeter)
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1269,7 +1269,7 @@ func (d *Downloader) fetchBodies(from uint64) error {
 	var (
 		deliver = func(packet dataPack) (int, error) {
 			pack := packet.(*bodyPack)
-			return d.queue.DeliverBodies(pack.peerID, pack.transactions, pack.uncles)
+			return d.queue.DeliverBodies(pack.peerID, pack.transactions, pack.uncles, pack.sidecars)
 		}
 		expire   = func() map[string]int { return d.queue.ExpireBodies(d.peers.rates.TargetTimeout()) }
 		fetch    = func(p *peerConnection, req *fetchRequest) error { return p.FetchBodies(req) }
@@ -1946,8 +1946,8 @@ func (d *Downloader) DeliverHeaders(id string, headers []*types.Header) error {
 }
 
 // DeliverBodies injects a new batch of block bodies received from a remote node.
-func (d *Downloader) DeliverBodies(id string, transactions [][]*types.Transaction, uncles [][]*types.Header) error {
-	return d.deliver(d.bodyCh, &bodyPack{id, transactions, uncles}, bodyInMeter, bodyDropMeter)
+func (d *Downloader) DeliverBodies(id string, transactions [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]types.BlobTxSidecar) error {
+	return d.deliver(d.bodyCh, &bodyPack{id, transactions, uncles, sidecars}, bodyInMeter, bodyDropMeter)
 }
 
 // DeliverReceipts injects a new batch of receipts received from a remote node.

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -452,7 +452,7 @@ func (dlp *downloadTesterPeer) RequestHeadersByNumber(origin uint64, amount int,
 // batches of block bodies from the particularly requested peer.
 func (dlp *downloadTesterPeer) RequestBodies(hashes []common.Hash) error {
 	txs, uncles := dlp.chain.bodies(hashes)
-	go dlp.dl.downloader.DeliverBodies(dlp.id, txs, uncles)
+	go dlp.dl.downloader.DeliverBodies(dlp.id, txs, uncles, [][]types.BlobTxSidecar{})
 	return nil
 }
 
@@ -762,7 +762,7 @@ func TestInactiveDownloader63(t *testing.T) {
 	if err := tester.downloader.DeliverHeaders("bad peer", []*types.Header{}); err != errNoSyncActive {
 		t.Errorf("error mismatch: have %v, want %v", err, errNoSyncActive)
 	}
-	if err := tester.downloader.DeliverBodies("bad peer", [][]*types.Transaction{}, [][]*types.Header{}); err != errNoSyncActive {
+	if err := tester.downloader.DeliverBodies("bad peer", [][]*types.Transaction{}, [][]*types.Header{}, [][]types.BlobTxSidecar{}); err != errNoSyncActive {
 		t.Errorf("error mismatch: have %v, want %v", err, errNoSyncActive)
 	}
 	if err := tester.downloader.DeliverReceipts("bad peer", [][]*types.Receipt{}); err != errNoSyncActive {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -452,7 +452,7 @@ func (dlp *downloadTesterPeer) RequestHeadersByNumber(origin uint64, amount int,
 // batches of block bodies from the particularly requested peer.
 func (dlp *downloadTesterPeer) RequestBodies(hashes []common.Hash) error {
 	txs, uncles := dlp.chain.bodies(hashes)
-	go dlp.dl.downloader.DeliverBodies(dlp.id, txs, uncles, [][]types.BlobTxSidecar{})
+	go dlp.dl.downloader.DeliverBodies(dlp.id, txs, uncles, [][]*types.BlobTxSidecar{})
 	return nil
 }
 
@@ -762,7 +762,7 @@ func TestInactiveDownloader63(t *testing.T) {
 	if err := tester.downloader.DeliverHeaders("bad peer", []*types.Header{}); err != errNoSyncActive {
 		t.Errorf("error mismatch: have %v, want %v", err, errNoSyncActive)
 	}
-	if err := tester.downloader.DeliverBodies("bad peer", [][]*types.Transaction{}, [][]*types.Header{}, [][]types.BlobTxSidecar{}); err != errNoSyncActive {
+	if err := tester.downloader.DeliverBodies("bad peer", [][]*types.Transaction{}, [][]*types.Header{}, [][]*types.BlobTxSidecar{}); err != errNoSyncActive {
 		t.Errorf("error mismatch: have %v, want %v", err, errNoSyncActive)
 	}
 	if err := tester.downloader.DeliverReceipts("bad peer", [][]*types.Receipt{}); err != errNoSyncActive {

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -67,7 +67,7 @@ type fetchResult struct {
 	Header       *types.Header
 	Uncles       []*types.Header
 	Transactions types.Transactions
-	Sidecars     []types.BlobTxSidecar
+	Sidecars     []*types.BlobTxSidecar
 	Receipts     types.Receipts
 }
 
@@ -754,7 +754,7 @@ func (q *queue) DeliverHeaders(id string, headers []*types.Header, headerProcCh 
 // DeliverBodies injects a block body retrieval response into the results queue.
 // The method returns the number of blocks bodies accepted from the delivery and
 // also wakes any threads waiting for data delivery.
-func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLists [][]*types.Header, sidecars [][]types.BlobTxSidecar) (int, error) {
+func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLists [][]*types.Header, sidecars [][]*types.BlobTxSidecar) (int, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	trieHasher := trie.NewStackTrie(nil)

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -67,6 +67,7 @@ type fetchResult struct {
 	Header       *types.Header
 	Uncles       []*types.Header
 	Transactions types.Transactions
+	Sidecars     []types.BlobTxSidecar
 	Receipts     types.Receipts
 }
 
@@ -753,7 +754,7 @@ func (q *queue) DeliverHeaders(id string, headers []*types.Header, headerProcCh 
 // DeliverBodies injects a block body retrieval response into the results queue.
 // The method returns the number of blocks bodies accepted from the delivery and
 // also wakes any threads waiting for data delivery.
-func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLists [][]*types.Header) (int, error) {
+func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLists [][]*types.Header, sidecars [][]types.BlobTxSidecar) (int, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	trieHasher := trie.NewStackTrie(nil)
@@ -770,6 +771,9 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLi
 	reconstruct := func(index int, result *fetchResult) {
 		result.Transactions = txLists[index]
 		result.Uncles = uncleLists[index]
+		if len(sidecars) > 0 {
+			result.Sidecars = sidecars[index]
+		}
 		result.SetBodyDone()
 	}
 	return q.deliver(id, q.blockTaskPool, q.blockTaskQueue, q.blockPendPool,

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -320,7 +320,7 @@ func XTestDelivery(t *testing.T) {
 					uncles = append(uncles, emptyList)
 				}
 				time.Sleep(100 * time.Millisecond)
-				_, err := q.DeliverBodies(peer.id, txs, uncles, [][]types.BlobTxSidecar{})
+				_, err := q.DeliverBodies(peer.id, txs, uncles, [][]*types.BlobTxSidecar{})
 				if err != nil {
 					fmt.Printf("delivered %d bodies %v\n", len(txs), err)
 				}

--- a/eth/downloader/queue_test.go
+++ b/eth/downloader/queue_test.go
@@ -320,7 +320,7 @@ func XTestDelivery(t *testing.T) {
 					uncles = append(uncles, emptyList)
 				}
 				time.Sleep(100 * time.Millisecond)
-				_, err := q.DeliverBodies(peer.id, txs, uncles)
+				_, err := q.DeliverBodies(peer.id, txs, uncles, [][]types.BlobTxSidecar{})
 				if err != nil {
 					fmt.Printf("delivered %d bodies %v\n", len(txs), err)
 				}

--- a/eth/downloader/types.go
+++ b/eth/downloader/types.go
@@ -47,7 +47,7 @@ type bodyPack struct {
 	peerID       string
 	transactions [][]*types.Transaction
 	uncles       [][]*types.Header
-	sidecars     [][]types.BlobTxSidecar
+	sidecars     [][]*types.BlobTxSidecar
 }
 
 func (p *bodyPack) PeerId() string { return p.peerID }

--- a/eth/downloader/types.go
+++ b/eth/downloader/types.go
@@ -47,6 +47,7 @@ type bodyPack struct {
 	peerID       string
 	transactions [][]*types.Transaction
 	uncles       [][]*types.Header
+	sidecars     [][]types.BlobTxSidecar
 }
 
 func (p *bodyPack) PeerId() string { return p.peerID }

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -121,18 +121,20 @@ type headerFilterTask struct {
 // bodyFilterTask represents a batch of block bodies (transactions and uncles)
 // needing fetcher filtering.
 type bodyFilterTask struct {
-	peer         string                 // The source peer of block bodies
-	transactions [][]*types.Transaction // Collection of transactions per block bodies
-	uncles       [][]*types.Header      // Collection of uncles per block bodies
-	time         time.Time              // Arrival time of the blocks' contents
+	peer         string                  // The source peer of block bodies
+	transactions [][]*types.Transaction  // Collection of transactions per block bodies
+	uncles       [][]*types.Header       // Collection of uncles per block bodies
+	sidecars     [][]types.BlobTxSidecar // Collection of sidecars per block bodies
+	time         time.Time               // Arrival time of the blocks' contents
 }
 
 // blockOrHeaderInject represents a schedules import operation.
 type blockOrHeaderInject struct {
 	origin string
 
-	header *types.Header // Used for light mode fetcher which only cares about header.
-	block  *types.Block  // Used for normal mode fetcher which imports full block.
+	header   *types.Header // Used for light mode fetcher which only cares about header.
+	block    *types.Block  // Used for normal mode fetcher which imports full block.
+	sidecars []types.BlobTxSidecar
 }
 
 // number returns the block number of the injected object.
@@ -258,10 +260,11 @@ func (f *BlockFetcher) Notify(peer string, hash common.Hash, number uint64, time
 }
 
 // Enqueue tries to fill gaps the fetcher's future import queue.
-func (f *BlockFetcher) Enqueue(peer string, block *types.Block) error {
+func (f *BlockFetcher) Enqueue(peer string, block *types.Block, sidecars []types.BlobTxSidecar) error {
 	op := &blockOrHeaderInject{
-		origin: peer,
-		block:  block,
+		origin:   peer,
+		block:    block,
+		sidecars: sidecars,
 	}
 	select {
 	case f.inject <- op:
@@ -301,7 +304,7 @@ func (f *BlockFetcher) FilterHeaders(peer string, headers []*types.Header, time 
 
 // FilterBodies extracts all the block bodies that were explicitly requested by
 // the fetcher, returning those that should be handled differently.
-func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, uncles [][]*types.Header, time time.Time) ([][]*types.Transaction, [][]*types.Header) {
+func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]types.BlobTxSidecar, time time.Time) ([][]*types.Transaction, [][]*types.Header, [][]types.BlobTxSidecar) {
 	log.Trace("Filtering bodies", "peer", peer, "txs", len(transactions), "uncles", len(uncles))
 
 	// Send the filter channel to the fetcher
@@ -310,20 +313,20 @@ func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transac
 	select {
 	case f.bodyFilter <- filter:
 	case <-f.quit:
-		return nil, nil
+		return nil, nil, nil
 	}
 	// Request the filtering of the body list
 	select {
-	case filter <- &bodyFilterTask{peer: peer, transactions: transactions, uncles: uncles, time: time}:
+	case filter <- &bodyFilterTask{peer: peer, transactions: transactions, uncles: uncles, sidecars: sidecars, time: time}:
 	case <-f.quit:
-		return nil, nil
+		return nil, nil, nil
 	}
 	// Retrieve the bodies remaining after filtering
 	select {
 	case task := <-filter:
-		return task.transactions, task.uncles
+		return task.transactions, task.uncles, task.sidecars
 	case <-f.quit:
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 
@@ -425,7 +428,7 @@ func (f *BlockFetcher) loop() {
 			if f.light {
 				continue
 			}
-			f.enqueue(op.origin, nil, op.block)
+			f.enqueue(op.origin, nil, op.block, op.sidecars)
 
 		case hash := <-f.done:
 			// A pending import finished, remove all traces of the notification
@@ -586,12 +589,12 @@ func (f *BlockFetcher) loop() {
 			}
 			// Schedule the header for light fetcher import
 			for _, announce := range lightHeaders {
-				f.enqueue(announce.origin, announce.header, nil)
+				f.enqueue(announce.origin, announce.header, nil, nil)
 			}
 			// Schedule the header-only blocks for import
 			for _, block := range complete {
 				if announce := f.completing[block.Hash()]; announce != nil {
-					f.enqueue(announce.origin, nil, block)
+					f.enqueue(announce.origin, nil, block, nil)
 				}
 			}
 
@@ -605,6 +608,7 @@ func (f *BlockFetcher) loop() {
 			}
 			bodyFilterInMeter.Mark(int64(len(task.transactions)))
 			blocks := []*types.Block{}
+			sidecarsList := [][]types.BlobTxSidecar{}
 			// abort early if there's nothing explicitly requested
 			if len(f.completing) > 0 {
 				for i := 0; i < len(task.transactions) && i < len(task.uncles); i++ {
@@ -636,6 +640,9 @@ func (f *BlockFetcher) loop() {
 							block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
+							if len(task.sidecars) > 0 {
+								sidecarsList = append(sidecarsList, task.sidecars[i])
+							}
 						} else {
 							f.forgetHash(hash)
 						}
@@ -644,6 +651,9 @@ func (f *BlockFetcher) loop() {
 					if matched {
 						task.transactions = append(task.transactions[:i], task.transactions[i+1:]...)
 						task.uncles = append(task.uncles[:i], task.uncles[i+1:]...)
+						if len(task.sidecars) > 0 {
+							task.sidecars = append(task.sidecars[:i], task.sidecars[i+1:]...)
+						}
 						i--
 						continue
 					}
@@ -656,9 +666,13 @@ func (f *BlockFetcher) loop() {
 				return
 			}
 			// Schedule the retrieved blocks for ordered import
-			for _, block := range blocks {
+			for i, block := range blocks {
 				if announce := f.completing[block.Hash()]; announce != nil {
-					f.enqueue(announce.origin, nil, block)
+					var sidecars []types.BlobTxSidecar
+					if len(sidecarsList) > i {
+						sidecars = sidecarsList[i]
+					}
+					f.enqueue(announce.origin, nil, block, sidecars)
 				}
 			}
 		}
@@ -705,7 +719,7 @@ func (f *BlockFetcher) rescheduleComplete(complete *time.Timer) {
 
 // enqueue schedules a new header or block import operation, if the component
 // to be imported has not yet been seen.
-func (f *BlockFetcher) enqueue(peer string, header *types.Header, block *types.Block) {
+func (f *BlockFetcher) enqueue(peer string, header *types.Header, block *types.Block, sidecars []types.BlobTxSidecar) {
 	var (
 		hash   common.Hash
 		number uint64
@@ -738,6 +752,7 @@ func (f *BlockFetcher) enqueue(peer string, header *types.Header, block *types.B
 		} else {
 			op.block = block
 		}
+		op.sidecars = sidecars
 		f.queues[peer] = count
 		f.queued[hash] = op
 		f.queue.Push(op, -int64(number))

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -549,10 +549,10 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		// Send the block to a subset of our peers
 		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 		for _, peer := range transfer {
-			var sidecars []types.BlobTxSidecar
+			var sidecars []*types.BlobTxSidecar
 			if peer.Version() >= eth.ETH100 {
 				for _, blobSidecar := range rawdb.ReadBlobSidecars(h.database, block.Hash(), block.NumberU64()) {
-					sidecars = append(sidecars, (*blobSidecar).BlobTxSidecar)
+					sidecars = append(sidecars, &blobSidecar.BlobTxSidecar)
 				}
 			}
 			peer.AsyncSendNewBlock(block, td, sidecars)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vote"
@@ -548,7 +549,13 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		// Send the block to a subset of our peers
 		transfer := peers[:int(math.Sqrt(float64(len(peers))))]
 		for _, peer := range transfer {
-			peer.AsyncSendNewBlock(block, td)
+			var sidecars []types.BlobTxSidecar
+			if peer.Version() >= eth.ETH100 {
+				for _, blobSidecar := range rawdb.ReadBlobSidecars(h.database, block.Hash(), block.NumberU64()) {
+					sidecars = append(sidecars, (*blobSidecar).BlobTxSidecar)
+				}
+			}
+			peer.AsyncSendNewBlock(block, td, sidecars)
 		}
 		log.Trace("Propagated block", "hash", hash, "recipients", len(transfer), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
 		return

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -69,7 +69,11 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 
 	case *eth.BlockBodiesPacket:
 		txset, uncleset := packet.Unpack()
-		return h.handleBodies(peer, txset, uncleset)
+		return h.handleBodies(peer, txset, uncleset, [][]types.BlobTxSidecar{})
+
+	case *eth.BlockBodiesPacket100:
+		txset, uncleset, sidecarset := packet.Unpack()
+		return h.handleBodies(peer, txset, uncleset, sidecarset)
 
 	case *eth.NodeDataPacket:
 		if err := h.downloader.DeliverNodeData(peer.ID(), *packet); err != nil {
@@ -88,7 +92,10 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		return h.handleBlockAnnounces(peer, hashes, numbers)
 
 	case *eth.NewBlockPacket:
-		return h.handleBlockBroadcast(peer, packet.Block, packet.TD)
+		return h.handleBlockBroadcast(peer, packet.Block, packet.TD, []types.BlobTxSidecar{})
+
+	case *eth.NewBlockPacket100:
+		return h.handleBlockBroadcast(peer, packet.Block, packet.TD, packet.Sidecars)
 
 	case *eth.NewPooledTransactionHashesPacket66:
 		return h.txFetcher.Notify(peer.ID(), *packet)
@@ -165,7 +172,7 @@ func (h *ethHandler) handleHeaders(peer *eth.Peer, headers []*types.Header) erro
 
 // handleBodies is invoked from a peer's message handler when it transmits a batch
 // of block bodies for the local node to process.
-func (h *ethHandler) handleBodies(peer *eth.Peer, txs [][]*types.Transaction, uncles [][]*types.Header) error {
+func (h *ethHandler) handleBodies(peer *eth.Peer, txs [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]types.BlobTxSidecar) error {
 	// Filter out any explicitly requested bodies, deliver the rest to the downloader
 	filter := len(txs) > 0 || len(uncles) > 0
 	if filter {
@@ -202,7 +209,7 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 
 // handleBlockBroadcast is invoked from a peer's message handler when it transmits a
 // block broadcast for the local node to process.
-func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td *big.Int) error {
+func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td *big.Int, sidecars []types.BlobTxSidecar) error {
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block)
 

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -90,8 +90,11 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	case *eth.NewBlockPacket:
 		return h.handleBlockBroadcast(peer, packet.Block, packet.TD)
 
-	case *eth.NewPooledTransactionHashesPacket:
+	case *eth.NewPooledTransactionHashesPacket66:
 		return h.txFetcher.Notify(peer.ID(), *packet)
+
+	case *eth.NewPooledTransactionHashesPacket68:
+		return h.txFetcher.Notify(peer.ID(), packet.Hashes)
 
 	case *eth.TransactionsPacket:
 		return h.txFetcher.Enqueue(peer.ID(), *packet, false)

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -69,7 +69,7 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 
 	case *eth.BlockBodiesPacket:
 		txset, uncleset := packet.Unpack()
-		return h.handleBodies(peer, txset, uncleset, [][]types.BlobTxSidecar{})
+		return h.handleBodies(peer, txset, uncleset, [][]*types.BlobTxSidecar{})
 
 	case *eth.BlockBodiesPacket100:
 		txset, uncleset, sidecarset := packet.Unpack()
@@ -92,7 +92,7 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		return h.handleBlockAnnounces(peer, hashes, numbers)
 
 	case *eth.NewBlockPacket:
-		return h.handleBlockBroadcast(peer, packet.Block, packet.TD, []types.BlobTxSidecar{})
+		return h.handleBlockBroadcast(peer, packet.Block, packet.TD, []*types.BlobTxSidecar{})
 
 	case *eth.NewBlockPacket100:
 		return h.handleBlockBroadcast(peer, packet.Block, packet.TD, packet.Sidecars)
@@ -172,7 +172,7 @@ func (h *ethHandler) handleHeaders(peer *eth.Peer, headers []*types.Header) erro
 
 // handleBodies is invoked from a peer's message handler when it transmits a batch
 // of block bodies for the local node to process.
-func (h *ethHandler) handleBodies(peer *eth.Peer, txs [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]types.BlobTxSidecar) error {
+func (h *ethHandler) handleBodies(peer *eth.Peer, txs [][]*types.Transaction, uncles [][]*types.Header, sidecars [][]*types.BlobTxSidecar) error {
 	// Filter out any explicitly requested bodies, deliver the rest to the downloader
 	filter := len(txs) > 0 || len(uncles) > 0
 	if filter {
@@ -209,7 +209,7 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 
 // handleBlockBroadcast is invoked from a peer's message handler when it transmits a
 // block broadcast for the local node to process.
-func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td *big.Int, sidecars []types.BlobTxSidecar) error {
+func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td *big.Int, sidecars []*types.BlobTxSidecar) error {
 	// Schedule the block for import
 	h.blockFetcher.Enqueue(peer.ID(), block, sidecars)
 

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -176,10 +176,10 @@ func (h *ethHandler) handleBodies(peer *eth.Peer, txs [][]*types.Transaction, un
 	// Filter out any explicitly requested bodies, deliver the rest to the downloader
 	filter := len(txs) > 0 || len(uncles) > 0
 	if filter {
-		txs, uncles = h.blockFetcher.FilterBodies(peer.ID(), txs, uncles, time.Now())
+		txs, uncles, sidecars = h.blockFetcher.FilterBodies(peer.ID(), txs, uncles, sidecars, time.Now())
 	}
 	if len(txs) > 0 || len(uncles) > 0 || !filter {
-		err := h.downloader.DeliverBodies(peer.ID(), txs, uncles)
+		err := h.downloader.DeliverBodies(peer.ID(), txs, uncles, sidecars)
 		if err != nil {
 			log.Debug("Failed to deliver bodies", "err", err)
 		}
@@ -211,7 +211,7 @@ func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, 
 // block broadcast for the local node to process.
 func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td *big.Int, sidecars []types.BlobTxSidecar) error {
 	// Schedule the block for import
-	h.blockFetcher.Enqueue(peer.ID(), block)
+	h.blockFetcher.Enqueue(peer.ID(), block, sidecars)
 
 	// Assuming the block is importable by the peer, but possibly not yet done so,
 	// calculate the head hash and TD that the peer truly must have.

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -734,7 +734,7 @@ func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
 	// Try to broadcast all malformations and ensure they all get discarded
 	for _, header := range []*types.Header{malformedUncles, malformedTransactions, malformedEverything} {
 		block := types.NewBlockWithHeader(header).WithBody(head.Transactions(), head.Uncles())
-		if err := src.SendNewBlock(block, big.NewInt(131136), []types.BlobTxSidecar{}); err != nil {
+		if err := src.SendNewBlock(block, big.NewInt(131136), []*types.BlobTxSidecar{}); err != nil {
 			t.Fatalf("failed to broadcast block: %v", err)
 		}
 		select {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -61,8 +61,12 @@ func (h *testEthHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		h.blockBroadcasts.Send(packet.Block)
 		return nil
 
-	case *eth.NewPooledTransactionHashesPacket:
+	case *eth.NewPooledTransactionHashesPacket66:
 		h.txAnnounces.Send(([]common.Hash)(*packet))
+		return nil
+
+	case *eth.NewPooledTransactionHashesPacket68:
+		h.txAnnounces.Send(packet.Hashes)
 		return nil
 
 	case *eth.TransactionsPacket:

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -734,7 +734,7 @@ func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
 	// Try to broadcast all malformations and ensure they all get discarded
 	for _, header := range []*types.Header{malformedUncles, malformedTransactions, malformedEverything} {
 		block := types.NewBlockWithHeader(header).WithBody(head.Transactions(), head.Uncles())
-		if err := src.SendNewBlock(block, big.NewInt(131136)); err != nil {
+		if err := src.SendNewBlock(block, big.NewInt(131136), []types.BlobTxSidecar{}); err != nil {
 			t.Fatalf("failed to broadcast block: %v", err)
 		}
 		select {

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -142,13 +142,17 @@ func (p *Peer) announceTransactions() {
 		if done == nil && len(queue) > 0 {
 			// Pile transaction hashes until we reach our allowed network limit
 			var (
-				count   int
-				pending []common.Hash
-				size    common.StorageSize
+				count        int
+				pending      []common.Hash
+				pendingTypes []byte
+				pendingSizes []uint32
+				size         common.StorageSize
 			)
 			for count = 0; count < len(queue) && size < maxTxPacketSize; count++ {
-				if p.txpool.Get(queue[count]) != nil {
+				if tx := p.txpool.Get(queue[count]); tx != nil {
 					pending = append(pending, queue[count])
+					pendingTypes = append(pendingTypes, tx.Type())
+					pendingSizes = append(pendingSizes, uint32(tx.Size()))
 					size += common.HashLength
 				}
 			}
@@ -159,9 +163,16 @@ func (p *Peer) announceTransactions() {
 			if len(pending) > 0 {
 				done = make(chan struct{})
 				go func() {
-					if err := p.sendPooledTransactionHashes(pending); err != nil {
-						fail <- err
-						return
+					if p.version >= ETH100 {
+						if err := p.sendPooledTransactionHashes68(pending, pendingTypes, pendingSizes); err != nil {
+							fail <- err
+							return
+						}
+					} else {
+						if err := p.sendPooledTransactionHashes66(pending); err != nil {
+							fail <- err
+							return
+						}
 					}
 					close(done)
 					p.Log().Trace("Sent transaction announcements", "count", len(pending))

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -32,8 +32,9 @@ const (
 // blockPropagation is a block propagation event, waiting for its turn in the
 // broadcast queue.
 type blockPropagation struct {
-	block *types.Block
-	td    *big.Int
+	block    *types.Block
+	td       *big.Int
+	sidecars []types.BlobTxSidecar
 }
 
 // broadcastBlocks is a write loop that multiplexes blocks and block accouncements
@@ -43,7 +44,7 @@ func (p *Peer) broadcastBlocks() {
 	for {
 		select {
 		case prop := <-p.queuedBlocks:
-			if err := p.SendNewBlock(prop.block, prop.td); err != nil {
+			if err := p.SendNewBlock(prop.block, prop.td, prop.sidecars); err != nil {
 				return
 			}
 			p.Log().Trace("Propagated block", "number", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -34,7 +34,7 @@ const (
 type blockPropagation struct {
 	block    *types.Block
 	td       *big.Int
-	sidecars []types.BlobTxSidecar
+	sidecars []*types.BlobTxSidecar
 }
 
 // broadcastBlocks is a write loop that multiplexes blocks and block accouncements

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -188,6 +188,21 @@ var eth66 = map[uint64]msgHandler{
 	PooledTransactionsMsg:         handlePooledTransactions66,
 }
 
+var eth100 = map[uint64]msgHandler{
+	NewBlockHashesMsg:             handleNewBlockhashes,
+	NewBlockMsg:                   handleNewBlock100,
+	TransactionsMsg:               handleTransactions,
+	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes68,
+	GetBlockHeadersMsg:            handleGetBlockHeaders66,
+	BlockHeadersMsg:               handleBlockHeaders66,
+	GetBlockBodiesMsg:             handleGetBlockBodies100,
+	BlockBodiesMsg:                handleBlockBodies100,
+	GetReceiptsMsg:                handleGetReceipts66,
+	ReceiptsMsg:                   handleReceipts66,
+	GetPooledTransactionsMsg:      handleGetPooledTransactions66,
+	PooledTransactionsMsg:         handlePooledTransactions66,
+}
+
 // handleMessage is invoked whenever an inbound message is received from a remote
 // peer. The remote connection is torn down upon returning any error.
 func handleMessage(backend Backend, peer *Peer) error {
@@ -202,9 +217,9 @@ func handleMessage(backend Backend, peer *Peer) error {
 	defer msg.Discard()
 
 	var handlers = eth66
-	//if peer.Version() >= ETH67 { // Left in as a sample when new protocol is added
-	//	handlers = eth67
-	//}
+	if peer.Version() >= ETH100 {
+		handlers = eth100
+	}
 
 	// Track the amount of time it takes to serve the request and run the handler
 	if metrics.Enabled {

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -175,7 +175,7 @@ var eth66 = map[uint64]msgHandler{
 	NewBlockHashesMsg:             handleNewBlockhashes,
 	NewBlockMsg:                   handleNewBlock,
 	TransactionsMsg:               handleTransactions,
-	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes,
+	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes66,
 	GetBlockHeadersMsg:            handleGetBlockHeaders66,
 	BlockHeadersMsg:               handleBlockHeaders66,
 	GetBlockBodiesMsg:             handleGetBlockBodies66,

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -381,9 +381,9 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 }
 
 // Tests that the state trie nodes can be retrieved based on hashes.
-func TestGetNodeData66(t *testing.T) { testGetNodeData(t, ETH66) }
+func TestGetNodeData66(t *testing.T) { testGetNodeData(t, ETH66, false) }
 
-func testGetNodeData(t *testing.T, protocol uint) {
+func testGetNodeData(t *testing.T, protocol uint, drop bool) {
 	t.Parallel()
 
 	// Define three accounts to simulate transactions with
@@ -444,8 +444,15 @@ func testGetNodeData(t *testing.T, protocol uint) {
 		GetNodeDataPacket: hashes,
 	})
 	msg, err := peer.app.ReadMsg()
-	if err != nil {
-		t.Fatalf("failed to read node data response: %v", err)
+	if !drop {
+		if err != nil {
+			t.Fatalf("failed to read node data response: %v", err)
+		}
+	} else {
+		if err != nil {
+			return
+		}
+		t.Fatalf("succeeded to read node data response on non-supporting protocol: %v", msg)
 	}
 	if msg.Code != NodeDataMsg {
 		t.Fatalf("response packet code mismatch: have %x, want %x", msg.Code, NodeDataMsg)

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -134,6 +134,16 @@ func handleGetBlockBodies66(backend Backend, msg Decoder, peer *Peer) error {
 	return peer.ReplyBlockBodiesRLP(query.RequestId, response)
 }
 
+func handleGetBlockBodies100(backend Backend, msg Decoder, peer *Peer) error {
+	// Decode the block body retrieval message
+	var query GetBlockBodiesPacket66
+	if err := msg.Decode(&query); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	response, sidecars := answerGetBlockBodiesQuery100(backend, query.GetBlockBodiesPacket, peer)
+	return peer.ReplyBlockBodiesRLP100(query.RequestId, response, sidecars)
+}
+
 func answerGetBlockBodiesQuery(backend Backend, query GetBlockBodiesPacket, peer *Peer) []rlp.RawValue {
 	// Gather blocks until the fetch or network limits is reached
 	var (
@@ -151,6 +161,35 @@ func answerGetBlockBodiesQuery(backend Backend, query GetBlockBodiesPacket, peer
 		}
 	}
 	return bodies
+}
+
+func answerGetBlockBodiesQuery100(backend Backend, query GetBlockBodiesPacket, peer *Peer) ([]rlp.RawValue, [][]*types.BlobTxSidecar) {
+	// Gather blocks until the fetch or network limits is reached
+	var (
+		bytes        int
+		bodies       []rlp.RawValue
+		sidecarsList [][]*types.BlobTxSidecar
+	)
+	for lookups, hash := range query {
+		if bytes >= softResponseLimit || len(bodies) >= maxBodiesServe ||
+			lookups >= 2*maxBodiesServe {
+			break
+		}
+		if data := backend.Chain().GetBodyRLP(hash); len(data) != 0 {
+			bodies = append(bodies, data)
+			bytes += len(data)
+			sidecars := make([]*types.BlobTxSidecar, 0)
+			blobSidecars := backend.Chain().GetBlobSidecarsByHash(hash)
+			if blobSidecars != nil {
+				for _, sidecar := range blobSidecars {
+					sidecars = append(sidecars, &sidecar.BlobTxSidecar)
+				}
+			}
+			sidecarsList = append(sidecarsList, sidecars)
+		}
+
+	}
+	return bodies, sidecarsList
 }
 
 func handleGetNodeData66(backend Backend, msg Decoder, peer *Peer) error {
@@ -271,6 +310,32 @@ func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
 	return backend.Handle(peer, ann)
 }
 
+func handleNewBlock100(backend Backend, msg Decoder, peer *Peer) error {
+	// Retrieve and decode the propagated block
+	ann := new(NewBlockPacket100)
+	if err := msg.Decode(ann); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if err := ann.sanityCheck(); err != nil {
+		return err
+	}
+	if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
+		log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
+		return nil // TODO(karalabe): return error eventually, but wait a few releases
+	}
+	if hash := types.DeriveSha(ann.Block.Transactions(), trie.NewStackTrie(nil)); hash != ann.Block.TxHash() {
+		log.Warn("Propagated block has invalid body", "have", hash, "exp", ann.Block.TxHash())
+		return nil // TODO(karalabe): return error eventually, but wait a few releases
+	}
+	ann.Block.ReceivedAt = msg.Time()
+	ann.Block.ReceivedFrom = peer
+
+	// Mark the peer as owning the block
+	peer.markBlock(ann.Block.Hash())
+
+	return backend.Handle(peer, ann)
+}
+
 func handleBlockHeaders66(backend Backend, msg Decoder, peer *Peer) error {
 	// A batch of headers arrived to one of our previous requests
 	res := new(BlockHeadersPacket66)
@@ -291,6 +356,17 @@ func handleBlockBodies66(backend Backend, msg Decoder, peer *Peer) error {
 	requestTracker.Fulfil(peer.id, peer.version, BlockBodiesMsg, res.RequestId)
 
 	return backend.Handle(peer, &res.BlockBodiesPacket)
+}
+
+func handleBlockBodies100(backend Backend, msg Decoder, peer *Peer) error {
+	// A batch of block bodies arrived to one of our previous requests
+	res := new(BlockBodiesPacket100)
+	if err := msg.Decode(res); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	requestTracker.Fulfil(peer.id, peer.version, BlockBodiesMsg, res.RequestId)
+
+	return backend.Handle(peer, res)
 }
 
 func handleNodeData66(backend Backend, msg Decoder, peer *Peer) error {

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -315,18 +315,38 @@ func handleReceipts66(backend Backend, msg Decoder, peer *Peer) error {
 	return backend.Handle(peer, &res.ReceiptsPacket)
 }
 
-func handleNewPooledTransactionHashes(backend Backend, msg Decoder, peer *Peer) error {
+func handleNewPooledTransactionHashes66(backend Backend, msg Decoder, peer *Peer) error {
 	// New transaction announcement arrived, make sure we have
 	// a valid and fresh chain to handle them
 	if !backend.AcceptTxs() {
 		return nil
 	}
-	ann := new(NewPooledTransactionHashesPacket)
+	ann := new(NewPooledTransactionHashesPacket66)
 	if err := msg.Decode(ann); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	// Schedule all the unknown hashes for retrieval
 	for _, hash := range *ann {
+		peer.markTransaction(hash)
+	}
+	return backend.Handle(peer, ann)
+}
+
+func handleNewPooledTransactionHashes68(backend Backend, msg Decoder, peer *Peer) error {
+	// New transaction announcement arrived, make sure we have
+	// a valid and fresh chain to handle them
+	if !backend.AcceptTxs() {
+		return nil
+	}
+	ann := new(NewPooledTransactionHashesPacket68)
+	if err := msg.Decode(ann); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if len(ann.Hashes) != len(ann.Types) || len(ann.Hashes) != len(ann.Sizes) {
+		return fmt.Errorf("%w: message %v: invalid len of fields: %v %v %v", errDecode, msg, len(ann.Hashes), len(ann.Types), len(ann.Sizes))
+	}
+	// Schedule all the unknown hashes for retrieval
+	for _, hash := range ann.Hashes {
 		peer.markTransaction(hash)
 	}
 	return backend.Handle(peer, ann)

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -310,6 +310,16 @@ func (p *Peer) ReplyBlockBodiesRLP(id uint64, bodies []rlp.RawValue) error {
 	})
 }
 
+// ReplyBlockBodiesRLP100 is the eth/100 version of SendBlockBodiesRLP.
+func (p *Peer) ReplyBlockBodiesRLP100(id uint64, bodies []rlp.RawValue, sidecars [][]*types.BlobTxSidecar) error {
+	// Not packed into BlockBodiesPacket to avoid RLP decoding
+	return p2p.Send(p.rw, BlockBodiesMsg, BlockBodiesRLPPacket100{
+		RequestId:            id,
+		BlockBodiesRLPPacket: bodies,
+		Sidecars:             sidecars,
+	})
+}
+
 // ReplyNodeData is the eth/66 response to GetNodeData.
 func (p *Peer) ReplyNodeData(id uint64, data [][]byte) error {
 	return p2p.Send(p.rw, NodeDataMsg, NodeDataPacket66{

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -272,7 +272,7 @@ func (p *Peer) AsyncSendNewBlockHash(block *types.Block) {
 }
 
 // SendNewBlock propagates an entire block to a remote peer.
-func (p *Peer) SendNewBlock(block *types.Block, td *big.Int, sidecars []types.BlobTxSidecar) error {
+func (p *Peer) SendNewBlock(block *types.Block, td *big.Int, sidecars []*types.BlobTxSidecar) error {
 	// Mark all the block hash as known, but ensure we don't overflow our limits
 	p.knownBlocks.Add(block.Hash())
 	if p.Version() >= ETH100 {
@@ -290,7 +290,7 @@ func (p *Peer) SendNewBlock(block *types.Block, td *big.Int, sidecars []types.Bl
 
 // AsyncSendNewBlock queues an entire block for propagation to a remote peer. If
 // the peer's broadcast queue is full, the event is silently dropped.
-func (p *Peer) AsyncSendNewBlock(block *types.Block, td *big.Int, sidecars []types.BlobTxSidecar) {
+func (p *Peer) AsyncSendNewBlock(block *types.Block, td *big.Int, sidecars []*types.BlobTxSidecar) {
 	select {
 	case p.queuedBlocks <- &blockPropagation{block: block, td: td, sidecars: sidecars}:
 		// Mark all the block hash as known, but ensure we don't overflow our limits

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -194,16 +194,29 @@ func (p *Peer) AsyncSendTransactions(hashes []common.Hash) {
 	}
 }
 
-// sendPooledTransactionHashes sends transaction hashes to the peer and includes
+// sendPooledTransactionHashes66 sends transaction hashes to the peer and includes
 // them in its transaction hash set for future reference.
 //
 // This method is a helper used by the async transaction announcer. Don't call it
 // directly as the queueing (memory) and transmission (bandwidth) costs should
 // not be managed directly.
-func (p *Peer) sendPooledTransactionHashes(hashes []common.Hash) error {
+func (p *Peer) sendPooledTransactionHashes66(hashes []common.Hash) error {
 	// Mark all the transactions as known, but ensure we don't overflow our limits
 	p.knownTxs.Add(hashes...)
-	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket(hashes))
+	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket66(hashes))
+}
+
+// sendPooledTransactionHashes68 sends transaction hashes (tagged with their type
+// and size) to the peer and includes them in its transaction hash set for future
+// reference.
+//
+// This method is a helper used by the async transaction announcer. Don't call it
+// directly as the queueing (memory) and transmission (bandwidth) costs should
+// not be managed directly.
+func (p *Peer) sendPooledTransactionHashes68(hashes []common.Hash, types []byte, sizes []uint32) error {
+	// Mark all the transactions as known, but ensure we don't overflow our limits
+	p.knownTxs.Add(hashes...)
+	return p2p.Send(p.rw, NewPooledTransactionHashesMsg, NewPooledTransactionHashesPacket68{Types: types, Sizes: sizes, Hashes: hashes})
 }
 
 // AsyncSendPooledTransactionHashes queues a list of transactions hashes to eventually

--- a/eth/protocols/eth/peer_test.go
+++ b/eth/protocols/eth/peer_test.go
@@ -49,6 +49,8 @@ func newTestPeer(name string, version uint, backend Backend) (*testPeer, <-chan 
 	peer := NewPeer(version, p2p.NewPeer(id, name, nil), net, backend.TxPool())
 	errc := make(chan error, 1)
 	go func() {
+		defer app.Close()
+
 		errc <- backend.RunPeer(peer, func(peer *Peer) error {
 			return Handle(backend, peer)
 		})

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -30,7 +30,8 @@ import (
 
 // Constants to match up protocol versions and messages
 const (
-	ETH66 = 66
+	ETH66  = 66
+	ETH100 = 100
 )
 
 // ProtocolName is the official short name of the `eth` protocol used during
@@ -39,11 +40,11 @@ const ProtocolName = "eth"
 
 // ProtocolVersions are the supported versions of the `eth` protocol (first
 // is primary).
-var ProtocolVersions = []uint{ETH66}
+var ProtocolVersions = []uint{ETH100, ETH66}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{ETH66: 17}
+var protocolLengths = map[uint]uint64{ETH100: 17, ETH66: 17}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
@@ -194,6 +195,26 @@ func (request *NewBlockPacket) sanityCheck() error {
 	return nil
 }
 
+// NewBlockPacket100 is the network packet for the block propagation message over eth/100.
+type NewBlockPacket100 struct {
+	Block    *types.Block
+	TD       *big.Int
+	Sidecars []types.BlobTxSidecar
+}
+
+// sanityCheck verifies that the values are reasonable, as a DoS protection
+func (request *NewBlockPacket100) sanityCheck() error {
+	if err := request.Block.SanityCheck(); err != nil {
+		return err
+	}
+	//TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
+	// larger, it will still fit within 100 bits
+	if tdlen := request.TD.BitLen(); tdlen > 100 {
+		return fmt.Errorf("too large block TD: bitlen %d", tdlen)
+	}
+	return nil
+}
+
 // GetBlockBodiesPacket represents a block body query.
 type GetBlockBodiesPacket []common.Hash
 
@@ -212,6 +233,13 @@ type BlockBodiesPacket66 struct {
 	BlockBodiesPacket
 }
 
+// BlockBodiesPacket100 is the network packet for block content distribution over eth/100.
+type BlockBodiesPacket100 struct {
+	RequestId uint64
+	BlockBodiesPacket
+	Sidecars [][]*types.BlobTxSidecar
+}
+
 // BlockBodiesRLPPacket is used for replying to block body requests, in cases
 // where we already have them RLP-encoded, and thus can avoid the decode-encode
 // roundtrip.
@@ -221,6 +249,13 @@ type BlockBodiesRLPPacket []rlp.RawValue
 type BlockBodiesRLPPacket66 struct {
 	RequestId uint64
 	BlockBodiesRLPPacket
+}
+
+// BlockBodiesRLPPacket100 is the BlockBodiesRLPPacket over eth/100
+type BlockBodiesRLPPacket100 struct {
+	RequestId uint64
+	BlockBodiesRLPPacket
+	Sidecars [][]*types.BlobTxSidecar
 }
 
 // BlockBody represents the data content of a single block.
@@ -240,6 +275,20 @@ func (p *BlockBodiesPacket) Unpack() ([][]*types.Transaction, [][]*types.Header)
 		txset[i], uncleset[i] = body.Transactions, body.Uncles
 	}
 	return txset, uncleset
+}
+
+// Unpack retrieves the transactions, uncles, blobs, proofs, and commitments from the range packet and returns
+// them in a split flat format that's more consistent with the internal data structures.
+func (p *BlockBodiesPacket100) Unpack() ([][]*types.Transaction, [][]*types.Header, [][]*types.BlobTxSidecar) {
+	var (
+		txset      = make([][]*types.Transaction, len(p.BlockBodiesPacket))
+		uncleset   = make([][]*types.Header, len(p.BlockBodiesPacket))
+		sidecarset = make([][]*types.BlobTxSidecar, len(p.BlockBodiesPacket))
+	)
+	for i, body := range p.BlockBodiesPacket {
+		txset[i], uncleset[i], sidecarset[i] = body.Transactions, body.Uncles, p.Sidecars[i]
+	}
+	return txset, uncleset, sidecarset
 }
 
 // GetNodeDataPacket represents a trie node data query.
@@ -345,8 +394,14 @@ func (*GetBlockBodiesPacket) Kind() byte   { return GetBlockBodiesMsg }
 func (*BlockBodiesPacket) Name() string { return "BlockBodies" }
 func (*BlockBodiesPacket) Kind() byte   { return BlockBodiesMsg }
 
+func (*BlockBodiesPacket100) Name() string { return "BlockBodies" }
+func (*BlockBodiesPacket100) Kind() byte   { return BlockBodiesMsg }
+
 func (*NewBlockPacket) Name() string { return "NewBlock" }
 func (*NewBlockPacket) Kind() byte   { return NewBlockMsg }
+
+func (*NewBlockPacket100) Name() string { return "NewBlock" }
+func (*NewBlockPacket100) Kind() byte   { return NewBlockMsg }
 
 func (*GetNodeDataPacket) Name() string { return "GetNodeData" }
 func (*GetNodeDataPacket) Kind() byte   { return GetNodeDataMsg }

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -287,8 +287,15 @@ type ReceiptsRLPPacket66 struct {
 	ReceiptsRLPPacket
 }
 
-// NewPooledTransactionHashesPacket represents a transaction announcement packet.
-type NewPooledTransactionHashesPacket []common.Hash
+// NewPooledTransactionHashesPacket66 represents a transaction announcement packet on eth/66 and eth/67.
+type NewPooledTransactionHashesPacket66 []common.Hash
+
+// NewPooledTransactionHashesPacket68 represents a transaction announcement packet on eth/68 and newer.
+type NewPooledTransactionHashesPacket68 struct {
+	Types  []byte
+	Sizes  []uint32
+	Hashes []common.Hash
+}
 
 // GetPooledTransactionsPacket represents a transaction query.
 type GetPooledTransactionsPacket []common.Hash
@@ -353,8 +360,11 @@ func (*GetReceiptsPacket) Kind() byte   { return GetReceiptsMsg }
 func (*ReceiptsPacket) Name() string { return "Receipts" }
 func (*ReceiptsPacket) Kind() byte   { return ReceiptsMsg }
 
-func (*NewPooledTransactionHashesPacket) Name() string { return "NewPooledTransactionHashes" }
-func (*NewPooledTransactionHashesPacket) Kind() byte   { return NewPooledTransactionHashesMsg }
+func (*NewPooledTransactionHashesPacket66) Name() string { return "NewPooledTransactionHashes" }
+func (*NewPooledTransactionHashesPacket66) Kind() byte   { return NewPooledTransactionHashesMsg }
+
+func (*NewPooledTransactionHashesPacket68) Name() string { return "NewPooledTransactionHashes" }
+func (*NewPooledTransactionHashesPacket68) Kind() byte   { return NewPooledTransactionHashesMsg }
 
 func (*GetPooledTransactionsPacket) Name() string { return "GetPooledTransactions" }
 func (*GetPooledTransactionsPacket) Kind() byte   { return GetPooledTransactionsMsg }

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -199,7 +199,7 @@ func (request *NewBlockPacket) sanityCheck() error {
 type NewBlockPacket100 struct {
 	Block    *types.Block
 	TD       *big.Int
-	Sidecars []types.BlobTxSidecar
+	Sidecars []*types.BlobTxSidecar
 }
 
 // sanityCheck verifies that the values are reasonable, as a DoS protection


### PR DESCRIPTION
This PR is to:
- Cherry-pick ETH68, which added `Types` and `Sizes` to `TransactionHashesPacket`. `Sizes` will be useful for blob transactions, which are large in size, as it helps prevent bandwidth overload in the network.
- Implement ETH100, adding new blob's field `Sidecars` to `BlockBodiesPacket` when broadcasting and receiving new blocks.