### PR TITLE
eth/gasestimator: fix nil blob gas fee cap

### DIFF
--- a/eth/gasestimator/gasestimator.go
+++ b/eth/gasestimator/gasestimator.go
@@ -80,7 +80,7 @@ func Estimate(ctx context.Context, call core.Message, opts *Options, gasCap uint
 			}
 			available.Sub(available, call.Value())
 		}
-		if opts.Config.IsCancun(opts.Header.Number) {
+		if opts.Config.IsCancun(opts.Header.Number) && len(call.BlobHashes()) > 0 {
 			blobGasPerBlob := new(big.Int).SetUint64(params.BlobTxBlobGasPerBlob)
 			blobBalanceUsage := new(big.Int).SetUint64(uint64(len(call.BlobHashes())))
 			blobBalanceUsage.Mul(blobBalanceUsage, blobGasPerBlob)
@@ -88,6 +88,7 @@ func Estimate(ctx context.Context, call core.Message, opts *Options, gasCap uint
 			if blobBalanceUsage.Cmp(available) >= 0 {
 				return 0, nil, core.ErrInsufficientFunds
 			}
+			available.Sub(available, blobBalanceUsage)
 		}
 		allowance := new(big.Int).Div(available, feeCap)
 


### PR DESCRIPTION
This PR adds more condition for blob transaction path, preventing `call.BlobGasFeeCap()` being nil when send non-blob transaction.