### PR TITLE
eth: add the blob size when estimating block bodies answer packet

### DIFF
--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -57,6 +58,11 @@ const (
 	// containing 200+ transactions nowadays, the practical limit will always
 	// be softResponseLimit.
 	maxReceiptsServe = 1024
+)
+
+var (
+	// estBlobSize is the approximate size of a RLP encoded blob.
+	estBlobSize = len(kzg4844.Blob{}) + len(kzg4844.Commitment{}) + len(kzg4844.Proof{}) + 100
 )
 
 // Handler is a callback to invoke from an outside runner after the boilerplate

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -180,10 +180,9 @@ func answerGetBlockBodiesQuery100(backend Backend, query GetBlockBodiesPacket, p
 			bytes += len(data)
 			sidecars := make([]*types.BlobTxSidecar, 0)
 			blobSidecars := backend.Chain().GetBlobSidecarsByHash(hash)
-			if blobSidecars != nil {
-				for _, sidecar := range blobSidecars {
-					sidecars = append(sidecars, &sidecar.BlobTxSidecar)
-				}
+			for _, sidecar := range blobSidecars {
+				sidecars = append(sidecars, &sidecar.BlobTxSidecar)
+				bytes += len(sidecar.BlobTxSidecar.Blobs) * estBlobSize
 			}
 			sidecarsList = append(sidecarsList, sidecars)
 		}


### PR DESCRIPTION
Currently, blob size is not added when estimating block bodies answer packet. Therefore, a node can try to create a block bodies answer packet that is bigger the maximum limit (10 MB in eth protocol, 16 MB in rlpx). This commit adds the blob size to correctly track the block bodies answer packet's size.