### PR TITLE
consortium-v2: reduce the system transaction's gas limit after Venoki

### DIFF
--- a/consensus/consortium/common/constants.go
+++ b/consensus/consortium/common/constants.go
@@ -10,6 +10,9 @@ const (
 	ExtraSeal                        = crypto.SignatureLength
 	ExtraVanity                      = 32
 	MaxFinalityVotePercentage uint16 = 10_000
+
+	// The gas limit of system transaction after Venoki
+	systemTransactionGasLimit = 50_000_000
 )
 
 var (


### PR DESCRIPTION
System transaction is a special transaction which is not constrained by the gas pool block limit. So currently, system transaction has a very high gas limit (i.e. MaxUint64 / 2). It is unnecessary because actual gas used is much lower and must be fewer than block gas limit. Besides, the high transaction gas limit also causes issues with developer tools.

This commit reduces the system transaction gas limit to 50_000_000 after Venoki. The change to system transaction in getTransactionOpts requires the Venoki hardfork. Other places where the high gas limit is used to call contract do not require hardfork logic because we assume that 50_000_000 is enough to perform these contract calls and the results of contract calls do not depend on the provided gas limit.