### PR TITLE
cli: skip migrating global flags for nil action

### DIFF
--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -78,9 +78,11 @@ func MigrateGlobalFlags(ctx *cli.Context) {
 	// This iterates over all commands and wraps their action function.
 	iterate(ctx.App.Commands, func(cmd *cli.Command) {
 		action := cmd.Action
-		cmd.Action = func(ctx *cli.Context) error {
-			doMigrateFlags(ctx)
-			return action(ctx)
+		if action != nil {
+			cmd.Action = func(ctx *cli.Context) error {
+				doMigrateFlags(ctx)
+				return action(ctx)
+			}
 		}
 	})
 }


### PR DESCRIPTION
```
> ./build/bin/ronin account

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10035aa]

goroutine 1 [running]:
github.com/ethereum/go-ethereum/internal/flags.MigrateGlobalFlags.func2.1(0xc0004eeec0)
        github.com/ethereum/go-ethereum/internal/flags/helpers.go:83 +0x2a
github.com/urfave/cli/v2.(*Command).Run(0x29b36c0, 0xc0004eeec0, {0xc0006da160, 0x1, 0x1})
        github.com/urfave/cli/v2@v2.27.1/command.go:279 +0x97d
github.com/urfave/cli/v2.(*Command).Run(0xc0005eec60, 0xc0004cc080, {0xc000156000, 0x2, 0x2})
        github.com/urfave/cli/v2@v2.27.1/command.go:272 +0xbb7
github.com/urfave/cli/v2.(*App).RunContext(0xc00028da00, {0x1d92a58, 0x2c71480}, {0xc000156000, 0x2, 0x2})
        github.com/urfave/cli/v2@v2.27.1/app.go:337 +0x58b
github.com/urfave/cli/v2.(*App).Run(...)
        github.com/urfave/cli/v2@v2.27.1/app.go:311
main.main()
        github.com/ethereum/go-ethereum/cmd/ronin/main.go:308 +0x45
```
Currently, we get the crash because the account command does not define any actions, it requires the user to provide further subcommand. Normally, when having a command with nil action, the cli package will print the helper. However, since we want the global flags to be available to subcommand, we create a wrapper action which migrates the global flags before calling the underlying action. And we create a wrapper action without checking the underlying action is nil which leads to nil action to be called. This commit skips creating the wrapper action to migrate flags when the underlying action is nil.