### PR TITLE
eth/tracers: fix system transaction and prestate tracer after Venoki

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -420,8 +420,10 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
 	// Check clauses 1-3, buy gas if everything is correct
-	if err := st.preCheck(); err != nil {
-		return nil, err
+	if !st.evm.Config.IsSystemTransaction {
+		if err := st.preCheck(); err != nil {
+			return nil, err
+		}
 	}
 
 	if tracer := st.evm.Config.Tracer; tracer != nil {


### PR DESCRIPTION
- core: skip gas check for system transaction when tracing

As system transaction has 0 gas price, it does not pass the check that gas price
must be greater or equal to base fee when base fee is not 0. Skip gas check for
system transaction in TransitionDb, system transaction will go through
TransitionDb only in tracing path not in normal transaction processing path.

- eth/tracers: fix balance tracking in prestate tracer after Venoki

Add ronin treasury to balance tracking after Venoki as base fee and blob fee are
transferred to it. The blob fee is subtracted from sender's balance added to
ronin treasury's balance in buyGas which is before the CaptureStart hook. So we
need to fix these balances up to get the correct balance before the transaction
happens.