### PR TITLE
crypto/kzg4844: cache the verify blob proof result

### DIFF
--- a/crypto/kzg4844/kzg4844_test.go
+++ b/crypto/kzg4844/kzg4844_test.go
@@ -193,3 +193,25 @@ func benchmarkVerifyBlobProof(b *testing.B, ckzg bool) {
 		VerifyBlobProof(blob, commitment, proof)
 	}
 }
+
+func BenchmarkCKZGVerifyBlobProofCacheMiss(b *testing.B) { benchmarkVerifyBlobProofCacheMiss(b, true) }
+func BenchmarkGoKZGVerifyBlobProofCacheMiss(b *testing.B) {
+	benchmarkVerifyBlobProofCacheMiss(b, false)
+}
+func benchmarkVerifyBlobProofCacheMiss(b *testing.B, ckzg bool) {
+	if ckzg && !ckzgAvailable {
+		b.Skip("CKZG unavailable in this test build")
+	}
+	defer func(old bool) { useCKZG.Store(old) }(useCKZG.Load())
+	useCKZG.Store(ckzg)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		blob := randBlob()
+		commitment, _ := BlobToCommitment(blob)
+		proof, _ := ComputeBlobProof(blob, commitment)
+		b.StartTimer()
+		VerifyBlobProof(blob, commitment, proof)
+	}
+}


### PR DESCRIPTION
There are 2 places that verify blob proof: transaction pool when a blob
transaction is added, blob sidecar of a new block. The blob in a blob
transaction in pool is very likely to be included in a mined block in the near
future. So we can cache the verification result to avoid double verification.

The benchmark results show significant improvement in cache hit case and
insignificant overhead in cache miss case.

Benchmark with cache hit
```
                       │    old.txt     │               new.txt                │
                       │     sec/op     │    sec/op     vs base                │
GoKZGVerifyBlobProof-8   2813.49µ ± 15%   19.74µ ± 17%  -99.30% (p=0.000 n=10)
```
Benchmark with cache miss
```
                                │   old.txt   │            new.txt            │
                                │   sec/op    │   sec/op     vs base          │
GoKZGVerifyBlobProofCacheMiss-8   4.194m ± 7%   4.391m ± 6%  ~ (p=0.165 n=10)
```