### PR TITLE
eth/fetcher: remove sidecars pass while broadcasting block hash

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -849,7 +849,7 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block, sidecars []
 		}
 		// If import succeeded, broadcast the block
 		blockAnnounceOutTimer.UpdateSince(block.ReceivedAt)
-		go f.broadcastBlock(block, sidecars, false)
+		go f.broadcastBlock(block, nil, false)
 
 		// Invoke the testing hook if needed
 		if f.importedHook != nil {


### PR DESCRIPTION
As after block/sidecar is imported into local chain, only block hash is broadcasted to peers, hence, we can emit passing the sidecars to broadcastBlock function.