### PR TITLE
consortium-v2: prepare access list and transient storage in system transaction

### DIFF
--- a/consensus/consortium/common/contract.go
+++ b/consensus/consortium/common/contract.go
@@ -549,6 +549,14 @@ func applyMessage(
 	// Create a new context to be used in the EVM environment
 	opts.EVMContext.CurrentTransaction = tx
 	from, _ := types.Sender(types.MakeSigner(opts.ChainConfig, opts.Header.Number), tx)
+
+	chainRules := opts.ChainConfig.Rules(opts.Header.Number)
+	if chainRules.IsShanghai {
+		opts.State.Prepare(chainRules, from, from, tx.To(), vm.ActivePrecompiles(chainRules), nil)
+	} else if chainRules.IsBerlin {
+		opts.State.ResetAccessList()
+	}
+
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(*opts.EVMContext, vm.TxContext{Origin: from, GasPrice: big.NewInt(0)}, opts.State, opts.ChainConfig, vm.Config{})

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1033,6 +1033,11 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 	return root, err
 }
 
+// ResetAccessList sets access list to empty
+func (s *StateDB) ResetAccessList() {
+	s.accessList = newAccessList()
+}
+
 // Prepare handles the preparatory steps for executing a state transition with.
 // This method must be invoked before state transition.
 //


### PR DESCRIPTION
In 576852519 ("core/state: remove newAccessList in SetTxContext"), we remove the access list reset in SetTxContext because later in statedb.Prepare we already reset the list. However, system transaction does not call to statedb.Prepare before processing transaction. This results in a consensus breaking change. This commit create a new access list reset function and adds to system transaction path to fix the issue. Moreover, we add the statedb.Prepare call to system transaction path after Shanghai to make EIP-3651: warm coinbase and EIP-1153 - Transient storage opcodes work correctly in system transaction.