### PR TITLE
core: capture opcode execution in subscriber only

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1843,11 +1843,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 
 		// Process block using the parent state as reference point
 		substart := time.Now()
-		publishEvents := []*vm.PublishEvent{}
-		if bc.enableAdditionalChainEvent {
-			publishEvents = bc.OpEvents()
-		}
-		receipts, logs, internalTxs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig, publishEvents...)
+		receipts, logs, internalTxs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig, bc.OpEvents()...)
 		if err != nil {
 			bc.reportBlock(block, receipts, err)
 			atomic.StoreUint32(&followupInterrupt, 1)

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -444,17 +444,20 @@ func (bc *BlockChain) ReadDirtyAccounts(hash common.Hash) []*types.DirtyStateAcc
 }
 
 func (bc *BlockChain) OpEvents() []*vm.PublishEvent {
-	return []*vm.PublishEvent{
-		{
-			OpCodes: []vm.OpCode{
-				vm.CALL,
-				vm.DELEGATECALL,
-				vm.CREATE,
-				vm.CREATE2,
+	if bc.enableAdditionalChainEvent {
+		return []*vm.PublishEvent{
+			{
+				OpCodes: []vm.OpCode{
+					vm.CALL,
+					vm.DELEGATECALL,
+					vm.CREATE,
+					vm.CREATE2,
+				},
+				Event: &InternalTransactionEvent{},
 			},
-			Event: &InternalTransactionEvent{},
-		},
+		}
 	}
+	return nil
 }
 
 type InternalTransactionEvent struct{}


### PR DESCRIPTION
enableAdditionalChainEvent is true in subscriber only to publish additional information including opcode execution. Currently, in insertChain, we already enableAdditionalChainEvent the before capturing opcode execution. However, in system transaction, we always capture opcode execution by using bc.OpEvents without checking enableAdditionalChainEvent. This commit moves the enableAdditionalChainEvent check into bc.OpEvents so that opcode execution is captured only when enableAdditionalChainEvent is true.