### PR TITLE
core/rawdb: use atomic int to prevent data race

### DIFF
--- a/core/rawdb/chain_iterator.go
+++ b/core/rawdb/chain_iterator.go
@@ -132,11 +132,12 @@ func iterateTransactions(db ethdb.Database, from uint64, to uint64, reverse bool
 		}
 	}
 	// process runs in parallel
-	nThreadsAlive := int32(threads)
+	var nThreadsAlive atomic.Int32
+	nThreadsAlive.Store(int32(threads))
 	process := func() {
 		defer func() {
 			// Last processor closes the result channel
-			if atomic.AddInt32(&nThreadsAlive, -1) == 0 {
+			if nThreadsAlive.Add(-1) == 0 {
 				close(hashesCh)
 			}
 		}()

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -65,9 +64,9 @@ func (frdb *freezerdb) Freeze(threshold uint64) error {
 	}
 	// Set the freezer threshold to a temporary value
 	defer func(old uint64) {
-		atomic.StoreUint64(&frdb.AncientStore.(*freezer).threshold, old)
-	}(atomic.LoadUint64(&frdb.AncientStore.(*freezer).threshold))
-	atomic.StoreUint64(&frdb.AncientStore.(*freezer).threshold, threshold)
+		frdb.AncientStore.(*freezer).threshold.Store(old)
+	}(frdb.AncientStore.(*freezer).threshold.Load())
+	frdb.AncientStore.(*freezer).threshold.Store(threshold)
 
 	// Trigger a freeze cycle and block until it's done
 	trigger := make(chan struct{}, 1)

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -443,8 +443,8 @@ func (f *freezer) freeze(db ethdb.KeyValueStore) {
 		batch.Reset()
 
 		// Step into the future and delete and dangling side chains
-		if f.frozen.Load() > 0 {
-			tip := f.frozen.Load()
+		tip := f.frozen.Load()
+		if tip > 0 {
 			for len(dangling) > 0 {
 				drop := make(map[common.Hash]struct{})
 				for _, hash := range dangling {

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -309,7 +309,7 @@ func (f *freezer) Sync() error {
 func (f *freezer) repair() error {
 	min := uint64(math.MaxUint64)
 	for _, table := range f.tables {
-		items := atomic.LoadUint64(&table.items)
+		items := table.items.Load()
 		if min > items {
 			min = items
 		}

--- a/core/rawdb/freezer_batch.go
+++ b/core/rawdb/freezer_batch.go
@@ -18,7 +18,6 @@ package rawdb
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -107,7 +106,7 @@ func (t *freezerTable) newBatch() *freezerTableBatch {
 func (batch *freezerTableBatch) reset() {
 	batch.dataBuffer = batch.dataBuffer[:0]
 	batch.indexBuffer = batch.indexBuffer[:0]
-	batch.curItem = atomic.LoadUint64(&batch.t.items)
+	batch.curItem = batch.t.items.Load()
 	batch.totalBytes = 0
 }
 
@@ -201,7 +200,7 @@ func (batch *freezerTableBatch) commit() error {
 
 	// Update headBytes of table.
 	batch.t.headBytes += dataSize
-	atomic.StoreUint64(&batch.t.items, batch.curItem)
+	batch.t.items.Store(batch.curItem)
 
 	// Update metrics.
 	batch.t.sizeGauge.Inc(dataSize + indexSize)

--- a/core/rawdb/freezer_table_test.go
+++ b/core/rawdb/freezer_table_test.go
@@ -191,7 +191,7 @@ func TestFreezerRepairDanglingHeadLarge(t *testing.T) {
 		writeChunks(t, f, 255, 15)
 
 		// The last item should be there
-		if _, err = f.Retrieve(f.items - 1); err != nil {
+		if _, err = f.Retrieve(f.items.Load() - 1); err != nil {
 			t.Fatal(err)
 		}
 		f.Close()
@@ -317,7 +317,7 @@ func TestFreezerRepairDanglingIndex(t *testing.T) {
 		writeChunks(t, f, 9, 15)
 
 		// The last item should be there
-		if _, err = f.Retrieve(f.items - 1); err != nil {
+		if _, err = f.Retrieve(f.items.Load() - 1); err != nil {
 			f.Close()
 			t.Fatal(err)
 		}
@@ -350,8 +350,8 @@ func TestFreezerRepairDanglingIndex(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer f.Close()
-		if f.items != 7 {
-			t.Fatalf("expected %d items, got %d", 7, f.items)
+		if f.items.Load() != 7 {
+			t.Fatalf("expected %d items, got %d", 7, f.items.Load())
 		}
 		if err := assertFileSize(fileToCrop, 15); err != nil {
 			t.Fatal(err)
@@ -374,7 +374,7 @@ func TestFreezerTruncate(t *testing.T) {
 		writeChunks(t, f, 30, 15)
 
 		// The last item should be there
-		if _, err = f.Retrieve(f.items - 1); err != nil {
+		if _, err = f.Retrieve(f.items.Load() - 1); err != nil {
 			t.Fatal(err)
 		}
 		f.Close()
@@ -388,8 +388,8 @@ func TestFreezerTruncate(t *testing.T) {
 		}
 		defer f.Close()
 		f.truncate(10) // 150 bytes
-		if f.items != 10 {
-			t.Fatalf("expected %d items, got %d", 10, f.items)
+		if f.items.Load() != 10 {
+			t.Fatalf("expected %d items, got %d", 10, f.items.Load())
 		}
 		// 45, 45, 45, 15 -- bytes should be 15
 		if f.headBytes != 15 {
@@ -444,9 +444,9 @@ func TestFreezerRepairFirstFile(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if f.items != 1 {
+		if f.items.Load() != 1 {
 			f.Close()
-			t.Fatalf("expected %d items, got %d", 0, f.items)
+			t.Fatalf("expected %d items, got %d", 0, f.items.Load())
 		}
 
 		// Write 40 bytes
@@ -483,7 +483,7 @@ func TestFreezerReadAndTruncate(t *testing.T) {
 		writeChunks(t, f, 30, 15)
 
 		// The last item should be there
-		if _, err = f.Retrieve(f.items - 1); err != nil {
+		if _, err = f.Retrieve(f.items.Load() - 1); err != nil {
 			t.Fatal(err)
 		}
 		f.Close()
@@ -495,9 +495,9 @@ func TestFreezerReadAndTruncate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if f.items != 30 {
+		if f.items.Load() != 30 {
 			f.Close()
-			t.Fatalf("expected %d items, got %d", 0, f.items)
+			t.Fatalf("expected %d items, got %d", 0, f.items.Load())
 		}
 		for y := byte(0); y < 30; y++ {
 			f.Retrieve(uint64(y))


### PR DESCRIPTION
Currently, some fields (i.e., `frozen`) in rawdb packet are currently stored atomically but read non-atomically, causing a data race. As a result, one of our shadow nodes (with data race detector flag set) meets a race condition error.
```
WARNING: DATA RACE
Write at 0x00c0001fa280 by main goroutine:
  sync/atomic.StoreInt64()
      runtime/race_amd64.s:237 +0xb
  sync/atomic.StoreUint64()
      <autogenerated>:1 +0x1b
  github.com/ethereum/go-ethereum/core/rawdb.(*freezerdb).TruncateAncients()
      <autogenerated>:1 +0x67
  github.com/ethereum/go-ethereum/node.(*closeTrackingDB).TruncateAncients()
      <autogenerated>:1 +0x56
  github.com/ethereum/go-ethereum/core.(*BlockChain).setHeadBeyondRoot.func2()
      github.com/ethereum/go-ethereum/core/blockchain.go:728 +0xbb
  github.com/ethereum/go-ethereum/core.(*HeaderChain).SetHead()
      github.com/ethereum/go-ethereum/core/headerchain.go:598 +0xb72
  github.com/ethereum/go-ethereum/core.(*BlockChain).setHeadBeyondRoot()
      github.com/ethereum/go-ethereum/core/blockchain.go:746 +0x33b
  github.com/ethereum/go-ethereum/core.NewBlockChain()
      github.com/ethereum/go-ethereum/core/blockchain.go:335 +0x1d8e
...
...
Previous read at 0x00c0001fa280 by goroutine 4197:
  github.com/ethereum/go-ethereum/core/rawdb.(*freezer).freeze()
      github.com/ethereum/go-ethereum/core/rawdb/freezer.go:384 +0x553
  github.com/ethereum/go-ethereum/core/rawdb.NewDatabaseWithFreezer.func1()
      github.com/ethereum/go-ethereum/core/rawdb/database.go:223 +0x4c

Goroutine 4197 (running) created at:
  github.com/ethereum/go-ethereum/core/rawdb.NewDatabaseWithFreezer()
      github.com/ethereum/go-ethereum/core/rawdb/database.go:222 +0xeb9
  github.com/ethereum/go-ethereum/core/rawdb.Open()
      github.com/ethereum/go-ethereum/core/rawdb/database.go:346 +0xc8
```

To mitigate this, this PR migrates to using atomic.Uint64 for some fields to enforce developer read/write these fields in atomic access manner.
Full log: [full_log.txt](https://github.com/user-attachments/files/16747300/untitled2.txt)

Reference: https://github.com/ethereum/go-ethereum/pull/26935/files
