### PR TITLE
consortium, eth: remove unused blob sidecars from verify blob header function

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -215,8 +215,8 @@ func (c *Clique) Author(header *types.Header) (common.Address, error) {
 }
 
 // VerifyBlobHeader only available in v2
-func (c *Clique) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars) {
-	return nil, nil
+func (c *Clique) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error {
+	return nil
 }
 
 // VerifyHeader checks whether a header conforms to the consensus rules.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -85,7 +85,7 @@ type Engine interface {
 	VerifyHeader(chain ChainHeaderReader, header *types.Header, seal bool) error
 
 	// VerifyBlobHeader verifies a block's header blob and corresponding sidecar
-	VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars)
+	VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error
 
 	// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 	// concurrently. The method returns a quit channel to abort the operations and

--- a/consensus/consortium/main.go
+++ b/consensus/consortium/main.go
@@ -49,12 +49,12 @@ func (c *Consortium) Author(header *types.Header) (common.Address, error) {
 }
 
 // VerifyBlobHeader implements consensus.Engine, verifies a block's header blob and corresponding sidecar
-func (c *Consortium) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars) {
+func (c *Consortium) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error {
 	if c.chainConfig.IsConsortiumV2(block.Header().Number) && c.chainConfig.IsCancun(block.Header().Number) {
 		return c.v2.VerifyBlobHeader(block, sidecars)
 	}
 
-	return nil, nil
+	return nil
 }
 
 // VerifyHeader checks whether a header conforms to the consensus rules.

--- a/consensus/consortium/v1/consortium.go
+++ b/consensus/consortium/v1/consortium.go
@@ -170,8 +170,8 @@ func (c *Consortium) Author(header *types.Header) (common.Address, error) {
 }
 
 // VerifyBlobHeader only available in v2
-func (c *Consortium) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars) {
-	return nil, nil
+func (c *Consortium) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error {
+	return nil
 }
 
 // VerifyHeader checks whether a header conforms to the consensus rules.

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -2628,12 +2628,9 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix() - int64(blobKeepPeriod) - 1000),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars := c.VerifyBlobHeader(block, sidecars)
+	err := c.VerifyBlobHeader(block, sidecars)
 	if err != nil {
 		t.Fatal("Expected blob check to be skipped, err:", err)
-	}
-	if blobSidecars != nil {
-		t.Fatal("Expected blobSidecars to be nil if skip check")
 	}
 
 	// Test 2: Block with expired blobs, invalid sidecars
@@ -2641,12 +2638,9 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix() - int64(blobKeepPeriod) - 1000),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars = c.VerifyBlobHeader(block, fakeSidecars)
+	err = c.VerifyBlobHeader(block, fakeSidecars)
 	if err != nil {
 		t.Fatal("Expected blob check to be skipped, err:", err)
-	}
-	if blobSidecars != nil {
-		t.Fatal("Expected blobSidecars to be nil if skip check")
 	}
 
 	// Test 3: Block with valid blobs, valid sidecars
@@ -2654,12 +2648,9 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix()),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars = c.VerifyBlobHeader(block, sidecars)
+	err = c.VerifyBlobHeader(block, sidecars)
 	if err != nil {
 		t.Fatal("Expected blob check to pass, err:", err)
-	}
-	if len(*blobSidecars) != 2 {
-		t.Fatal("Expected blobSidecars to have 2 elements")
 	}
 
 	// Test 4: Block with valid blobs, invalid sidecars
@@ -2667,12 +2658,9 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix()),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars = c.VerifyBlobHeader(block, fakeSidecars)
+	err = c.VerifyBlobHeader(block, fakeSidecars)
 	if err == nil {
 		t.Fatal("Expected blob check to fail due to invalid sidecars")
-	}
-	if blobSidecars != nil {
-		t.Fatal("Expected blobSidecars to be nil if check failed")
 	}
 
 	// Test 5: Block with valid blobs, valid commitments, but invalid proofs
@@ -2680,7 +2668,7 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix()),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars = c.VerifyBlobHeader(block, []*types.BlobTxSidecar{
+	err = c.VerifyBlobHeader(block, []*types.BlobTxSidecar{
 		{
 			Blobs:       sidecars[0].Blobs,
 			Commitments: sidecars[0].Commitments,
@@ -2698,12 +2686,9 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix()),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars = c.VerifyBlobHeader(block, sidecars[:len(sidecars)-1])
+	err = c.VerifyBlobHeader(block, sidecars[:len(sidecars)-1])
 	if err == nil {
 		t.Fatal("Expected blob check to fail due to invalid commitments' length")
-	}
-	if blobSidecars != nil {
-		t.Fatal("Expected blobSidecars to be nil if check failed")
 	}
 
 	// Test 7: Block with exceeding blobs
@@ -2715,11 +2700,8 @@ func TestVerifyBlobHeader(t *testing.T) {
 		Time: uint64(time.Now().Unix()),
 	}, txs, []*types.Header{}, []*types.Receipt{}, trie.NewStackTrie(nil))
 
-	err, blobSidecars = c.VerifyBlobHeader(block, sidecars)
+	err = c.VerifyBlobHeader(block, sidecars)
 	if err == nil {
 		t.Fatal("Expected blob check to fail due to exceeding blobs")
-	}
-	if blobSidecars != nil {
-		t.Fatal("Expected blobSidecars to be nil if check failed")
 	}
 }

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -117,8 +117,8 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainHeaderReader, header *ty
 }
 
 // VerifyBlobHeader only available in v2
-func (ethash *Ethash) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars) {
-	return nil, nil
+func (ethash *Ethash) VerifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error {
+	return nil
 }
 
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1726,7 +1726,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	sidecars := make([][]*types.BlobTxSidecar, len(results))
 	for i, result := range results {
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
-		if err, _ := d.verifyBlobHeader(blocks[i], result.Sidecars); err != nil {
+		if err := d.verifyBlobHeader(blocks[i], result.Sidecars); err != nil {
 			return fmt.Errorf("%w: %v", errInvalidBody, err)
 		}
 		sidecars[i] = result.Sidecars

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -411,8 +411,8 @@ func (dl *downloadTester) dropPeer(id string) {
 }
 
 // verifyBlobHeader is a non placeholder for the blob header verification.
-func (dl *downloadTester) verifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars) {
-	return nil, nil
+func (dl *downloadTester) verifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error {
+	return nil
 }
 
 // Snapshots implements the BlockChain interface for the downloader, but is a noop.

--- a/eth/downloader/types.go
+++ b/eth/downloader/types.go
@@ -26,7 +26,7 @@ import (
 type peerDropFn func(id string)
 
 // blobHeaderVerifierFn is a callback type to verify a block's blobs
-type blobHeaderVerifierFn func(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars)
+type blobHeaderVerifierFn func(block *types.Block, sidecars []*types.BlobTxSidecar) error
 
 // dataPack is a data message returned by a peer for some query.
 type dataPack interface {

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -83,7 +83,7 @@ type bodyRequesterFn func([]common.Hash) error
 type headerVerifierFn func(header *types.Header) error
 
 // blobHeaderVerifierFn is a callback type to verify a block's blobs
-type blobHeaderVerifierFn func(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars)
+type blobHeaderVerifierFn func(block *types.Block, sidecars []*types.BlobTxSidecar) error
 
 // blockBroadcasterFn is a callback type for broadcasting a block to connected peers.
 type blockBroadcasterFn func(block *types.Block, sidecars []*types.BlobTxSidecar, propagate bool)
@@ -825,7 +825,7 @@ func (f *BlockFetcher) importBlocks(peer string, block *types.Block, sidecars []
 		// Quickly validate the header and propagate the block if it passes
 		err := f.verifyHeader(block.Header())
 		if err == nil {
-			err, _ = f.verifyBlobHeader(block, sidecars)
+			err = f.verifyBlobHeader(block, sidecars)
 		}
 		switch err {
 		case nil:

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -124,8 +124,8 @@ func (f *fetcherTester) verifyHeader(header *types.Header) error {
 }
 
 // verifyBlobHeader is a non placeholder for the blob header verification.
-func (f *fetcherTester) verifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) (error, *types.BlobSidecars) {
-	return nil, nil
+func (f *fetcherTester) verifyBlobHeader(block *types.Block, sidecars []*types.BlobTxSidecar) error {
+	return nil
 }
 
 // broadcastBlock is a nop placeholder for the block broadcasting.


### PR DESCRIPTION
The verify blob header function is primarily used during block fetching and downloading. Since its blob sidecar output is unused, we can eliminate it, transforming the function into a pure verification check.