### PR TITLE
all: bump github.com/hashicorp/golang-lru to version 2

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -41,7 +41,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/arc/v2"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -143,11 +143,11 @@ var (
 type SignerFn func(signer accounts.Account, mimeType string, message []byte) ([]byte, error)
 
 // ecrecover extracts the Ethereum account address from a signed header.
-func ecrecover(header *types.Header, sigcache *lru.ARCCache) (common.Address, error) {
+func ecrecover(header *types.Header, sigcache *arc.ARCCache[common.Hash, common.Address]) (common.Address, error) {
 	// If the signature's already cached, return that
 	hash := header.Hash()
 	if address, known := sigcache.Get(hash); known {
-		return address.(common.Address), nil
+		return address, nil
 	}
 	// Retrieve the signature from the header extra-data
 	if len(header.Extra) < extraSeal {
@@ -173,8 +173,8 @@ type Clique struct {
 	config *params.CliqueConfig // Consensus engine configuration parameters
 	db     ethdb.Database       // Database to store and retrieve snapshot checkpoints
 
-	recents    *lru.ARCCache // Snapshots for recent block to speed up reorgs
-	signatures *lru.ARCCache // Signatures of recent blocks to speed up mining
+	recents    *arc.ARCCache[common.Hash, *Snapshot]      // Snapshots for recent block to speed up reorgs
+	signatures *arc.ARCCache[common.Hash, common.Address] // Signatures of recent blocks to speed up mining
 
 	proposals map[common.Address]bool // Current list of proposals we are pushing
 
@@ -195,8 +195,8 @@ func New(config *params.CliqueConfig, db ethdb.Database) *Clique {
 		conf.Epoch = epochLength
 	}
 	// Allocate the snapshot caches and create the engine
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 
 	return &Clique{
 		config:     &conf,
@@ -376,7 +376,7 @@ func (c *Clique) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 	for snap == nil {
 		// If an in-memory snapshot was found, use that
 		if s, ok := c.recents.Get(hash); ok {
-			snap = s.(*Snapshot)
+			snap = s
 			break
 		}
 		// If an on-disk checkpoint snapshot can be found, use that

--- a/consensus/clique/snapshot.go
+++ b/consensus/clique/snapshot.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/arc/v2"
 )
 
 // Vote represents a single vote that an authorized signer made to modify the
@@ -48,8 +48,8 @@ type Tally struct {
 
 // Snapshot is the state of the authorization voting at a given point in time.
 type Snapshot struct {
-	config   *params.CliqueConfig // Consensus engine parameters to fine tune behavior
-	sigcache *lru.ARCCache        // Cache of recent block signatures to speed up ecrecover
+	config   *params.CliqueConfig                       // Consensus engine parameters to fine tune behavior
+	sigcache *arc.ARCCache[common.Hash, common.Address] // Cache of recent block signatures to speed up ecrecover
 
 	Number  uint64                      `json:"number"`  // Block number where the snapshot was created
 	Hash    common.Hash                 `json:"hash"`    // Block hash where the snapshot was created
@@ -69,7 +69,7 @@ func (s signersAscending) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // newSnapshot creates a new snapshot with the specified startup parameters. This
 // method does not initialize the set of recent signers, so only ever use if for
 // the genesis block.
-func newSnapshot(config *params.CliqueConfig, sigcache *lru.ARCCache, number uint64, hash common.Hash, signers []common.Address) *Snapshot {
+func newSnapshot(config *params.CliqueConfig, sigcache *arc.ARCCache[common.Hash, common.Address], number uint64, hash common.Hash, signers []common.Address) *Snapshot {
 	snap := &Snapshot{
 		config:   config,
 		sigcache: sigcache,
@@ -86,7 +86,7 @@ func newSnapshot(config *params.CliqueConfig, sigcache *lru.ARCCache, number uin
 }
 
 // loadSnapshot loads an existing snapshot from the database.
-func loadSnapshot(config *params.CliqueConfig, sigcache *lru.ARCCache, db ethdb.Database, hash common.Hash) (*Snapshot, error) {
+func loadSnapshot(config *params.CliqueConfig, sigcache *arc.ARCCache[common.Hash, common.Address], db ethdb.Database, hash common.Hash) (*Snapshot, error) {
 	blob, err := db.Get(append([]byte("clique-"), hash[:]...))
 	if err != nil {
 		return nil, err

--- a/consensus/consortium/v1/consortium.go
+++ b/consensus/consortium/v1/consortium.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/hashicorp/golang-lru/arc/v2"
 	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -45,7 +46,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-	lru "github.com/hashicorp/golang-lru"
 )
 
 const (
@@ -100,8 +100,8 @@ type Consortium struct {
 	config      *params.ConsortiumConfig // Consensus engine configuration parameters
 	db          ethdb.Database           // Database to store and retrieve snapshot checkpoints
 
-	recents    *lru.ARCCache // Snapshots for recent block to speed up reorgs
-	signatures *lru.ARCCache // Signatures of recent blocks to speed up mining
+	recents    *arc.ARCCache[common.Hash, *Snapshot]      // Snapshots for recent block to speed up reorgs
+	signatures *arc.ARCCache[common.Hash, common.Address] // Signatures of recent blocks to speed up mining
 
 	proposals map[common.Address]bool // Current list of proposals we are pushing
 
@@ -130,8 +130,8 @@ func New(chainConfig *params.ChainConfig, db ethdb.Database, ethAPI *ethapi.Publ
 		consortiumConfig.Epoch = epochLength
 	}
 	// Allocate the snapshot caches and create the engine
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 
 	consortium := Consortium{
 		chainConfig:               chainConfig,
@@ -309,7 +309,7 @@ func (c *Consortium) snapshot(chain consensus.ChainHeaderReader, number uint64, 
 	for snap == nil {
 		// If an in-memory snapshot was found, use that
 		if s, ok := c.recents.Get(hash); ok {
-			snap = s.(*Snapshot)
+			snap = s
 			break
 		}
 		// If an on-disk checkpoint snapshot can be found, use that
@@ -807,11 +807,11 @@ func (c *Consortium) initContract(coinbase common.Address, signTxFn consortiumCo
 }
 
 // ecrecover extracts the Ethereum account address from a signed header.
-func Ecrecover(header *types.Header, sigcache *lru.ARCCache) (common.Address, error) {
+func Ecrecover(header *types.Header, sigcache *arc.ARCCache[common.Hash, common.Address]) (common.Address, error) {
 	// If the signature's already cached, return that
 	hash := header.Hash()
 	if address, known := sigcache.Get(hash); known {
-		return address.(common.Address), nil
+		return address, nil
 	}
 	// Retrieve the signature from the header extra-data
 	if len(header.Extra) < consortiumCommon.ExtraSeal {

--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/arc/v2"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -98,8 +98,8 @@ type Consortium struct {
 	forkedBlock uint64
 	db          ethdb.Database // Database to store and retrieve snapshot checkpoints
 
-	recents    *lru.ARCCache // Snapshots for recent block to speed up reorgs
-	signatures *lru.ARCCache // Signatures of recent blocks to speed up mining
+	recents    *arc.ARCCache[common.Hash, *Snapshot]      // Snapshots for recent block to speed up reorgs
+	signatures *arc.ARCCache[common.Hash, common.Address] // Signatures of recent blocks to speed up mining
 
 	lock     sync.RWMutex              // Protects the below 4 fields
 	val      common.Address            // Ethereum address of the signing key
@@ -135,8 +135,8 @@ func New(
 	}
 
 	// Allocate the snapshot caches and create the engine
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 
 	consortium := Consortium{
 		chainConfig: chainConfig,
@@ -582,7 +582,7 @@ func (c *Consortium) snapshot(chain consensus.ChainHeaderReader, number uint64, 
 	for snap == nil {
 		// If an in-memory snapshot was found, use that
 		if s, ok := c.recents.Get(hash); ok {
-			snap = s.(*Snapshot)
+			snap = s
 			break
 		}
 
@@ -1710,11 +1710,11 @@ func (c *Consortium) GetFinalityVoterAt(
 }
 
 // ecrecover extracts the Ronin account address from a signed header.
-func ecrecover(header *types.Header, sigcache *lru.ARCCache, chainId *big.Int) (common.Address, error) {
+func ecrecover(header *types.Header, sigcache *arc.ARCCache[common.Hash, common.Address], chainId *big.Int) (common.Address, error) {
 	// If the signature's already cached, return that
 	hash := header.Hash()
 	if address, known := sigcache.Get(hash); known {
-		return address.(common.Address), nil
+		return address, nil
 	}
 	// Retrieve the signature from the header extra-data
 	if len(header.Extra) < consortiumCommon.ExtraSeal {

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -28,7 +28,7 @@ import (
 	blsCommon "github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/arc/v2"
 )
 
 func TestSealableValidators(t *testing.T) {
@@ -733,7 +733,7 @@ func TestVerifyFinalitySignature(t *testing.T) {
 	}
 
 	snap := newSnapshot(nil, nil, nil, 10, common.Hash{}, nil, valWithBlsPub, nil)
-	recents, _ := lru.NewARC(inmemorySnapshots)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
 	c := Consortium{
 		chainConfig: &params.ChainConfig{
 			ShillinBlock: big.NewInt(0),
@@ -845,7 +845,7 @@ func TestVerifyFinalitySignatureTripp(t *testing.T) {
 	}
 
 	snap := newSnapshot(nil, nil, nil, 10, common.Hash{}, nil, valWithBlsPub, nil)
-	recents, _ := lru.NewARC(inmemorySnapshots)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
 	c := Consortium{
 		chainConfig: &params.ChainConfig{
 			ShillinBlock: big.NewInt(0),
@@ -1445,7 +1445,7 @@ func TestVerifyVote(t *testing.T) {
 	}
 
 	snap := newSnapshot(nil, nil, nil, 10, common.Hash{}, nil, valWithBlsPub, nil)
-	recents, _ := lru.NewARC(inmemorySnapshots)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
 	c := Consortium{
 		chainConfig: &params.ChainConfig{
 			ShillinBlock: big.NewInt(0),
@@ -1572,8 +1572,8 @@ func TestKnownBlockReorg(t *testing.T) {
 		validators: make(map[common.Address]blsCommon.PublicKey),
 	}
 	mock.validators[validatorAddrs[0]] = blsKeys[0].PublicKey()
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 
 	v2 := Consortium{
 		chainConfig: &chainConfig,
@@ -1824,8 +1824,8 @@ func TestUpgradeRoninTrustedOrg(t *testing.T) {
 			validatorAddr: blsSecretKey.PublicKey(),
 		},
 	}
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 
 	v2 := Consortium{
 		chainConfig: &chainConfig,
@@ -1971,8 +1971,8 @@ func TestUpgradeAxieProxyCode(t *testing.T) {
 			validatorAddr,
 		},
 	}
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 	v2 := &Consortium{
 		chainConfig: chainConfig,
 		contract:    mock,
@@ -2091,8 +2091,8 @@ func TestSystemTransactionOrder(t *testing.T) {
 			validatorAddr: blsSecretKey.PublicKey(),
 		},
 	}
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 
 	v2 := Consortium{
 		chainConfig: &chainConfig,
@@ -2212,8 +2212,8 @@ func TestIsPeriodBlock(t *testing.T) {
 	if _, err := chain.InsertChain(bs[:]); err != nil {
 		panic(err)
 	}
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 	mock := &mockContract{
 		validators: map[common.Address]blsCommon.PublicKey{},
 	}
@@ -2308,8 +2308,8 @@ func TestIsTrippEffective(t *testing.T) {
 	if _, err := chain.InsertChain(bs[:]); err != nil {
 		panic(err)
 	}
-	recents, _ := lru.NewARC(inmemorySnapshots)
-	signatures, _ := lru.NewARC(inmemorySignatures)
+	recents, _ := arc.NewARC[common.Hash, *Snapshot](inmemorySnapshots)
+	signatures, _ := arc.NewARC[common.Hash, common.Address](inmemorySignatures)
 	mock := &mockContract{
 		validators: map[common.Address]blsCommon.PublicKey{},
 	}

--- a/consensus/consortium/v2/snapshot.go
+++ b/consensus/consortium/v2/snapshot.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/params"
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/hashicorp/golang-lru/arc/v2"
 )
 
 // Snapshot is the state of the authorization validators at a given point in time.
@@ -26,7 +26,7 @@ type Snapshot struct {
 	chainConfig *params.ChainConfig
 	config      *params.ConsortiumConfig // Consensus engine parameters to fine tune behavior
 	ethAPI      *ethapi.PublicBlockChainAPI
-	sigCache    *lru.ARCCache // Cache of recent block signatures to speed up ecrecover
+	sigCache    *arc.ARCCache[common.Hash, common.Address] // Cache of recent block signatures to speed up ecrecover
 
 	Number     uint64                      `json:"number"`               // Block number where the snapshot was created
 	Hash       common.Hash                 `json:"hash"`                 // Block hash where the snapshot was created
@@ -57,7 +57,7 @@ func (s validatorsAscending) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func newSnapshot(
 	chainConfig *params.ChainConfig,
 	config *params.ConsortiumConfig,
-	sigcache *lru.ARCCache,
+	sigcache *arc.ARCCache[common.Hash, common.Address],
 	number uint64,
 	hash common.Hash,
 	validators []common.Address,
@@ -90,7 +90,7 @@ func newSnapshot(
 // loadSnapshot loads an existing snapshot from the database.
 func loadSnapshot(
 	config *params.ConsortiumConfig,
-	sigcache *lru.ARCCache,
+	sigcache *arc.ARCCache[common.Hash, common.Address],
 	db ethdb.Database,
 	hash common.Hash,
 	ethAPI *ethapi.PublicBlockChainAPI,

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
 var ErrInvalidDumpMagic = errors.New("invalid dump magic")
@@ -172,7 +172,7 @@ type lru struct {
 	mu   sync.Mutex
 	// Items are kept in a LRU cache, but there is a special case:
 	// We always keep an item for (highest seen epoch) + 1 as the 'future item'.
-	cache      *simplelru.LRU
+	cache      *simplelru.LRU[uint64, interface{}]
 	future     uint64
 	futureItem interface{}
 }
@@ -183,7 +183,7 @@ func newlru(what string, maxItems int, new func(epoch uint64) interface{}) *lru 
 	if maxItems <= 0 {
 		maxItems = 1
 	}
-	cache, _ := simplelru.NewLRU(maxItems, func(key, value interface{}) {
+	cache, _ := simplelru.NewLRU[uint64, interface{}](maxItems, func(key uint64, value interface{}) {
 		log.Trace("Evicted ethash "+what, "epoch", key)
 	})
 	return &lru{what: what, new: new, cache: cache}

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -89,8 +89,7 @@ func (bc *BlockChain) GetHeaderByNumber(number uint64) *types.Header {
 // hash, caching it if found.
 func (bc *BlockChain) GetBody(hash common.Hash) *types.Body {
 	// Short circuit if the body's already in the cache, retrieve otherwise
-	if cached, ok := bc.bodyCache.Get(hash); ok {
-		body := cached.(*types.Body)
+	if body, ok := bc.bodyCache.Get(hash); ok {
 		return body
 	}
 	number := bc.hc.GetBlockNumber(hash)
@@ -110,8 +109,8 @@ func (bc *BlockChain) GetBody(hash common.Hash) *types.Body {
 // caching it if found.
 func (bc *BlockChain) GetBodyRLP(hash common.Hash) rlp.RawValue {
 	// Short circuit if the body's already in the cache, retrieve otherwise
-	if cached, ok := bc.bodyRLPCache.Get(hash); ok {
-		return cached.(rlp.RawValue)
+	if body, ok := bc.bodyRLPCache.Get(hash); ok {
+		return body
 	}
 	number := bc.hc.GetBlockNumber(hash)
 	if number == nil {
@@ -150,7 +149,7 @@ func (bc *BlockChain) HasFastBlock(hash common.Hash, number uint64) bool {
 func (bc *BlockChain) GetBlock(hash common.Hash, number uint64) *types.Block {
 	// Short circuit if the block's already in the cache, retrieve otherwise
 	if block, ok := bc.blockCache.Get(hash); ok {
-		return block.(*types.Block)
+		return block
 	}
 	block := rawdb.ReadBlock(bc.db, hash, number)
 	if block == nil {
@@ -202,7 +201,7 @@ func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*type
 // GetReceiptsByHash retrieves the receipts for all transactions in a given block.
 func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {
-		return receipts.(types.Receipts)
+		return receipts
 	}
 	number := rawdb.ReadHeaderNumber(bc.db, hash)
 	if number == nil {
@@ -246,7 +245,7 @@ func (bc *BlockChain) GetAncestor(hash common.Hash, number, ancestor uint64, max
 func (bc *BlockChain) GetTransactionLookup(hash common.Hash) *rawdb.LegacyTxLookupEntry {
 	// Short circuit if the txlookup already in the cache, retrieve otherwise
 	if lookup, exist := bc.txLookupCache.Get(hash); exist {
-		return lookup.(*rawdb.LegacyTxLookupEntry)
+		return lookup
 	}
 	tx, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(bc.db, hash)
 	if tx == nil {
@@ -426,7 +425,7 @@ func (bc *BlockChain) WriteInternalTransactions(hash common.Hash, internalTxs []
 func (bc *BlockChain) ReadInternalTransactions(hash common.Hash) []*types.InternalTransaction {
 	// get internal txs from cache
 	if internalTxs, exist := bc.internalTransactionsCache.Get(hash); exist {
-		return internalTxs.([]*types.InternalTransaction)
+		return internalTxs
 	}
 	// otherwise get from db
 	internalTxs := rawdb.ReadInternalTransactions(bc.db, hash)
@@ -439,7 +438,7 @@ func (bc *BlockChain) ReadInternalTransactions(hash common.Hash) []*types.Intern
 
 func (bc *BlockChain) ReadDirtyAccounts(hash common.Hash) []*types.DirtyStateAccount {
 	if dirtyAccount, _ := bc.dirtyAccountsCache.Get(hash); dirtyAccount != nil {
-		return dirtyAccount.([]*types.DirtyStateAccount)
+		return dirtyAccount
 	}
 	return nil
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/trie"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const (
@@ -117,7 +117,7 @@ func NewDatabase(db ethdb.Database) Database {
 // is safe for concurrent use and retains a lot of collapsed RLP trie nodes in a
 // large memory cache.
 func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
-	csc, _ := lru.New(codeSizeCacheSize)
+	csc, _ := lru.New[common.Hash, int](codeSizeCacheSize)
 	return &cachingDB{
 		db:            trie.NewDatabaseWithConfig(db, config),
 		codeSizeCache: csc,
@@ -127,7 +127,7 @@ func NewDatabaseWithConfig(db ethdb.Database, config *trie.Config) Database {
 
 type cachingDB struct {
 	db            *trie.Database
-	codeSizeCache *lru.Cache
+	codeSizeCache *lru.Cache[common.Hash, int]
 	codeCache     *fastcache.Cache
 }
 
@@ -192,7 +192,7 @@ func (db *cachingDB) ContractCodeWithPrefix(addrHash, codeHash common.Hash) ([]b
 // ContractCodeSize retrieves a particular contracts code's size.
 func (db *cachingDB) ContractCodeSize(addrHash, codeHash common.Hash) (int, error) {
 	if cached, ok := db.codeSizeCache.Get(codeHash); ok {
-		return cached.(int), nil
+		return cached, nil
 	}
 	code, err := db.ContractCode(addrHash, codeHash)
 	return len(code), err

--- a/crypto/bls/blst/public_key.go
+++ b/crypto/bls/blst/public_key.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto/bls/common"
 	"github.com/ethereum/go-ethereum/params"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
 )
 
 var maxKeys = 1000000
-var pubkeyCache, _ = lru.New(maxKeys)
+var pubkeyCache, _ = lru.New[[params.BLSPubkeyLength]byte, common.PublicKey](maxKeys)
 
 // PublicKey used in the BLS signature scheme.
 type PublicKey struct {

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -185,10 +185,11 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.Block
 // actually processed range is returned to avoid ambiguity when parts of the requested range
 // are not available or when the head has changed during processing this request.
 // Three arrays are returned based on the processed blocks:
-// - reward: the requested percentiles of effective priority fees per gas of transactions in each
-//   block, sorted in ascending order and weighted by gas used.
-// - baseFee: base fee per gas in the given block
-// - gasUsedRatio: gasUsed/gasLimit in the given block
+//   - reward: the requested percentiles of effective priority fees per gas of transactions in each
+//     block, sorted in ascending order and weighted by gas used.
+//   - baseFee: base fee per gas in the given block
+//   - gasUsedRatio: gasUsed/gasLimit in the given block
+//
 // Note: baseFee includes the next block after the newest of the returned range, because this
 // value can be derived from the newest block.
 func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
@@ -249,13 +250,9 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 					oracle.processBlock(fees, rewardPercentiles)
 					results <- fees
 				} else {
-					cacheKey := struct {
-						number      uint64
-						percentiles string
-					}{blockNumber, string(percentileKey)}
-
+					cacheKey := historyCacheKey{blockNumber, string(percentileKey)}
 					if p, ok := oracle.historyCache.Get(cacheKey); ok {
-						fees.results = p.(processedFees)
+						fees.results = p
 						results <- fees
 					} else {
 						if len(rewardPercentiles) != 0 {

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/graph-gophers/graphql-go v1.3.0
 	github.com/hashicorp/go-bexpr v0.1.10
-	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/holiman/bloomfilter/v2 v2.0.3
 	github.com/holiman/uint256 v1.2.1
 	github.com/huin/goupnp v1.1.0
@@ -74,6 +73,8 @@ require (
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be
 	github.com/golang/mock v1.6.0
 	github.com/grafana/pyroscope-go v1.1.1
+	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/klauspost/compress v1.17.3
 	github.com/pkg/errors v0.9.1
 	github.com/supranational/blst v0.3.11

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,10 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
-github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.7 h1:QxkVTxwColcduO+LP7eJO56r2hFiG8zEbfAAzRv52KQ=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.7/go.mod h1:Pe7gBlGdc8clY5LJ0LpJXMt5AmgmWNH1g+oFFVUHOEc=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
 const (
@@ -222,7 +222,7 @@ type worker struct {
 	fullTaskHook func()                             // Method to call before pushing the full sealing task.
 	resubmitHook func(time.Duration, time.Duration) // Method to call upon updating resubmitting interval.
 
-	recentMinedBlocks *lru.Cache
+	recentMinedBlocks *lru.Cache[uint64, []common.Hash]
 }
 
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, init bool) *worker {
@@ -255,7 +255,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	worker.chainHeadSub = eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh)
 	worker.chainSideSub = eth.BlockChain().SubscribeChainSideEvent(worker.chainSideCh)
 
-	worker.recentMinedBlocks, _ = lru.New(recentMinedCacheLimit)
+	worker.recentMinedBlocks, _ = lru.New[uint64, []common.Hash](recentMinedCacheLimit)
 
 	// Sanitize recommit interval if the user-specified one is too short.
 	recommit := worker.config.Recommit
@@ -681,9 +681,8 @@ func (w *worker) resultLoop() {
 			}
 
 			if w.chainConfig.IsConsortiumV2(block.Number()) {
-				if parents, ok := w.recentMinedBlocks.Get(block.NumberU64()); ok {
+				if parentsHash, ok := w.recentMinedBlocks.Get(block.NumberU64()); ok {
 					isDoubleSign := false
-					parentsHash := parents.([]common.Hash)
 					for _, parent := range parentsHash {
 						if block.ParentHash() == parent {
 							isDoubleSign = true

--- a/p2p/discover/v5wire/session.go
+++ b/p2p/discover/v5wire/session.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/hashicorp/golang-lru/simplelru"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 )
 
 const handshakeTimeout = time.Second
@@ -33,7 +33,7 @@ const handshakeTimeout = time.Second
 // The SessionCache keeps negotiated encryption keys and
 // state for in-progress handshakes in the Discovery v5 wire protocol.
 type SessionCache struct {
-	sessions   *simplelru.LRU
+	sessions   *simplelru.LRU[sessionID, *session]
 	handshakes map[sessionID]*Whoareyou
 	clock      mclock.Clock
 
@@ -62,7 +62,7 @@ func (s *session) keysFlipped() *session {
 }
 
 func NewSessionCache(maxItems int, clock mclock.Clock) *SessionCache {
-	cache, err := simplelru.NewLRU(maxItems, nil)
+	cache, err := simplelru.NewLRU[sessionID, *session](maxItems, nil)
 	if err != nil {
 		panic("can't create session cache")
 	}
@@ -99,7 +99,7 @@ func (sc *SessionCache) session(id enode.ID, addr string) *session {
 	if !ok {
 		return nil
 	}
-	return item.(*session)
+	return item
 }
 
 // readKey returns the current read key for the given node.


### PR DESCRIPTION
golang-lru version 2 supports generic in replacement of interface{} which makes it safer for development as type check is performed at compile time instead of runtime. This commit integrates Ronin with new package version.