### PR TITLE
eth: add length check for sidecars in BlockBodiesPacket100

### DIFF
--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -364,6 +364,11 @@ func handleBlockBodies100(backend Backend, msg Decoder, peer *Peer) error {
 	if err := msg.Decode(res); err != nil {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
+	if len(res.Sidecars) != 0 && len(res.Sidecars) != len(res.BlockBodiesPacket) {
+		return fmt.Errorf("%w: message %v: invalid len of fields: %v %v",
+			errDecode, msg, len(res.BlockBodiesPacket), len(res.Sidecars))
+	}
+
 	requestTracker.Fulfil(peer.id, peer.version, BlockBodiesMsg, res.RequestId)
 
 	return backend.Handle(peer, res)

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -281,14 +281,13 @@ func (p *BlockBodiesPacket) Unpack() ([][]*types.Transaction, [][]*types.Header)
 // them in a split flat format that's more consistent with the internal data structures.
 func (p *BlockBodiesPacket100) Unpack() ([][]*types.Transaction, [][]*types.Header, [][]*types.BlobTxSidecar) {
 	var (
-		txset      = make([][]*types.Transaction, len(p.BlockBodiesPacket))
-		uncleset   = make([][]*types.Header, len(p.BlockBodiesPacket))
-		sidecarset = make([][]*types.BlobTxSidecar, len(p.BlockBodiesPacket))
+		txset    = make([][]*types.Transaction, len(p.BlockBodiesPacket))
+		uncleset = make([][]*types.Header, len(p.BlockBodiesPacket))
 	)
 	for i, body := range p.BlockBodiesPacket {
-		txset[i], uncleset[i], sidecarset[i] = body.Transactions, body.Uncles, p.Sidecars[i]
+		txset[i], uncleset[i] = body.Transactions, body.Uncles
 	}
-	return txset, uncleset, sidecarset
+	return txset, uncleset, p.Sidecars
 }
 
 // GetNodeDataPacket represents a trie node data query.


### PR DESCRIPTION
Add length check and reject BlockBodiesPacket100 with sidecars' length are not
either 0 or the same as number of blocks.