### PR TITLE
p2p, eth: create ENR filtering earlier before p2p server starts

### DIFF
--- a/eth/protocols/eth/discovery.go
+++ b/eth/protocols/eth/discovery.go
@@ -19,7 +19,6 @@ package eth
 import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -56,11 +55,6 @@ func StartENRUpdater(chain *core.BlockChain, ln *enode.LocalNode) {
 			}
 		}
 	}()
-}
-
-func StartENRFilter(chain *core.BlockChain, p2p *p2p.Server) {
-	forkFilter := forkid.NewFilter(chain)
-	p2p.SetFilter(forkFilter)
 }
 
 // currentENREntry constructs an `eth` ENR entry based on the current state of the chain.


### PR DESCRIPTION
The race detector reports the following data race
```
WARNING: DATA RACE
Read at 0x00c0014e60b4 by goroutine 4291:
  github.com/ethereum/go-ethereum/core/forkid.newFilter.func1()
      github.com/ethereum/go-ethereum/core/forkid/forkid.go:163 +0xf1
  github.com/ethereum/go-ethereum/p2p.(*Server).setupDiscovery.func2()
      github.com/ethereum/go-ethereum/p2p/server.go:615 +0x1a2
  github.com/ethereum/go-ethereum/p2p/discover.(*Table).filterNode()
      github.com/ethereum/go-ethereum/p2p/discover/table.go:585 +0x456
  github.com/ethereum/go-ethereum/p2p/discover.(*Table).addSeenNodeSync()
      github.com/ethereum/go-ethereum/p2p/discover/table.go:548 +0x1c4
  github.com/ethereum/go-ethereum/p2p/discover.(*Table).addSeenNode.func1()
      github.com/ethereum/go-ethereum/p2p/discover/table.go:527 +0x47

Previous write at 0x00c0014e60b4 by main goroutine:
  github.com/ethereum/go-ethereum/core/forkid.newFilter()
      github.com/ethereum/go-ethereum/core/forkid/forkid.go:127 +0x1a4
  github.com/ethereum/go-ethereum/core/forkid.NewFilter()
      github.com/ethereum/go-ethereum/core/forkid/forkid.go:99 +0xf7
  github.com/ethereum/go-ethereum/eth/protocols/eth.StartENRFilter()
      github.com/ethereum/go-ethereum/eth/protocols/eth/discovery.go:62 +0xa9
  github.com/ethereum/go-ethereum/eth.(*Ethereum).Start()
      github.com/ethereum/go-ethereum/eth/backend.go:655 +0x3b
```
The ENR filter is created when Ethereum starts and is passed to p2p server, this is a write access on ENR filter. The p2p server uses this filter when discovering a peer, this is a read access. Currently, the p2p server starts before Ethereum starts, so peer discovery happens concurrently with Ethereum's start. Moreover, the read and write access do not synchronise with each other so the data race happens. This commit moves the ENR filter creation to Ethereum creation which happens before p2p server starts to fix the data race.