### PR TITLE
core/rawdb: fix double-lock causing hang (#24189)

### DIFF
--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -416,8 +416,11 @@ func ReadCanonicalBodyRLP(db ethdb.Reader, number uint64) rlp.RawValue {
 		if len(data) > 0 {
 			return nil
 		}
-		// Get it by hash from leveldb
-		data, _ = db.Get(blockBodyKey(number, ReadCanonicalHash(db, number)))
+		// Block is not in ancients, read from leveldb by hash and number.
+		// Note: ReadCanonicalHash cannot be used here because it also
+		// calls ReadAncients internally.
+		hash, _ := db.Get(headerHashKey(number))
+		data, _ = db.Get(blockBodyKey(number, common.BytesToHash(hash)))
 		return nil
 	})
 	return data


### PR DESCRIPTION
commit https://github.com/ethereum/go-ethereum/commit/66a908c5e87a4f38c0507ae2c7e53b242deb7128.

Recursive read-locking is prohibited in RWMutex which can lead to deadlock. ReadCanonicalHash internally calls ReadAncients which cause recursive read-locking. This commit reads the block directly from leveldb/pebbledb in case block is not in ancient without using helper function ReadCanonicalHash.