### PR TITLE
miner/worker: check if the transaction is evicted before committing

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1038,6 +1038,12 @@ Loop:
 		}
 
 		tx := selectedTx.Resolve()
+		if tx == nil {
+			log.Trace("Transaction is evicted from pool", "hash", selectedTx.Hash)
+			txs.Pop()
+			continue
+		}
+
 		// Error may be ignored here. The error has already been checked
 		// during transaction acceptance is the transaction pool.
 		//


### PR DESCRIPTION
There is a case where a blob transaction returned from txpool pending transaction query is evicted before commit. This leads to transaction's lazy resolve returns nil. This commit adds the nil check to ensure the transaction is not evicted before committing.