### PR TITLE
rpc: remove msg params when log rpc error

### DIFF
--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -297,7 +297,7 @@ func (h *handler) handleCallMsg(ctx *callProc, msg *jsonrpcMessage) *jsonrpcMess
 	case msg.isCall():
 		resp := h.handleCall(ctx, msg)
 		var ctx []interface{}
-		ctx = append(ctx, "elapsed", time.Since(start), "id", RawMsgForLog{msg.ID}, "params", RawMsgForLog{msg.Params})
+		ctx = append(ctx, "elapsed", time.Since(start), "id", RawMsgForLog{msg.ID})
 		if resp.Error != nil {
 			ctx = append(ctx, "err", resp.Error.Message)
 			if resp.Error.Data != nil {


### PR DESCRIPTION
Currently, error when send raw blob tx ends up a long unused log of sidecars data, this pr removes this unused log data, and only print out format:

```
WARN [08-22|17:39:31.389] Served eth_sendRawTransaction            conn=[::1]:61565 elapsed=14.860042ms id=8
    err="nonce too high: tx nonce 68, gapped nonce 65"
```