### PR TITLE
core/vm: move readOnly check outside the TSTORE opcode

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -190,6 +190,7 @@ func enable1153(jt *JumpTable) {
 		constantGas: params.WarmStorageReadCostEIP2929,
 		minStack:    minStack(2, 0),
 		maxStack:    maxStack(2, 0),
+		writes:      true,
 	}
 }
 
@@ -204,9 +205,6 @@ func opTload(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]by
 
 // opTstore implements TSTORE opcode
 func opTstore(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	if interpreter.readOnly {
-		return nil, ErrWriteProtection
-	}
 	loc := scope.Stack.pop()
 	val := scope.Stack.pop()
 	interpreter.evm.StateDB.SetTransientState(scope.Contract.Address(), loc.Bytes32(), val.Bytes32())


### PR DESCRIPTION
In Ronin, currently we don't have commit 9393d1fb5d ("core/vm: Move interpreter.ReadOnly check into the opcode implementations"). So the readonly check is still in the main interpreter loop, not in the opcode implementation. This commit makes the TSTORE opcode consistent with that behavior in the other opcodes.