### PR TITLE
core/types: fix response uncapitalized blob sidecars

### DIFF
--- a/core/types/blob_sidecar.go
+++ b/core/types/blob_sidecar.go
@@ -6,7 +6,7 @@ type BlobSidecars []*BlobSidecar
 
 type BlobSidecar struct {
 	BlobTxSidecar
-	TxHash common.Hash
+	TxHash common.Hash `json:"txHash"`
 }
 
 func NewBlobSidecarFromTx(tx *Transaction) *BlobSidecar {

--- a/core/types/blob_tx.go
+++ b/core/types/blob_tx.go
@@ -54,9 +54,9 @@ type BlobTx struct {
 
 // BlobTxSidecar contains the blobs of a blob transaction.
 type BlobTxSidecar struct {
-	Blobs       []kzg4844.Blob       // Blobs needed by the blob pool
-	Commitments []kzg4844.Commitment // Commitments needed by the blob pool
-	Proofs      []kzg4844.Proof      // Proofs needed by the blob pool
+	Blobs       []kzg4844.Blob       `json:"blobs"`       // Blobs needed by the blob pool
+	Commitments []kzg4844.Commitment `json:"commitments"` // Commitments needed by the blob pool
+	Proofs      []kzg4844.Proof      `json:"proofs"`      // Proofs needed by the blob pool
 }
 
 // BlobHashes computes the blob hashes of the given blobs.


### PR DESCRIPTION
Old rpc response for eth_getBlobSidecarsByHash
```
[
       {
            "Blobs": [],
            "Commitments": [],
            "Proofs": [],
            "TxHash": ""
        }
]

```

New response
```
[
       {
            "blobs": [],
            "commitments": [],
            "proofs": [],
            "txHash": ""
        }
]
```


_Easy to merge_