### PR TITLE
p2p/enr: reduce allocation in Record.encode (#24034)

### DIFF
--- a/p2p/enr/enr.go
+++ b/p2p/enr/enr.go
@@ -304,7 +304,7 @@ func (r *Record) AppendElements(list []interface{}) []interface{} {
 }
 
 func (r *Record) encode(sig []byte) (raw []byte, err error) {
-	list := make([]interface{}, 1, 2*len(r.pairs)+1)
+	list := make([]interface{}, 1, 2*len(r.pairs)+2)
 	list[0] = sig
 	list = r.AppendElements(list)
 	if raw, err = rlp.EncodeToBytes(list); err != nil {


### PR DESCRIPTION
+2 ( including sig and seq ), avoid reallocation when over capacity
```
// AppendElements appends the sequence number and entries to the given slice.
func (r *Record) AppendElements(list []interface{}) []interface{} {
	list = append(list, r.seq)
	for _, p := range r.pairs {
		list = append(list, p.k, p.v)
	}
	return list
}
```