### PR TITLE
core: allow different gasTipCap and gasFeeCap after Venoki

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -349,8 +349,11 @@ func (st *StateTransition) preCheck() error {
 				msg.ExpiredTime(), st.evm.Context.Time)
 		}
 
-		if msg.GasTipCap().Cmp(msg.GasFeeCap()) != 0 {
-			return ErrDifferentFeeCapTipCap
+		// Before Venoki (base fee is 0), we have the rule that these 2 fields must be the same
+		if !st.evm.ChainConfig().IsVenoki(st.evm.Context.BlockNumber) {
+			if msg.GasTipCap().Cmp(msg.GasFeeCap()) != 0 {
+				return ErrDifferentFeeCapTipCap
+			}
 		}
 	}
 

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -167,11 +167,11 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 			return err
 		}
 	} else if tx.Type() == types.SponsoredTxType {
-		// Currently, these 2 fields must be the same in sponsored transaction.
-		// We create 2 separate fields to reserve for the future, in case we
-		// decide to support dynamic fee transaction.
-		if tx.GasFeeCap().Cmp(tx.GasTipCap()) != 0 {
-			return core.ErrDifferentFeeCapTipCap
+		// Before Venoki (base fee is 0), we have the rule that these 2 fields must be the same
+		if !opts.Config.IsVenoki(head.Number) {
+			if tx.GasFeeCap().Cmp(tx.GasTipCap()) != 0 {
+				return core.ErrDifferentFeeCapTipCap
+			}
 		}
 
 		// Ensure sponsored transaction is not expired


### PR DESCRIPTION
After Venoki, when base fee is enabled, remove the restriction that gasTipCap must be the same as gasFeeCap in sponsored transaction.