### PR TITLE
eth: remove redundant sidecar read

### DIFF
--- a/eth/sync.go
+++ b/eth/sync.go
@@ -259,11 +259,9 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		// scenario will most often crop up in private and hackathon networks with
 		// degenerate connectivity, but it should be healthy for the mainnet too to
 		// more reliably update peers or the local TD state.
-		var sidecars []*types.BlobTxSidecar
-		for _, blobSidecar := range rawdb.ReadBlobSidecars(h.database, head.Hash(), head.NumberU64()) {
-			sidecars = append(sidecars, &blobSidecar.BlobTxSidecar)
-		}
-		h.BroadcastBlock(head, sidecars, false)
+		// We only announce block hash to the network so don't need to read sidecar
+		// here.
+		h.BroadcastBlock(head, nil, false)
 	}
 	return nil
 }


### PR DESCRIPTION
When finishing syncing, we only broadcast the head block hash to network (argument propagate = false when calling BroadcastBlock), so the sidecars are not used. Therefore, this commit removes the redundant sidecar read.