### PR TITLE
consensus, core: enable base fee after Venoki fork

### DIFF
--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -47,48 +49,53 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 
 // CalcBaseFee calculates the basefee of the header.
 func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
-	return big.NewInt(0)
+	blockNumber := new(big.Int).Add(parent.Number, common.Big1)
 
-	/*
-		We temporarily set the base fee to 0, the following logic may be enabled in
-		the future hardfork.
+	if !config.IsVenoki(blockNumber) {
+		return big.NewInt(0)
+	}
 
-		// If the current block is the first EIP-1559 block, return the InitialBaseFee.
-		if !config.IsLondon(parent.Number) {
-			return new(big.Int).SetUint64(params.InitialBaseFee)
-		}
+	// Current block is the first block in Venoki, return initial base fee
+	if !config.IsVenoki(parent.Number) {
+		return new(big.Int).SetUint64(params.InitialBaseFee)
+	}
 
-		var (
-			parentGasTarget          = parent.GasLimit / params.ElasticityMultiplier
-			parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
-			baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
+	var (
+		parentGasTarget          = parent.GasLimit / params.ElasticityMultiplier
+		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
+		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
+	)
+	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
+	if parent.GasUsed == parentGasTarget {
+		return new(big.Int).Set(parent.BaseFee)
+	}
+	if parent.GasUsed > parentGasTarget {
+		// If the parent block used more gas than its target, the baseFee should increase.
+		gasUsedDelta := new(big.Int).SetUint64(parent.GasUsed - parentGasTarget)
+		x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
+		y := x.Div(x, parentGasTargetBig)
+		baseFeeDelta := math.BigMax(
+			x.Div(y, baseFeeChangeDenominator),
+			common.Big1,
 		)
-		// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
-		if parent.GasUsed == parentGasTarget {
-			return new(big.Int).Set(parent.BaseFee)
-		}
-		if parent.GasUsed > parentGasTarget {
-			// If the parent block used more gas than its target, the baseFee should increase.
-			gasUsedDelta := new(big.Int).SetUint64(parent.GasUsed - parentGasTarget)
-			x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
-			y := x.Div(x, parentGasTargetBig)
-			baseFeeDelta := math.BigMax(
-				x.Div(y, baseFeeChangeDenominator),
-				common.Big1,
-			)
 
-			return x.Add(parent.BaseFee, baseFeeDelta)
-		} else {
-			// Otherwise if the parent block used less gas than its target, the baseFee should decrease.
-			gasUsedDelta := new(big.Int).SetUint64(parentGasTarget - parent.GasUsed)
-			x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
-			y := x.Div(x, parentGasTargetBig)
-			baseFeeDelta := x.Div(y, baseFeeChangeDenominator)
-
-			return math.BigMax(
-				x.Sub(parent.BaseFee, baseFeeDelta),
-				common.Big0,
-			)
+		return x.Add(parent.BaseFee, baseFeeDelta)
+	} else {
+		// If the parent's base fee is at the minimum already, fast return the minimum base fee
+		minimumBaseFee := big.NewInt(params.MinimumBaseFee)
+		if parent.BaseFee.Cmp(minimumBaseFee) == 0 {
+			return minimumBaseFee
 		}
-	*/
+		// Otherwise if the parent block used less gas than its target, the baseFee should decrease.
+		gasUsedDelta := new(big.Int).SetUint64(parentGasTarget - parent.GasUsed)
+		x := new(big.Int).Mul(parent.BaseFee, gasUsedDelta)
+		y := x.Div(x, parentGasTargetBig)
+		baseFeeDelta := x.Div(y, baseFeeChangeDenominator)
+
+		// Ensure the minimum baseFee is 1 gwei.
+		return math.BigMax(
+			x.Sub(parent.BaseFee, baseFeeDelta),
+			minimumBaseFee,
+		)
+	}
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -501,6 +501,15 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.evm.Context.Coinbase, newEffectiveTip)
 	}
 
+	// After Venoki the base fee is non-zero and the fee is transferred to treasury
+	if rules.IsVenoki {
+		treasuryAddress := st.evm.ChainConfig().RoninTreasuryAddress
+		if treasuryAddress != nil {
+			fee := new(big.Int).Mul(big.NewInt(int64(st.gasUsed())), st.evm.Context.BaseFee)
+			st.state.AddBalance(*treasuryAddress, fee)
+		}
+	}
+
 	return &ExecutionResult{
 		UsedGas:     st.gasUsed(),
 		RefundedGas: gasRefund,

--- a/params/config.go
+++ b/params/config.go
@@ -296,6 +296,7 @@ var (
 		// TODO: Fill this
 		ShanghaiBlock:        nil,
 		CancunBlock:          nil,
+		VenokiBlock:          nil,
 		RoninTreasuryAddress: nil,
 	}
 
@@ -354,6 +355,7 @@ var (
 		// TODO: Fill this
 		ShanghaiBlock:        nil,
 		CancunBlock:          nil,
+		VenokiBlock:          nil,
 		RoninTreasuryAddress: nil,
 	}
 
@@ -575,13 +577,13 @@ type ChainConfig struct {
 
 	AntennaBlock *big.Int `json:"antennaBlock,omitempty"` // AntennaBlock switch block (nil = no fork, 0 = already on activated)
 	// Miko hardfork introduces sponsored transactions
-	MikoBlock   *big.Int `json:"mikoBlock,omitempty"`   // Miko switch block (nil = no fork, 0 = already on activated)
-	TrippBlock  *big.Int `json:"trippBlock,omitempty"`  // Tripp switch block (nil = no fork, 0 = already on activated)
-	TrippPeriod *big.Int `json:"trippPeriod,omitempty"` // The period number at Tripp fork block.
-	AaronBlock  *big.Int `json:"aaronBlock,omitempty"`  // Aaron switch block (nil = no fork, 0 = already on activated)
-	CancunBlock *big.Int `json:"cancunBlock,omitempty"` // Cancun switch block (nil = no fork, 0 = already on activated)
-
+	MikoBlock     *big.Int `json:"mikoBlock,omitempty"`     // Miko switch block (nil = no fork, 0 = already on activated)
+	TrippBlock    *big.Int `json:"trippBlock,omitempty"`    // Tripp switch block (nil = no fork, 0 = already on activated)
+	TrippPeriod   *big.Int `json:"trippPeriod,omitempty"`   // The period number at Tripp fork block.
+	AaronBlock    *big.Int `json:"aaronBlock,omitempty"`    // Aaron switch block (nil = no fork, 0 = already on activated)
 	ShanghaiBlock *big.Int `json:"shanghaiBlock,omitempty"` // Shanghai switch block (nil = no fork, 0 = already on activated)
+	CancunBlock   *big.Int `json:"cancunBlock,omitempty"`   // Cancun switch block (nil = no fork, 0 = already on activated)
+	VenokiBlock   *big.Int `json:"venokiBlock,omitempty"`   // Venoki switch block (nil = no fork, 0 = already on activated)
 
 	BlacklistContractAddress           *common.Address `json:"blacklistContractAddress,omitempty"`           // Address of Blacklist Contract (nil = no blacklist)
 	FenixValidatorContractAddress      *common.Address `json:"fenixValidatorContractAddress,omitempty"`      // Address of Ronin Contract in the Fenix hardfork (nil = no blacklist)
@@ -715,7 +717,7 @@ func (c *ChainConfig) String() string {
 	chainConfigFmt += "Engine: %v, Blacklist Contract: %v, Fenix Validator Contract: %v, ConsortiumV2: %v, ConsortiumV2.RoninValidatorSet: %v, "
 	chainConfigFmt += "ConsortiumV2.SlashIndicator: %v, ConsortiumV2.StakingContract: %v, Puffy: %v, Buba: %v, Olek: %v, Shillin: %v, Antenna: %v, "
 	chainConfigFmt += "ConsortiumV2.ProfileContract: %v, ConsortiumV2.FinalityTracking: %v, whiteListDeployerContractV2Address: %v, roninTreasuryAddress: %v, "
-	chainConfigFmt += "Miko: %v, Tripp: %v, TrippPeriod: %v, Aaron: %v, Shanghai: %v, Cancun: %v}"
+	chainConfigFmt += "Miko: %v, Tripp: %v, TrippPeriod: %v, Aaron: %v, Shanghai: %v, Cancun: %v, Venoki: %v}"
 
 	return fmt.Sprintf(chainConfigFmt,
 		c.ChainID,
@@ -757,6 +759,7 @@ func (c *ChainConfig) String() string {
 		c.AaronBlock,
 		c.ShanghaiBlock,
 		c.CancunBlock,
+		c.VenokiBlock,
 	)
 }
 
@@ -903,6 +906,11 @@ func (c *ChainConfig) IsShanghai(num *big.Int) bool {
 // IsCancun returns whether the num is equals to or larger than the cancun fork block.
 func (c *ChainConfig) IsCancun(num *big.Int) bool {
 	return isForked(c.CancunBlock, num)
+}
+
+// IsVenoki returns whether the num is equals to or larger than the venoki fork block.
+func (c *ChainConfig) IsVenoki(num *big.Int) bool {
+	return isForked(c.VenokiBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -1127,6 +1135,7 @@ type Rules struct {
 	IsBerlin, IsLondon                                      bool
 	IsOdysseusFork, IsFenix, IsConsortiumV2, IsAntenna      bool
 	IsMiko, IsTripp, IsAaron, IsShanghai, IsCancun          bool
+	IsVenoki                                                bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1156,5 +1165,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsAaron:          c.IsAaron(num),
 		IsShanghai:       c.IsShanghai(num),
 		IsCancun:         c.IsCancun(num),
+		IsVenoki:         c.IsVenoki(num),
 	}
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -126,9 +126,10 @@ const (
 	// Introduced in Tangerine Whistle (Eip 150)
 	CreateBySelfdestructGas uint64 = 25000
 
-	BaseFeeChangeDenominator = 8          // Bounds the amount the base fee can change between blocks.
+	BaseFeeChangeDenominator = 32         // Bounds the amount the base fee can change between blocks.
 	ElasticityMultiplier     = 2          // Bounds the maximum gas limit an EIP-1559 block may have.
 	InitialBaseFee           = 1000000000 // Initial base fee for EIP-1559 blocks.
+	MinimumBaseFee           = 1000000000 // Minimum base fee after Venoki.
 
 	MaxCodeSize         = 24576                   // Maximum bytecode to permit for a contract
 	MaxCodeSizeShanghai = 32768                   // Maximum bytecode to permit for a contract after Shanghai


### PR DESCRIPTION
After London fork, we always set base fee to 0. This commit implements REP-0022: Enable base fee on Ronin
(https://github.com/ronin-chain/REPs/blob/main/REP-0022/REP-0022.md) to enable base fee calculation and transfer that fee to treasury after Venoki fork.