### PR TITLE
core/vm: correct the Istanbul bn256 precompiled contracts

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -114,6 +114,9 @@ func init() {
 	PrecompiledContractsByzantium[common.BytesToAddress([]byte{8})] = &bn256PairingByzantium{}
 
 	PrecompiledContractsIstanbul = copyPrecompiledContract(PrecompiledContractsByzantium)
+	PrecompiledContractsIstanbul[common.BytesToAddress([]byte{6})] = &bn256AddIstanbul{}
+	PrecompiledContractsIstanbul[common.BytesToAddress([]byte{7})] = &bn256ScalarMulIstanbul{}
+	PrecompiledContractsIstanbul[common.BytesToAddress([]byte{8})] = &bn256PairingIstanbul{}
 	PrecompiledContractsIstanbul[common.BytesToAddress([]byte{9})] = &blake2F{}
 
 	PrecompiledContractsConsortium = copyPrecompiledContract(PrecompiledContractsIstanbul)

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -426,4 +427,43 @@ func BenchmarkPrecompiledBLS12381G2MultiExpWorstCase(b *testing.B) {
 		NoBenchmark: false,
 	}
 	benchmarkPrecompiled("0f", testcase, b)
+}
+
+func TestIstanbulPrecompile(t *testing.T) {
+	evm := EVM{
+		chainConfig: &params.ChainConfig{},
+		chainRules: params.Rules{
+			IsIstanbul: true,
+		},
+	}
+	caller := AccountRef(common.Address{0x1})
+	precompiledContract, ok := evm.precompile(caller, common.BytesToAddress([]byte{6}))
+	if !ok {
+		t.Fatal("Failed to get Istanbul precompiled contract")
+	}
+
+	_, ok = precompiledContract.(*bn256AddIstanbul)
+	if !ok {
+		t.Fatal("Incorrect precompiled contract")
+	}
+
+	precompiledContract, ok = evm.precompile(caller, common.BytesToAddress([]byte{7}))
+	if !ok {
+		t.Fatal("Failed to get Istanbul precompiled contract")
+	}
+
+	_, ok = precompiledContract.(*bn256ScalarMulIstanbul)
+	if !ok {
+		t.Fatal("Incorrect precompiled contract")
+	}
+
+	precompiledContract, ok = evm.precompile(caller, common.BytesToAddress([]byte{8}))
+	if !ok {
+		t.Fatal("Failed to get Istanbul precompiled contract")
+	}
+
+	_, ok = precompiledContract.(*bn256PairingIstanbul)
+	if !ok {
+		t.Fatal("Incorrect precompiled contract")
+	}
 }


### PR DESCRIPTION
In commit 268d950147 ("core/vm: change Consortium precompiled mapping into global variable"), we mistakenly copy the Byzantium precompiled contracts to Istanbul and add blake2F at address 0x9 only. This is incorrect as the bn256 precompiled contracts at 0x6, 0x7, 0x8 are changed too. This commit fixes Istanbul precompiled contracts to have correct bn256 version.