### PR TITLE
cmd, core, eth, trie: track deleted nodes

### DIFF
--- a/cmd/ronin/dbcmd.go
+++ b/cmd/ronin/dbcmd.go
@@ -180,7 +180,7 @@ WARNING: This is a low-level operation which may cause database corruption!`,
 		Action:    dbDumpTrie,
 		Name:      "dumptrie",
 		Usage:     "Show the storage key/values of a given storage trie",
-		ArgsUsage: "<hex-encoded storage trie root> <hex-encoded start (optional)> <int max elements (optional)>",
+		ArgsUsage: "<hex-encoded state root> <hex-encoded account hash> <hex-encoded storage trie root> <hex-encoded start (optional)> <int max elements (optional)>",
 		Flags: []cli.Flag{
 			utils.DataDirFlag,
 			utils.DBEngineFlag,
@@ -468,7 +468,7 @@ func dbPut(ctx *cli.Context) error {
 
 // dbDumpTrie shows the key-value slots of a given storage trie
 func dbDumpTrie(ctx *cli.Context) error {
-	if ctx.NArg() < 1 {
+	if ctx.NArg() < 3 {
 		return fmt.Errorf("required arguments: %v", ctx.Command.ArgsUsage)
 	}
 	stack, _ := makeConfigNode(ctx)
@@ -477,29 +477,39 @@ func dbDumpTrie(ctx *cli.Context) error {
 	db := utils.MakeChainDatabase(ctx, stack, true)
 	defer db.Close()
 	var (
-		root  []byte
-		start []byte
-		max   = int64(-1)
-		err   error
+		state   []byte
+		storage []byte
+		account []byte
+		start   []byte
+		max     = int64(-1)
+		err     error
 	)
-	if root, err = hexutil.Decode(ctx.Args().Get(0)); err != nil {
-		log.Info("Could not decode the root", "error", err)
+	if state, err = hexutil.Decode(ctx.Args().Get(0)); err != nil {
+		log.Info("Could not decode the state", "error", err)
 		return err
 	}
-	stRoot := common.BytesToHash(root)
-	if ctx.NArg() >= 2 {
-		if start, err = hexutil.Decode(ctx.Args().Get(1)); err != nil {
+	if account, err = hexutil.Decode(ctx.Args().Get(1)); err != nil {
+		log.Info("Could not decode the account hash", "error", err)
+		return err
+	}
+	if storage, err = hexutil.Decode(ctx.Args().Get(2)); err != nil {
+		log.Info("Could not decode the storage trie root", "error", err)
+		return err
+	}
+	if ctx.NArg() > 3 {
+		if start, err = hexutil.Decode(ctx.Args().Get(3)); err != nil {
 			log.Info("Could not decode the seek position", "error", err)
 			return err
 		}
 	}
-	if ctx.NArg() >= 3 {
-		if max, err = strconv.ParseInt(ctx.Args().Get(2), 10, 64); err != nil {
+	if ctx.NArg() > 4 {
+		if max, err = strconv.ParseInt(ctx.Args().Get(4), 10, 64); err != nil {
 			log.Info("Could not decode the max count", "error", err)
 			return err
 		}
 	}
-	theTrie, err := trie.New(common.Hash{}, stRoot, trie.NewDatabase(db))
+	id := trie.StorageTrieID(common.BytesToHash(state), common.BytesToHash(account), common.BytesToHash(storage))
+	theTrie, err := trie.New(id, trie.NewDatabase(db))
 	if err != nil {
 		return err
 	}

--- a/cmd/ronin/snapshot.go
+++ b/cmd/ronin/snapshot.go
@@ -283,7 +283,7 @@ func traverseState(ctx *cli.Context) error {
 		log.Info("Start traversing the state", "root", root, "number", headBlock.NumberU64())
 	}
 	triedb := trie.NewDatabase(chaindb)
-	t, err := trie.NewSecure(common.Hash{}, root, triedb)
+	t, err := trie.NewSecure(trie.StateTrieID(root), triedb)
 	if err != nil {
 		log.Error("Failed to open trie", "root", root, "err", err)
 		return err
@@ -304,7 +304,7 @@ func traverseState(ctx *cli.Context) error {
 			return err
 		}
 		if acc.Root != emptyRoot {
-			storageTrie, err := trie.NewSecure(common.BytesToHash(accIter.Key), acc.Root, triedb)
+			storageTrie, err := trie.NewSecure(trie.StorageTrieID(root, common.BytesToHash(accIter.Key), acc.Root), triedb)
 			if err != nil {
 				log.Error("Failed to open storage trie", "root", acc.Root, "err", err)
 				return err
@@ -373,7 +373,7 @@ func traverseRawState(ctx *cli.Context) error {
 		log.Info("Start traversing the state", "root", root, "number", headBlock.NumberU64())
 	}
 	triedb := trie.NewDatabase(chaindb)
-	t, err := trie.NewSecure(common.Hash{}, root, triedb)
+	t, err := trie.NewSecure(trie.StateTrieID(root), triedb)
 	if err != nil {
 		log.Error("Failed to open trie", "root", root, "err", err)
 		return err
@@ -410,7 +410,7 @@ func traverseRawState(ctx *cli.Context) error {
 				return errors.New("invalid account")
 			}
 			if acc.Root != emptyRoot {
-				storageTrie, err := trie.NewSecure(common.BytesToHash(accIter.LeafKey()), acc.Root, triedb)
+				storageTrie, err := trie.NewSecure(trie.StorageTrieID(root, common.BytesToHash(accIter.LeafKey()), acc.Root), triedb)
 				if err != nil {
 					log.Error("Failed to open storage trie", "root", acc.Root, "err", err)
 					return errors.New("missing storage trie")

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -68,6 +68,8 @@ var (
 	snapshotStorageReadTimer = metrics.NewRegisteredTimer("chain/snapshot/storage/reads", nil)
 	snapshotCommitTimer      = metrics.NewRegisteredTimer("chain/snapshot/commits", nil)
 
+	triedbCommitTimer = metrics.NewRegisteredTimer("chain/triedb/commits", nil)
+
 	blockInsertTimer     = metrics.NewRegisteredTimer("chain/inserts", nil)
 	blockValidationTimer = metrics.NewRegisteredTimer("chain/validation", nil)
 	blockExecutionTimer  = metrics.NewRegisteredTimer("chain/execution", nil)
@@ -2019,8 +2021,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool, sidecars
 		accountCommitTimer.Update(statedb.AccountCommits)   // Account commits are complete, we can mark them
 		storageCommitTimer.Update(statedb.StorageCommits)   // Storage commits are complete, we can mark them
 		snapshotCommitTimer.Update(statedb.SnapshotCommits) // Snapshot commits are complete, we can mark them
+		triedbCommitTimer.Update(statedb.TrieDBCommits)     // Triedb commits are complete, we can mark them
 
-		blockWriteTimer.Update(time.Since(substart) - statedb.AccountCommits - statedb.StorageCommits - statedb.SnapshotCommits)
+		blockWriteTimer.Update(time.Since(substart) - statedb.AccountCommits - statedb.StorageCommits - statedb.SnapshotCommits - statedb.TrieDBCommits)
 		blockInsertTimer.UpdateSince(start)
 		blockTxsGauge.Update(int64(len(block.Transactions())))
 		blockGasUsedGauge.Update(int64(block.GasUsed()))

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -43,7 +43,7 @@ type Database interface {
 	OpenTrie(root common.Hash) (Trie, error)
 
 	// OpenStorageTrie opens the storage trie of an account.
-	OpenStorageTrie(addrHash, root common.Hash) (Trie, error)
+	OpenStorageTrie(stateRoot, addrHash, root common.Hash) (Trie, error)
 
 	// CopyTrie returns an independent copy of the given trie.
 	CopyTrie(Trie) Trie
@@ -145,7 +145,7 @@ type cachingDB struct {
 
 // OpenTrie opens the main account trie at a specific root hash.
 func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
-	tr, err := trie.NewSecure(common.Hash{}, root, db.triedb)
+	tr, err := trie.NewSecure(trie.StateTrieID(root), db.triedb)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +153,8 @@ func (db *cachingDB) OpenTrie(root common.Hash) (Trie, error) {
 }
 
 // OpenStorageTrie opens the storage trie of an account.
-func (db *cachingDB) OpenStorageTrie(addrHash, root common.Hash) (Trie, error) {
-	tr, err := trie.NewSecure(addrHash, root, db.triedb)
+func (db *cachingDB) OpenStorageTrie(stateRoot, addrHash, root common.Hash) (Trie, error) {
+	tr, err := trie.NewSecure(trie.StorageTrieID(stateRoot, addrHash, root), db.triedb)
 	if err != nil {
 		return nil, err
 	}

--- a/core/state/iterator.go
+++ b/core/state/iterator.go
@@ -109,7 +109,7 @@ func (it *NodeIterator) step() error {
 	if err := rlp.Decode(bytes.NewReader(it.stateIt.LeafBlob()), &account); err != nil {
 		return err
 	}
-	dataTrie, err := it.state.db.OpenStorageTrie(common.BytesToHash(it.stateIt.LeafKey()), account.Root)
+	dataTrie, err := it.state.db.OpenStorageTrie(it.state.originalRoot, common.BytesToHash(it.stateIt.LeafKey()), account.Root)
 	if err != nil {
 		return err
 	}

--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -19,10 +19,12 @@ package state
 import "github.com/ethereum/go-ethereum/metrics"
 
 var (
-	accountUpdatedMeter        = metrics.NewRegisteredMeter("state/update/account", nil)
-	storageUpdatedMeter        = metrics.NewRegisteredMeter("state/update/storage", nil)
-	accountDeletedMeter        = metrics.NewRegisteredMeter("state/delete/account", nil)
-	storageDeletedMeter        = metrics.NewRegisteredMeter("state/delete/storage", nil)
-	accountTrieCommittedMeter  = metrics.NewRegisteredMeter("state/commit/accountnodes", nil)
-	storageTriesCommittedMeter = metrics.NewRegisteredMeter("state/commit/storagenodes", nil)
+	accountUpdatedMeter      = metrics.NewRegisteredMeter("state/update/account", nil)
+	storageUpdatedMeter      = metrics.NewRegisteredMeter("state/update/storage", nil)
+	accountDeletedMeter      = metrics.NewRegisteredMeter("state/delete/account", nil)
+	storageDeletedMeter      = metrics.NewRegisteredMeter("state/delete/storage", nil)
+	accountTrieUpdatedMeter  = metrics.NewRegisteredMeter("state/update/accountnodes", nil)
+	storageTriesUpdatedMeter = metrics.NewRegisteredMeter("state/update/storagenodes", nil)
+	accountTrieDeletedMeter  = metrics.NewRegisteredMeter("state/delete/accountnodes", nil)
+	storageTriesDeletedMeter = metrics.NewRegisteredMeter("state/delete/storagenodes", nil)
 )

--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -410,7 +410,7 @@ func extractGenesis(db ethdb.Database, stateBloom *stateBloom) error {
 	if genesis == nil {
 		return errors.New("missing genesis block")
 	}
-	t, err := trie.NewSecure(common.Hash{}, genesis.Root(), trie.NewDatabase(db))
+	t, err := trie.NewSecure(trie.StateTrieID(genesis.Root()), trie.NewDatabase(db))
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func extractGenesis(db ethdb.Database, stateBloom *stateBloom) error {
 				return err
 			}
 			if acc.Root != emptyRoot {
-				storageTrie, err := trie.NewSecure(common.BytesToHash(accIter.LeafKey()), acc.Root, trie.NewDatabase(db))
+				storageTrie, err := trie.NewSecure(trie.StorageTrieID(genesis.Root(), common.BytesToHash(accIter.LeafKey()), acc.Root), trie.NewDatabase(db))
 				if err != nil {
 					return err
 				}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -144,7 +144,7 @@ type testHelper struct {
 func newHelper() *testHelper {
 	diskdb := rawdb.NewMemoryDatabase()
 	triedb := trie.NewDatabase(diskdb)
-	accTrie, _ := trie.NewSecure(common.Hash{}, common.Hash{}, triedb)
+	accTrie, _ := trie.NewSecure(trie.StateTrieID(common.Hash{}), triedb)
 	return &testHelper{
 		diskdb:  diskdb,
 		triedb:  triedb,
@@ -177,7 +177,7 @@ func (t *testHelper) addSnapStorage(accKey string, keys []string, vals []string)
 }
 
 func (t *testHelper) makeStorageTrie(stateRoot, owner common.Hash, keys []string, vals []string, commit bool) []byte {
-	stTrie, _ := trie.NewSecure(owner, common.Hash{}, t.triedb)
+	stTrie, _ := trie.NewSecure(trie.StorageTrieID(stateRoot, owner, common.Hash{}), t.triedb)
 	for i, k := range keys {
 		stTrie.Update([]byte(k), []byte(vals[i]))
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -162,9 +162,9 @@ func (s *stateObject) getTrie(db Database) Trie {
 		}
 		if s.trie == nil {
 			var err error
-			s.trie, err = db.OpenStorageTrie(s.addrHash, s.data.Root)
+			s.trie, err = db.OpenStorageTrie(s.db.originalRoot, s.addrHash, s.data.Root)
 			if err != nil {
-				s.trie, _ = db.OpenStorageTrie(s.addrHash, common.Hash{})
+				s.trie, _ = db.OpenStorageTrie(s.db.originalRoot, s.addrHash, common.Hash{})
 				s.setError(fmt.Errorf("can't create storage trie: %v", err))
 			}
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -124,6 +124,7 @@ type StateDB struct {
 	SnapshotAccountReads time.Duration
 	SnapshotStorageReads time.Duration
 	SnapshotCommits      time.Duration
+	TrieDBCommits        time.Duration
 
 	AccountUpdated int
 	StorageUpdated int
@@ -973,9 +974,11 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 
 	// Commit objects to the trie, measuring the elapsed time
 	var (
-		accountTrieNodes int
-		storageTrieNodes int
-		nodes            = trie.NewMergedNodeSet()
+		accountTrieNodesUpdated int
+		accountTrieNodesDeleted int
+		storageTrieNodesUpdated int
+		storageTrieNodesDeleted int
+		nodes                   = trie.NewMergedNodeSet()
 	)
 	codeWriter := s.db.TrieDB().DiskDB().NewBatch()
 	for addr := range s.stateObjectsDirty {
@@ -996,9 +999,9 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				if err := nodes.Merge(nodeSet); err != nil {
 					return common.Hash{}, err
 				}
-				// TODO: separate counter for update and delete
-				tmp, _ := nodeSet.Size()
-				storageTrieNodes += tmp
+				updated, deleted := nodeSet.Size()
+				storageTrieNodesUpdated += updated
+				storageTrieNodesDeleted += deleted
 			}
 		}
 	}
@@ -1031,8 +1034,7 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		if err := nodes.Merge(nodeSet); err != nil {
 			return common.Hash{}, err
 		}
-		// TODO: separate counter for update and delete
-		accountTrieNodes, _ = nodeSet.Size()
+		accountTrieNodesUpdated, accountTrieNodesDeleted = nodeSet.Size()
 	}
 	if metrics.EnabledExpensive {
 		s.AccountCommits += time.Since(start)
@@ -1041,16 +1043,16 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		storageUpdatedMeter.Mark(int64(s.StorageUpdated))
 		accountDeletedMeter.Mark(int64(s.AccountDeleted))
 		storageDeletedMeter.Mark(int64(s.StorageDeleted))
-		accountTrieCommittedMeter.Mark(int64(accountTrieNodes))
-		storageTriesCommittedMeter.Mark(int64(storageTrieNodes))
+		accountTrieUpdatedMeter.Mark(int64(accountTrieNodesUpdated))
+		accountTrieDeletedMeter.Mark(int64(accountTrieNodesDeleted))
+		storageTriesUpdatedMeter.Mark(int64(storageTrieNodesUpdated))
+		storageTriesDeletedMeter.Mark(int64(storageTrieNodesDeleted))
 		s.AccountUpdated, s.AccountDeleted = 0, 0
 		s.StorageUpdated, s.StorageDeleted = 0, 0
 	}
 	// If snapshotting is enabled, update the snapshot tree with this new version
 	if s.snap != nil {
-		if metrics.EnabledExpensive {
-			defer func(start time.Time) { s.SnapshotCommits += time.Since(start) }(time.Now())
-		}
+		start := time.Now()
 		// Only update if there's a state transition (skip empty Clique blocks)
 		if parent := s.snap.Root(); parent != root {
 			if err := s.snaps.Update(root, parent, s.snapDestructs, s.snapAccounts, s.snapStorage); err != nil {
@@ -1065,14 +1067,30 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 			}
 		}
 		s.snap, s.snapDestructs, s.snapAccounts, s.snapStorage = nil, nil, nil, nil
+		if metrics.EnabledExpensive {
+			s.SnapshotCommits += time.Since(start)
+		}
 	}
 
 	// Update Trie MergeNodeSets.
-	if err := s.db.TrieDB().Update(nodes); err != nil {
-		return common.Hash{}, err
+	if root == (common.Hash{}) {
+		root = emptyRoot
 	}
-	s.originalRoot = root
-	return root, err
+	origin := s.originalRoot
+	if origin == (common.Hash{}) {
+		origin = emptyRoot
+	}
+	if root != origin {
+		start := time.Now()
+		if err := s.db.TrieDB().Update(nodes); err != nil {
+			return common.Hash{}, err
+		}
+		s.originalRoot = root
+		if metrics.EnabledExpensive {
+			s.TrieDBCommits += time.Since(start)
+		}
+	}
+	return root, nil
 }
 
 // ResetAccessList sets access list to empty

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -996,7 +996,9 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 				if err := nodes.Merge(nodeSet); err != nil {
 					return common.Hash{}, err
 				}
-				storageTrieNodes += nodeSet.Len()
+				// TODO: separate counter for update and delete
+				tmp, _ := nodeSet.Size()
+				storageTrieNodes += tmp
 			}
 		}
 	}
@@ -1029,7 +1031,8 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, error) {
 		if err := nodes.Merge(nodeSet); err != nil {
 			return common.Hash{}, err
 		}
-		accountTrieNodes = nodeSet.Len()
+		// TODO: separate counter for update and delete
+		accountTrieNodes, _ = nodeSet.Size()
 	}
 	if metrics.EnabledExpensive {
 		s.AccountCommits += time.Since(start)

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -106,7 +106,7 @@ func checkTrieConsistency(db ethdb.Database, root common.Hash) error {
 	if v, _ := db.Get(root[:]); v == nil {
 		return nil // Consider a non existent state consistent.
 	}
-	trie, err := trie.New(common.Hash{}, root, trie.NewDatabase(db))
+	trie, err := trie.New(trie.StateTrieID(root), trie.NewDatabase(db))
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 	if commit {
 		srcDb.TrieDB().Commit(srcRoot, false, nil)
 	}
-	srcTrie, _ := trie.New(common.Hash{}, srcRoot, srcDb.TrieDB())
+	srcTrie, _ := trie.New(trie.StateTrieID(srcRoot), srcDb.TrieDB())
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
@@ -225,7 +225,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool) {
 					if err := rlp.DecodeBytes(srcTrie.Get(node.syncPath[0]), &acc); err != nil {
 						t.Fatalf("failed to decode account on path %x: %v", node.syncPath[0], err)
 					}
-					stTrie, err := trie.New(common.BytesToHash(node.syncPath[0]), acc.Root, srcDb.TrieDB())
+					stTrie, err := trie.New(trie.StorageTrieID(srcRoot, common.BytesToHash(node.syncPath[0]), acc.Root), srcDb.TrieDB())
 					if err != nil {
 						t.Fatalf("failed to retriev storage trie for path %x: %v", node.syncPath[1], err)
 					}

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -150,7 +150,7 @@ func (p *triePrefetcher) prefetch(owner common.Hash, root common.Hash, keys [][]
 	id := p.trieID(owner, root)
 	fetcher := p.fetchers[id]
 	if fetcher == nil {
-		fetcher = newSubfetcher(p.db, owner, root)
+		fetcher = newSubfetcher(p.db, p.root, owner, root)
 		p.fetchers[id] = fetcher
 	}
 	fetcher.schedule(keys)
@@ -206,6 +206,7 @@ func (p *triePrefetcher) trieID(owner common.Hash, root common.Hash) string {
 // the trie being worked on is retrieved from the prefetcher.
 type subfetcher struct {
 	db    Database    // Database to load trie nodes through
+	state common.Hash // Root hash of the state to prefetch
 	owner common.Hash // Owner of the trie, usually account hash
 	root  common.Hash // Root hash of the trie to prefetch
 	trie  Trie        // Trie being populated with nodes
@@ -225,9 +226,10 @@ type subfetcher struct {
 
 // newSubfetcher creates a goroutine to prefetch state items belonging to a
 // particular root hash.
-func newSubfetcher(db Database, owner common.Hash, root common.Hash) *subfetcher {
+func newSubfetcher(db Database, state common.Hash, owner common.Hash, root common.Hash) *subfetcher {
 	sf := &subfetcher{
 		db:    db,
+		state: state,
 		owner: owner,
 		root:  root,
 		wake:  make(chan struct{}, 1),
@@ -298,7 +300,7 @@ func (sf *subfetcher) loop() {
 		}
 		sf.trie = trie
 	} else {
-		trie, err := sf.db.OpenStorageTrie(sf.owner, sf.root)
+		trie, err := sf.db.OpenStorageTrie(sf.state, sf.owner, sf.root)
 		if err != nil {
 			log.Warn("Trie prefetcher failed opening trie", "root", sf.root, "err", err)
 			return

--- a/eth/api.go
+++ b/eth/api.go
@@ -551,11 +551,11 @@ func (api *PrivateDebugAPI) getModifiedAccounts(startBlock, endBlock *types.Bloc
 	}
 	triedb := api.eth.BlockChain().StateCache().TrieDB()
 
-	oldTrie, err := trie.NewSecure(common.Hash{}, startBlock.Root(), triedb)
+	oldTrie, err := trie.NewSecure(trie.StateTrieID(startBlock.Root()), triedb)
 	if err != nil {
 		return nil, err
 	}
-	newTrie, err := trie.NewSecure(common.Hash{}, endBlock.Root(), triedb)
+	newTrie, err := trie.NewSecure(trie.StateTrieID(endBlock.Root()), triedb)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -234,7 +234,7 @@ func (dl *downloadTester) CurrentFastBlock() *types.Block {
 func (dl *downloadTester) FastSyncCommitHead(hash common.Hash) error {
 	// For now only check that the state trie is correct
 	if block := dl.GetBlockByHash(hash); block != nil {
-		_, err := trie.NewSecure(common.Hash{}, block.Root(), trie.NewDatabase(dl.stateDb))
+		_, err := trie.NewSecure(trie.StateTrieID(block.Root()), trie.NewDatabase(dl.stateDb))
 		return err
 	}
 	return fmt.Errorf("non existent block: %x", hash[:4])

--- a/les/downloader/downloader_test.go
+++ b/les/downloader/downloader_test.go
@@ -229,7 +229,7 @@ func (dl *downloadTester) CurrentFastBlock() *types.Block {
 func (dl *downloadTester) FastSyncCommitHead(hash common.Hash) error {
 	// For now only check that the state trie is correct
 	if block := dl.GetBlockByHash(hash); block != nil {
-		_, err := trie.NewSecure(common.Hash{}, block.Root(), trie.NewDatabase(dl.stateDb))
+		_, err := trie.NewSecure(trie.StateTrieID(block.Root()), trie.NewDatabase(dl.stateDb))
 		return err
 	}
 	return fmt.Errorf("non existent block: %x", hash[:4])

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -406,7 +406,7 @@ func testGetProofs(t *testing.T, protocol int) {
 	accounts := []common.Address{bankAddr, userAddr1, userAddr2, signerAddr, {}}
 	for i := uint64(0); i <= bc.CurrentBlock().NumberU64(); i++ {
 		header := bc.GetHeaderByNumber(i)
-		trie, _ := trie.New(common.Hash{}, header.Root, trie.NewDatabase(server.db))
+		trie, _ := trie.New(trie.StateTrieID(header.Root), trie.NewDatabase(server.db))
 
 		for _, acc := range accounts {
 			req := ProofReq{
@@ -457,7 +457,7 @@ func testGetStaleProof(t *testing.T, protocol int) {
 		var expected []rlp.RawValue
 		if wantOK {
 			proofsV2 := light.NewNodeSet()
-			t, _ := trie.New(common.Hash{}, header.Root, trie.NewDatabase(server.db))
+			t, _ := trie.New(trie.StateTrieID(header.Root), trie.NewDatabase(server.db))
 			t.Prove(account, 0, proofsV2)
 			expected = proofsV2.NodeList()
 		}
@@ -513,7 +513,7 @@ func testGetCHTProofs(t *testing.T, protocol int) {
 		AuxData: [][]byte{rlp},
 	}
 	root := light.GetChtRoot(server.db, 0, bc.GetHeaderByNumber(config.ChtSize-1).Hash())
-	trie, _ := trie.New(common.Hash{}, root, trie.NewDatabase(rawdb.NewTable(server.db, light.ChtTablePrefix)))
+	trie, _ := trie.New(trie.StateTrieID(root), trie.NewDatabase(rawdb.NewTable(server.db, light.ChtTablePrefix)))
 	trie.Prove(key, 0, &proofsV2.Proofs)
 	// Assemble the requests for the different protocols
 	requestsV2 := []HelperTrieReq{{
@@ -578,7 +578,7 @@ func testGetBloombitsProofs(t *testing.T, protocol int) {
 		var proofs HelperTrieResps
 
 		root := light.GetBloomTrieRoot(server.db, 0, bc.GetHeaderByNumber(config.BloomTrieSize-1).Hash())
-		trie, _ := trie.New(common.Hash{}, root, trie.NewDatabase(rawdb.NewTable(server.db, light.BloomTrieTablePrefix)))
+		trie, _ := trie.New(trie.StateTrieID(root), trie.NewDatabase(rawdb.NewTable(server.db, light.BloomTrieTablePrefix)))
 		trie.Prove(key, 0, &proofs.Proofs)
 
 		// Send the proof request and verify the response

--- a/les/server_handler.go
+++ b/les/server_handler.go
@@ -360,7 +360,7 @@ func (h *serverHandler) AddTxsSync() bool {
 
 // getAccount retrieves an account from the state based on root.
 func getAccount(triedb *trie.Database, root, hash common.Hash) (types.StateAccount, error) {
-	trie, err := trie.New(common.Hash{}, root, triedb)
+	trie, err := trie.New(trie.StateTrieID(root), triedb)
 	if err != nil {
 		return types.StateAccount{}, err
 	}
@@ -392,7 +392,7 @@ func (h *serverHandler) GetHelperTrie(typ uint, index uint64) *trie.Trie {
 	if root == (common.Hash{}) {
 		return nil
 	}
-	trie, _ := trie.New(common.Hash{}, root, trie.NewDatabase(rawdb.NewTable(h.chainDb, prefix)))
+	trie, _ := trie.New(trie.StateTrieID(root), trie.NewDatabase(rawdb.NewTable(h.chainDb, prefix)))
 	return trie
 }
 

--- a/les/server_requests.go
+++ b/les/server_requests.go
@@ -429,7 +429,7 @@ func handleGetProofs(msg Decoder) (serveRequestFn, uint64, uint64, error) {
 					p.bumpInvalid()
 					continue
 				}
-				trie, err = statedb.OpenStorageTrie(common.BytesToHash(request.AccKey), account.Root)
+				trie, err = statedb.OpenStorageTrie(root, common.BytesToHash(request.AccKey), account.Root)
 				if trie == nil || err != nil {
 					p.Log().Warn("Failed to open storage trie for proof", "block", header.Number, "hash", header.Hash(), "account", common.BytesToHash(request.AccKey), "root", account.Root, "err", err)
 					continue

--- a/light/odr.go
+++ b/light/odr.go
@@ -54,9 +54,11 @@ type OdrRequest interface {
 
 // TrieID identifies a state or account storage trie
 type TrieID struct {
-	BlockHash, Root common.Hash
-	BlockNumber     uint64
-	AccKey          []byte
+	BlockHash   common.Hash
+	BlockNumber uint64
+	StateRoot   common.Hash
+	Root        common.Hash
+	AccKey      []byte
 }
 
 // StateTrieID returns a TrieID for a state trie belonging to a certain block
@@ -65,8 +67,9 @@ func StateTrieID(header *types.Header) *TrieID {
 	return &TrieID{
 		BlockHash:   header.Hash(),
 		BlockNumber: header.Number.Uint64(),
-		AccKey:      nil,
+		StateRoot:   header.Root,
 		Root:        header.Root,
+		AccKey:      nil,
 	}
 }
 
@@ -77,6 +80,7 @@ func StorageTrieID(state *TrieID, addrHash, root common.Hash) *TrieID {
 	return &TrieID{
 		BlockHash:   state.BlockHash,
 		BlockNumber: state.BlockNumber,
+		StateRoot:   state.StateRoot,
 		AccKey:      addrHash[:],
 		Root:        root,
 	}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -82,7 +82,7 @@ func (odr *testOdr) Retrieve(ctx context.Context, req OdrRequest) error {
 			req.Receipts = rawdb.ReadRawReceipts(odr.sdb, req.Hash, *number)
 		}
 	case *TrieRequest:
-		t, _ := trie.New(common.BytesToHash(req.Id.AccKey), req.Id.Root, trie.NewDatabase(odr.sdb))
+		t, _ := trie.New(trie.StorageTrieID(req.Id.StateRoot, common.BytesToHash(req.Id.AccKey), req.Id.Root), trie.NewDatabase(odr.sdb))
 		nodes := NewNodeSet()
 		t.Prove(req.Key, 0, nodes)
 		req.Proof = nodes

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -187,12 +187,12 @@ func (c *ChtIndexerBackend) Reset(ctx context.Context, section uint64, lastSecti
 		root = GetChtRoot(c.diskdb, section-1, lastSectionHead)
 	}
 	var err error
-	c.trie, err = trie.New(common.Hash{}, root, c.triedb)
+	c.trie, err = trie.New(trie.StateTrieID(root), c.triedb)
 
 	if err != nil && c.odr != nil {
 		err = c.fetchMissingNodes(ctx, section, root)
 		if err == nil {
-			c.trie, err = trie.New(common.Hash{}, root, c.triedb)
+			c.trie, err = trie.New(trie.StateTrieID(root), c.triedb)
 		}
 	}
 	c.section = section
@@ -228,7 +228,7 @@ func (c *ChtIndexerBackend) Commit() error {
 		}
 	}
 	// Re-create trie with nelwy generated root and updated database.
-	c.trie, err = trie.New(common.Hash{}, root, c.triedb)
+	c.trie, err = trie.New(trie.StateTrieID(root), c.triedb)
 	if err != nil {
 		return err
 	}
@@ -414,11 +414,11 @@ func (b *BloomTrieIndexerBackend) Reset(ctx context.Context, section uint64, las
 		root = GetBloomTrieRoot(b.diskdb, section-1, lastSectionHead)
 	}
 	var err error
-	b.trie, err = trie.New(common.Hash{}, root, b.triedb)
+	b.trie, err = trie.New(trie.StateTrieID(root), b.triedb)
 	if err != nil && b.odr != nil {
 		err = b.fetchMissingNodes(ctx, section, root)
 		if err == nil {
-			b.trie, err = trie.New(common.Hash{}, root, b.triedb)
+			b.trie, err = trie.New(trie.StateTrieID(root), b.triedb)
 		}
 	}
 	b.section = section
@@ -476,7 +476,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 	}
 
 	// Re-create trie with nelwy generated root and updated database.
-	b.trie, err = trie.New(common.Hash{}, root, b.triedb)
+	b.trie, err = trie.New(trie.StateTrieID(root), b.triedb)
 	if err != nil {
 		return err
 	}

--- a/light/trie.go
+++ b/light/trie.go
@@ -54,7 +54,7 @@ func (db *odrDatabase) OpenTrie(root common.Hash) (state.Trie, error) {
 	return &odrTrie{db: db, id: db.id}, nil
 }
 
-func (db *odrDatabase) OpenStorageTrie(addrHash, root common.Hash) (state.Trie, error) {
+func (db *odrDatabase) OpenStorageTrie(stateRoot, addrHash, root common.Hash) (state.Trie, error) {
 	return &odrTrie{db: db, id: StorageTrieID(db.id, addrHash, root)}, nil
 }
 
@@ -63,8 +63,7 @@ func (db *odrDatabase) CopyTrie(t state.Trie) state.Trie {
 	case *odrTrie:
 		cpy := &odrTrie{db: t.db, id: t.id}
 		if t.trie != nil {
-			cpytrie := *t.trie
-			cpy.trie = &cpytrie
+			cpy.trie = t.trie.Copy()
 		}
 		return cpy
 	default:
@@ -169,11 +168,13 @@ func (t *odrTrie) do(key []byte, fn func() error) error {
 	for {
 		var err error
 		if t.trie == nil {
-			var owner common.Hash
+			var id *trie.ID
 			if len(t.id.AccKey) > 0 {
-				owner = common.BytesToHash(t.id.AccKey)
+				id = trie.StorageTrieID(t.id.StateRoot, common.BytesToHash(t.id.AccKey), t.id.Root)
+			} else {
+				id = trie.StateTrieID(t.id.StateRoot)
 			}
-			t.trie, err = trie.New(owner, t.id.Root, trie.NewDatabase(t.db.backend.Database()))
+			t.trie, err = trie.New(id, trie.NewDatabase(t.db.backend.Database()))
 		}
 		if err == nil {
 			err = fn()
@@ -199,11 +200,13 @@ func newNodeIterator(t *odrTrie, startkey []byte) trie.NodeIterator {
 	// Open the actual non-ODR trie if that hasn't happened yet.
 	if t.trie == nil {
 		it.do(func() error {
-			var owner common.Hash
+			var id *trie.ID
 			if len(t.id.AccKey) > 0 {
-				owner = common.BytesToHash(t.id.AccKey)
+				id = trie.StorageTrieID(t.id.StateRoot, common.BytesToHash(t.id.AccKey), t.id.Root)
+			} else {
+				id = trie.StateTrieID(t.id.StateRoot)
 			}
-			t, err := trie.New(owner, t.id.Root, trie.NewDatabase(t.db.backend.Database()))
+			t, err := trie.New(id, trie.NewDatabase(t.db.backend.Database()))
 			if err == nil {
 				it.t.trie = t
 			}

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -174,7 +173,7 @@ func runRandTest(rt randTest) error {
 					return err
 				}
 			}
-			newtr, err := trie.New(common.Hash{}, hash, triedb)
+			newtr, err := trie.New(trie.TrieID(hash), triedb)
 			if err != nil {
 				return err
 			}

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -43,8 +43,9 @@ type committer struct {
 	tmp sliceBuffer
 	sha crypto.KeccakState
 
-	owner       common.Hash
+	owner       common.Hash // TODO: same as nodes.owner, consider removing
 	nodes       *NodeSet
+	tracer      *tracer
 	collectLeaf bool
 }
 
@@ -59,9 +60,10 @@ var committerPool = sync.Pool{
 }
 
 // newCommitter creates a new committer or picks one from the pool.
-func newCommitter(owner common.Hash, collectLeaf bool) *committer {
+func newCommitter(owner common.Hash, tracer *tracer, collectLeaf bool) *committer {
 	return &committer{
 		nodes:       NewNodeSet(owner),
+		tracer:      tracer,
 		collectLeaf: collectLeaf,
 	}
 }
@@ -71,6 +73,20 @@ func (c *committer) Commit(n node) (hashNode, *NodeSet, error) {
 	h, err := c.commit(nil, n)
 	if err != nil {
 		return nil, nil, err
+	}
+	// Some nodes can be deleted from trie which can't be captured by committer
+	// itself. Iterate all deleted nodes tracked by tracer and marked them as
+	// deleted only if they are present in database previously.
+	for _, path := range c.tracer.deleteList() {
+		// There are a few possibilities for this scenario(the node is deleted
+		// but not present in database previously), for example the node was
+		// embedded in the parent and now deleted from the trie. In this case
+		// it's noop from database's perspective.
+		val := c.tracer.getPrev(path)
+		if len(val) == 0 {
+			continue
+		}
+		c.nodes.markDeleted(path, val)
 	}
 	return h.(hashNode), c.nodes, nil
 }
@@ -103,6 +119,12 @@ func (c *committer) commit(path []byte, n node) (node, error) {
 		if hn, ok := hashedNode.(hashNode); ok {
 			return hn, nil
 		}
+		// The short node now is embedded in its parent. Mark the node as
+		// deleted if it's present in database previously. It's equivalent
+		// as deletion from database's perspective.
+		if prev := c.tracer.getPrev(path); len(prev) != 0 {
+			c.nodes.markDeleted(path, prev)
+		}
 		return collapsed, nil
 	case *fullNode:
 		hashedKids, err := c.commitChildren(path, cn)
@@ -115,6 +137,12 @@ func (c *committer) commit(path []byte, n node) (node, error) {
 		hashedNode := c.store(path, collapsed)
 		if hn, ok := hashedNode.(hashNode); ok {
 			return hn, nil
+		}
+		// The short node now is embedded in its parent. Mark the node as
+		// deleted if it's present in database previously. It's equivalent
+		// as deletion from database's perspective.
+		if prev := c.tracer.getPrev(path); len(prev) != 0 {
+			c.nodes.markDeleted(path, prev)
 		}
 		return collapsed, nil
 	case hashNode:
@@ -183,7 +211,7 @@ func (c *committer) store(path []byte, n node) node {
 	)
 
 	// Collect the dirty node to nodeset for return.
-	c.nodes.add(string(path), mnode)
+	c.nodes.markUpdated(path, mnode, c.tracer.getPrev(path))
 	// Collect the corresponding leaf node if it's required. We don't check
 	// full node since it's impossible to store value in fullNode. The key
 	// length of leaves should be exactly same.

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -361,7 +361,12 @@ func (it *nodeIterator) resolveHash(hash hashNode, path []byte) (node, error) {
 			}
 		}
 	}
-	return it.trie.resolveHash(hash, path)
+	// Retrieve the specified node from the underlying node reader.
+	// it.trie.resolveAndTrack is not used since in that function the
+	// loaded blob will be tracked, while it's not required here since
+	// all loaded nodes won't be linked to trie at all and track nodes
+	// may lead to out-of-memory issue.
+	return it.trie.reader.node(path, common.BytesToHash(hash))
 }
 
 func (st *nodeIteratorState) resolve(it *nodeIterator, path []byte) error {

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -65,7 +65,7 @@ func TestIterator(t *testing.T) {
 		t.Fatalf("Failed to commit trie %v", err)
 	}
 	db.Update(NewWithNodeSet(nodes))
-	trie, _ = New(common.Hash{}, root, db)
+	trie, _ = New(TrieID(root), db)
 	found := make(map[string]string)
 	it := NewIterator(trie.NodeIterator(nil))
 	for it.Next() {
@@ -226,7 +226,7 @@ func TestDifferenceIterator(t *testing.T) {
 	}
 	rootA, nodesA, _ := triea.Commit(false)
 	dba.Update(NewWithNodeSet(nodesA))
-	triea, _ = New(common.Hash{}, rootA, dba)
+	triea, _ = New(TrieID(rootA), dba)
 
 	dbb := NewDatabase(rawdb.NewMemoryDatabase())
 	trieb := NewEmpty(dbb)
@@ -235,7 +235,7 @@ func TestDifferenceIterator(t *testing.T) {
 	}
 	rootB, nodesB, _ := trieb.Commit(false)
 	dbb.Update(NewWithNodeSet(nodesB))
-	trieb, _ = New(common.Hash{}, rootB, dbb)
+	trieb, _ = New(TrieID(rootB), dbb)
 
 	found := make(map[string]string)
 	di, _ := NewDifferenceIterator(triea.NodeIterator(nil), trieb.NodeIterator(nil))
@@ -268,7 +268,7 @@ func TestUnionIterator(t *testing.T) {
 	}
 	rootA, nodesA, _ := triea.Commit(false)
 	dba.Update(NewWithNodeSet(nodesA))
-	triea, _ = New(common.Hash{}, rootA, dba)
+	triea, _ = New(TrieID(rootA), dba)
 
 	dbb := NewDatabase(rawdb.NewMemoryDatabase())
 	trieb := NewEmpty(dbb)
@@ -277,7 +277,7 @@ func TestUnionIterator(t *testing.T) {
 	}
 	rootB, nodesB, _ := trieb.Commit(false)
 	dbb.Update(NewWithNodeSet(nodesB))
-	trieb, _ = New(common.Hash{}, rootB, dbb)
+	trieb, _ = New(TrieID(rootB), dbb)
 
 	di, _ := NewUnionIterator([]NodeIterator{triea.NodeIterator(nil), trieb.NodeIterator(nil)})
 	it := NewIterator(di)
@@ -355,7 +355,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool) {
 	}
 	for i := 0; i < 20; i++ {
 		// Create trie that will load all nodes from DB.
-		tr, _ := New(common.Hash{}, tr.Hash(), triedb)
+		tr, _ := New(TrieID(tr.Hash()), triedb)
 
 		// Remove a random node from the database. It can't be the root node
 		// because that one is already loaded.
@@ -444,7 +444,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool) {
 	}
 	// Create a new iterator that seeks to "bars". Seeking can't proceed because
 	// the node is missing.
-	tr, _ := New(common.Hash{}, root, triedb)
+	tr, _ := New(TrieID(root), triedb)
 	it := tr.NodeIterator([]byte("bars"))
 	missing, ok := it.Error().(*MissingNodeError)
 	if !ok {
@@ -532,7 +532,7 @@ func makeLargeTestTrie() (*Database, *SecureTrie, *loggingDb) {
 	// Create an empty trie
 	logDb := &loggingDb{0, memorydb.New()}
 	triedb := NewDatabase(rawdb.NewDatabase(logDb))
-	trie, _ := NewSecure(common.Hash{}, common.Hash{}, triedb)
+	trie, _ := NewSecure(TrieID(common.Hash{}), triedb)
 
 	// Fill it with some arbitrary data
 	for i := 0; i < 10000; i++ {

--- a/trie/nodeset.go
+++ b/trie/nodeset.go
@@ -18,52 +18,171 @@ package trie
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // memoryNode is all the information we know about a single cached trie node
 // in the memory.
 type memoryNode struct {
-	hash common.Hash // Node hash, computed by hashing rlp value
-	size uint16      // Byte size of the useful cached data
-	node node        // Cached collapsed trie node, or raw rlp data
+	hash common.Hash // Node hash, computed by hashing rlp value, empty for deleted nodes
+	size uint16      // Byte size of the useful cached data, 0 for deleted nodes
+	node node        // Cached collapsed trie node, or raw rlp data, nil for deleted nodes
+}
+
+// memoryNodeSize is the raw size of a memoryNode data structure without any
+// node data included. It's an approximate size, but should be a lot better
+// than not counting them.
+// nolint:unused
+var memoryNodeSize = int(reflect.TypeOf(memoryNode{}).Size())
+
+// memorySize returns the total memory size used by this node.
+// nolint:unused
+func (n *memoryNode) memorySize(key int) int {
+	return int(n.size) + memoryNodeSize + key
+}
+
+// rlp returns the raw rlp encoded blob of the cached trie node, either directly
+// from the cache, or by regenerating it from the collapsed node.
+// nolint:unused
+func (n *memoryNode) rlp() []byte {
+	if node, ok := n.node.(rawNode); ok {
+		return node
+	}
+	enc, err := rlp.EncodeToBytes(n.node)
+	if err != nil {
+		log.Error("Failed to encode trie node", "err", err)
+	}
+	return enc
+}
+
+// obj returns the decoded and expanded trie node, either directly from the cache,
+// or by regenerating it from the rlp encoded blob.
+// nolint:unused
+func (n *memoryNode) obj() node {
+	if node, ok := n.node.(rawNode); ok {
+		return mustDecodeNode(n.hash[:], node)
+	}
+	return expandNode(n.hash[:], n.node)
+}
+
+// nodeWithPrev wraps the memoryNode with the previous node value.
+type nodeWithPrev struct {
+	*memoryNode
+	prev []byte // RLP-encoded previous value, nil means it's non-existent
+}
+
+// unwrap returns the internal memoryNode object.
+// nolint:unused
+func (n *nodeWithPrev) unwrap() *memoryNode {
+	return n.memoryNode
+}
+
+// memorySize returns the total memory size used by this node. It overloads
+// the function in memoryNode by counting the size of previous value as well.
+// nolint: unused
+func (n *nodeWithPrev) memorySize(key int) int {
+	return n.memoryNode.memorySize(key) + len(n.prev)
+}
+
+// nodesWithOrder represents a collection of dirty nodes which includes
+// newly-inserted and updated nodes. The modification order of all nodes
+// is represented by order list.
+type nodesWithOrder struct {
+	order []string                 // the path list of dirty nodes, sort by insertion order
+	nodes map[string]*nodeWithPrev // the map of dirty nodes, keyed by node path
 }
 
 // NodeSet contains all dirty nodes collected during the commit operation
 // Each node is keyed by path. It's not the thread-safe to use.
 type NodeSet struct {
-	owner  common.Hash            // the identifier of the trie
-	paths  []string               // the path of dirty nodes, sort by insertion order
-	nodes  map[string]*memoryNode // the map of dirty nodes, keyed by node path
-	leaves []*leaf                // the list of dirty leaves
+	owner   common.Hash       // the identifier of the trie
+	updates *nodesWithOrder   // the set of updated nodes(newly inserted, updated)
+	deletes map[string][]byte // the map of deleted nodes, keyed by node
+	leaves  []*leaf           // the list of dirty leaves
 }
 
 // NewNodeSet initializes an empty node set to be used for tracking dirty nodes
 // from a specific account or storage trie. The owner is zero for the account
 // trie and the owning account address hash for storage tries.
-
 func NewNodeSet(owner common.Hash) *NodeSet {
 	return &NodeSet{
 		owner: owner,
-		nodes: make(map[string]*memoryNode),
+		updates: &nodesWithOrder{
+			nodes: make(map[string]*nodeWithPrev),
+		},
+		deletes: make(map[string][]byte),
 	}
 }
 
-// add caches node with provided path and node object.
-func (set *NodeSet) add(path string, node *memoryNode) {
-	set.paths = append(set.paths, path)
-	set.nodes[path] = node
+// NewNodeSetWithDeletion initializes the nodeset with provided deletion set.
+func NewNodeSetWithDeletion(owner common.Hash, paths [][]byte, prev [][]byte) *NodeSet {
+	set := NewNodeSet(owner)
+	for i, path := range paths {
+		set.markDeleted(path, prev[i])
+	}
+	return set
 }
 
-// addLeaf caches the provided leaf node.
+// markUpdated marks the node as dirty(newly-inserted or updated) with provided
+// node path, node object along with its previous value.
+func (set *NodeSet) markUpdated(path []byte, node *memoryNode, prev []byte) {
+	set.updates.order = append(set.updates.order, string(path))
+	set.updates.nodes[string(path)] = &nodeWithPrev{
+		memoryNode: node,
+		prev:       prev,
+	}
+}
+
+// markDeleted marks the node as deleted with provided path and previous value.
+func (set *NodeSet) markDeleted(path []byte, prev []byte) {
+	set.deletes[string(path)] = prev
+}
+
+// addLeaf collects the provided leaf node into set.
 func (set *NodeSet) addLeaf(leaf *leaf) {
 	set.leaves = append(set.leaves, leaf)
 }
 
-// Len returns the number of dirty nodes contained in the set.
-func (set *NodeSet) Len() int {
-	return len(set.nodes)
+// Size returns the number of updated and deleted nodes contained in the set.
+func (set *NodeSet) Size() (int, int) {
+	return len(set.updates.order), len(set.deletes)
+}
+
+// Hashes returns the hashes of all updated nodes.
+func (set *NodeSet) Hashes() []common.Hash {
+	var ret []common.Hash
+	for _, node := range set.updates.nodes {
+		ret = append(ret, node.hash)
+	}
+	return ret
+}
+
+// Summary returns a string-representation of the NodeSet.
+func (set *NodeSet) Summary() string {
+	var out = new(strings.Builder)
+	fmt.Fprintf(out, "nodeset owner: %v\n", set.owner)
+	if set.updates != nil {
+		for _, key := range set.updates.order {
+			updated := set.updates.nodes[key]
+			if updated.prev != nil {
+				fmt.Fprintf(out, "  [*]: %x -> %v prev: %x\n", key, updated.hash, updated.prev)
+			} else {
+				fmt.Fprintf(out, "  [+]: %x -> %v\n", key, updated.hash)
+			}
+		}
+	}
+	for k, n := range set.deletes {
+		fmt.Fprintf(out, "  [-]: %x -> %x\n", k, n)
+	}
+	for _, n := range set.leaves {
+		fmt.Fprintf(out, "[leaf]: %v\n", n)
+	}
+	return out.String()
 }
 
 // MergedNodeSet represents a merged dirty node set for a group of tries.

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -61,8 +60,13 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) e
 			key = key[1:]
 			nodes = append(nodes, n)
 		case hashNode:
+			// Retrieve the specified node from the underlying node reader.
+			// trie.resolveAndTrack is not used since in that function the
+			// loaded blob will be tracked, while it's not required here since
+			// all loaded nodes won't be linked to trie at all and track nodes
+			// may lead to out-of-memory issue
 			var err error
-			tn, err = t.resolveHash(n, prefix)
+			tn, err = t.reader.node(prefix, common.BytesToHash(n))
 			if err != nil {
 				log.Error(fmt.Sprintf("Unhandled trie error: %v", err))
 				return err
@@ -558,7 +562,7 @@ func VerifyRangeProof(rootHash common.Hash, firstKey []byte, lastKey []byte, key
 	}
 	// Rebuild the trie with the leaf stream, the shape of trie
 	// should be same with the original one.
-	tr := &Trie{root: root, db: NewDatabase(rawdb.NewMemoryDatabase())}
+	tr := &Trie{root: root, reader: newEmptyReader()}
 	if empty {
 		tr.root = nil
 	}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -54,11 +54,11 @@ type SecureTrie struct {
 // Loaded nodes are kept around until their 'cache generation' expires.
 // A new cache generation is created by each call to Commit.
 // cachelimit sets the number of past cache generations to keep.
-func NewSecure(owner common.Hash, root common.Hash, db *Database) (*SecureTrie, error) {
+func NewSecure(id *ID, db *Database) (*SecureTrie, error) {
 	if db == nil {
 		panic("trie.NewSecure called without a database")
 	}
-	trie, err := New(owner, root, db)
+	trie, err := New(id, db)
 	if err != nil {
 		return nil, err
 	}

--- a/trie/secure_trie_test.go
+++ b/trie/secure_trie_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newEmptySecure() *SecureTrie {
-	trie, _ := NewSecure(common.Hash{}, common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+	trie, _ := NewSecure(TrieID(common.Hash{}), NewDatabase(rawdb.NewMemoryDatabase()))
 	return trie
 }
 
@@ -36,7 +36,7 @@ func newEmptySecure() *SecureTrie {
 func makeTestSecureTrie() (*Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(rawdb.NewMemoryDatabase())
-	trie, _ := NewSecure(common.Hash{}, common.Hash{}, triedb)
+	trie, _ := NewSecure(TrieID(common.Hash{}), triedb)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -31,7 +31,7 @@ import (
 func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
 	// Create an empty trie
 	triedb := NewDatabase(rawdb.NewMemoryDatabase())
-	trie, _ := NewSecure(common.Hash{}, common.Hash{}, triedb)
+	trie, _ := NewSecure(TrieID(common.Hash{}), triedb)
 
 	// Fill it with some arbitrary data
 	content := make(map[string][]byte)
@@ -68,7 +68,7 @@ func makeTestTrie() (*Database, *SecureTrie, map[string][]byte) {
 // content map.
 func checkTrieContents(t *testing.T, db *Database, root []byte, content map[string][]byte) {
 	// Check root availability and trie contents
-	trie, err := NewSecure(common.Hash{}, common.BytesToHash(root), db)
+	trie, err := NewSecure(TrieID(common.BytesToHash(root)), db)
 	if err != nil {
 		t.Fatalf("failed to create trie at %x: %v", root, err)
 	}
@@ -85,7 +85,7 @@ func checkTrieContents(t *testing.T, db *Database, root []byte, content map[stri
 // checkTrieConsistency checks that all nodes in a trie are indeed present.
 func checkTrieConsistency(db *Database, root common.Hash) error {
 	// Create and iterate a trie rooted in a subnode
-	trie, err := NewSecure(common.Hash{}, root, db)
+	trie, err := NewSecure(TrieID(root), db)
 	if err != nil {
 		return nil // Consider a non existent state consistent
 	}
@@ -107,7 +107,7 @@ func TestEmptySync(t *testing.T) {
 	dbA := NewDatabase(rawdb.NewMemoryDatabase())
 	dbB := NewDatabase(rawdb.NewMemoryDatabase())
 	emptyA := NewEmpty(dbA)
-	emptyB, _ := New(common.Hash{}, emptyRoot, dbB)
+	emptyB, _ := New(TrieID(emptyRoot), dbB)
 
 	for i, trie := range []*Trie{emptyA, emptyB} {
 		sync := NewSync(trie.Hash(), memorydb.New(), nil, NewSyncBloom(1, memorydb.New()), []*Database{dbA, dbB}[i].Scheme())

--- a/trie/trie_id.go
+++ b/trie/trie_id.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package trie
+
+import "github.com/ethereum/go-ethereum/common"
+
+// ID is the identifier for uniquely identifying a trie.
+type ID struct {
+	StateRoot common.Hash // The root of the corresponding state(block.root)
+	Owner     common.Hash // The contract address hash which the trie belongs to
+	Root      common.Hash // The root hash of trie
+}
+
+// StateTrieID constructs an identifier for state trie with the provided state root.
+func StateTrieID(root common.Hash) *ID {
+	return &ID{
+		StateRoot: root,
+		Owner:     common.Hash{},
+		Root:      root,
+	}
+}
+
+// StorageTrieID constructs an identifier for storage trie which belongs to a certain
+// state and contract specified by the stateRoot and owner.
+func StorageTrieID(stateRoot common.Hash, owner common.Hash, root common.Hash) *ID {
+	return &ID{
+		StateRoot: stateRoot,
+		Owner:     owner,
+		Root:      root,
+	}
+}
+
+// TrieID constructs an identifier for a standard trie(not a second-layer trie)
+// with provided root. It's mostly used in tests and some other tries like CHT trie.
+func TrieID(root common.Hash) *ID {
+	return &ID{
+		StateRoot: root,
+		Owner:     common.Hash{},
+		Root:      root,
+	}
+}

--- a/trie/trie_reader.go
+++ b/trie/trie_reader.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package trie
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Reader wraps the Node and NodeBlob method of a backing trie store.
+type Reader interface {
+	// Node retrieves the trie node with the provided trie identifier, hexary
+	// node path and the corresponding node hash.
+	// No error will be returned if the node is not found.
+	Node(owner common.Hash, path []byte, hash common.Hash) (node, error)
+
+	// NodeBlob retrieves the RLP-encoded trie node blob with the provided trie
+	// identifier, hexary node path and the corresponding node hash.
+	// No error will be returned if the node is not found.
+	NodeBlob(owner common.Hash, path []byte, hash common.Hash) ([]byte, error)
+}
+
+// NodeReader wraps all the necessary functions for accessing trie node.
+type NodeReader interface {
+	// GetReader returns a reader for accessing all trie nodes with provided
+	// state root. Nil is returned in case the state is not available.
+	GetReader(root common.Hash) Reader
+}
+
+// trieReader is a wrapper of the underlying node reader. It's not safe
+// for concurrent usage.
+type trieReader struct {
+	owner  common.Hash
+	reader Reader
+	banned map[string]struct{} // Marker to prevent node from being accessed, for tests
+}
+
+// newTrieReader initializes the trie reader with the given node reader.
+func newTrieReader(stateRoot, owner common.Hash, db NodeReader) (*trieReader, error) {
+	reader := db.GetReader(stateRoot)
+	if reader == nil {
+		return nil, fmt.Errorf("state not found #%x", stateRoot)
+	}
+	return &trieReader{owner: owner, reader: reader}, nil
+}
+
+// newEmptyReader initializes the pure in-memory reader. All read operations
+// should be forbidden and returns the MissingNodeError.
+func newEmptyReader() *trieReader {
+	return &trieReader{}
+}
+
+// node retrieves the trie node with the provided trie node information.
+// An MissingNodeError will be returned in case the node is not found or
+// any error is encountered.
+func (r *trieReader) node(path []byte, hash common.Hash) (node, error) {
+	// Perform the logics in tests for preventing trie node access.
+	if r.banned != nil {
+		if _, ok := r.banned[string(path)]; ok {
+			return nil, &MissingNodeError{Owner: r.owner, NodeHash: hash, Path: path}
+		}
+	}
+	if r.reader == nil {
+		return nil, &MissingNodeError{Owner: r.owner, NodeHash: hash, Path: path}
+	}
+	node, err := r.reader.Node(r.owner, path, hash)
+	if err != nil || node == nil {
+		return nil, &MissingNodeError{Owner: r.owner, NodeHash: hash, Path: path, err: err}
+	}
+	return node, nil
+}
+
+// node retrieves the rlp-encoded trie node with the provided trie node
+// information. An MissingNodeError will be returned in case the node is
+// not found or any error is encountered.
+func (r *trieReader) nodeBlob(path []byte, hash common.Hash) ([]byte, error) {
+	// Perform the logics in tests for preventing trie node access.
+	if r.banned != nil {
+		if _, ok := r.banned[string(path)]; ok {
+			return nil, &MissingNodeError{Owner: r.owner, NodeHash: hash, Path: path}
+		}
+	}
+	if r.reader == nil {
+		return nil, &MissingNodeError{Owner: r.owner, NodeHash: hash, Path: path}
+	}
+	blob, err := r.reader.NodeBlob(r.owner, path, hash)
+	if err != nil || len(blob) == 0 {
+		return nil, &MissingNodeError{Owner: r.owner, NodeHash: hash, Path: path, err: err}
+	}
+	return blob, nil
+}

--- a/trie/utils.go
+++ b/trie/utils.go
@@ -52,43 +52,43 @@ func newTracer() *tracer {
 
 // onRead tracks the newly loaded trie node and caches the rlp-encoded blob internally.
 // Don't change the value outside of function since it's not deep-copied.
-func (t *tracer) onRead(key []byte, val []byte) {
+func (t *tracer) onRead(path []byte, val []byte) {
 	// Tracer isn't used right now, remove this check later.
 	if t == nil {
 		return
 	}
-	t.origin[string(key)] = val
+	t.origin[string(path)] = val
 }
 
 // onInsert tracks the newly inserted trie node. If it's already
 // in the delete set(resurrected node), then just wipe it from
 // the deletion set as it's untouched.
-func (t *tracer) onInsert(key []byte) {
+func (t *tracer) onInsert(path []byte) {
 	// Tracer isn't used right now, remove this check latter.
 	if t == nil {
 		return
 	}
-	// If the key is in the delete set, then it's a resurrected node, then wipe it.
-	if _, present := t.delete[string(key)]; present {
-		delete(t.delete, string(key))
+	// If the path is in the delete set, then it's a resurrected node, then wipe it.
+	if _, present := t.delete[string(path)]; present {
+		delete(t.delete, string(path))
 		return
 	}
-	t.insert[string(key)] = struct{}{}
+	t.insert[string(path)] = struct{}{}
 }
 
 // OnDelete tracks the newly deleted trie node. If it's already
 // in the addition set, then just wipe it from the addtion set
 // as it's untouched.
-func (t *tracer) onDelete(key []byte) {
+func (t *tracer) onDelete(path []byte) {
 	// Tracer isn't used right now, remove this check latter.
 	if t == nil {
 		return
 	}
-	if _, present := t.insert[string(key)]; present {
-		delete(t.insert, string(key))
+	if _, present := t.insert[string(path)]; present {
+		delete(t.insert, string(path))
 		return
 	}
-	t.delete[string(key)] = struct{}{}
+	t.delete[string(path)] = struct{}{}
 }
 
 // insertList returns the tracked inserted trie nodes in list format.
@@ -98,8 +98,8 @@ func (t *tracer) insertList() [][]byte {
 		return nil
 	}
 	var ret [][]byte
-	for key := range t.insert {
-		ret = append(ret, []byte(key))
+	for path := range t.insert {
+		ret = append(ret, []byte(path))
 	}
 	return ret
 }
@@ -111,19 +111,36 @@ func (t *tracer) deleteList() [][]byte {
 		return nil
 	}
 	var ret [][]byte
-	for key := range t.delete {
-		ret = append(ret, []byte(key))
+	for path := range t.delete {
+		ret = append(ret, []byte(path))
 	}
 	return ret
 }
 
+// prevList returns the tracked node blobs in list format.
+func (t *tracer) prevList() ([][]byte, [][]byte) {
+	// Tracer isn't used right now, remove this check later.
+	if t == nil {
+		return nil, nil
+	}
+	var (
+		paths [][]byte
+		blobs [][]byte
+	)
+	for path, blob := range t.origin {
+		paths = append(paths, []byte(path))
+		blobs = append(blobs, blob)
+	}
+	return paths, blobs
+}
+
 // getPrev returns the cached original value of the specified node.
-func (t *tracer) getPrev(key []byte) []byte {
+func (t *tracer) getPrev(path []byte) []byte {
 	// Don't panic on uninitialized tracer, it's possible in testing.
 	if t == nil {
 		return nil
 	}
-	return t.origin[string(key)]
+	return t.origin[string(path)]
 }
 
 // reset clears the content tracked by tracer.

--- a/trie/utils_test.go
+++ b/trie/utils_test.go
@@ -17,6 +17,7 @@
 package trie
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -70,7 +71,7 @@ func TestTrieTracer(t *testing.T) {
 	// Commit the changes
 	root, nodes, _ := trie.Commit(false)
 	db.Update(NewWithNodeSet(nodes))
-	trie, _ = New(common.Hash{}, root, db)
+	trie, _ = New(TrieID(root), db)
 	trie.tracer = newTracer()
 
 	// Delete all the elements, check deletion set
@@ -120,5 +121,125 @@ func TestTrieTracerNoop(t *testing.T) {
 	}
 	if len(trie.tracer.deleteList()) != 0 {
 		t.Fatalf("Unexpected deleted node tracked %d", len(trie.tracer.deleteList()))
+	}
+}
+func TestTrieTracePrevValue(t *testing.T) {
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	trie := NewEmpty(db)
+	trie.tracer = newTracer()
+
+	paths, blobs := trie.tracer.prevList()
+	if len(paths) != 0 || len(blobs) != 0 {
+		t.Fatalf("Nothing should be tracked")
+	}
+	// Insert a batch of entries, all the nodes should be marked as inserted
+	vals := []struct{ k, v string }{
+		{"do", "verb"},
+		{"ether", "wookiedoo"},
+		{"horse", "stallion"},
+		{"shaman", "horse"},
+		{"doge", "coin"},
+		{"dog", "puppy"},
+		{"somethingveryoddindeedthis is", "myothernodedata"},
+	}
+	for _, val := range vals {
+		trie.Update([]byte(val.k), []byte(val.v))
+	}
+	paths, blobs = trie.tracer.prevList()
+	if len(paths) != 0 || len(blobs) != 0 {
+		t.Fatalf("Nothing should be tracked")
+	}
+
+	// Commit the changes and re-create with new root
+	root, nodes, _ := trie.Commit(false)
+	if err := db.Update(NewWithNodeSet(nodes)); err != nil {
+		t.Fatal(err)
+	}
+	trie, _ = New(TrieID(root), db)
+	trie.tracer = newTracer()
+	trie.resolveAndTrack(root.Bytes(), nil)
+
+	// Load all nodes in trie
+	for _, val := range vals {
+		trie.TryGet([]byte(val.k))
+	}
+
+	// Ensure all nodes are tracked by tracer with correct prev-values
+	iter := trie.NodeIterator(nil)
+	seen := make(map[string][]byte)
+	for iter.Next(true) {
+		// Embedded nodes are ignored since they are not present in
+		// database.
+		if iter.Hash() == (common.Hash{}) {
+			continue
+		}
+		blob, err := trie.reader.nodeBlob(iter.Path(), iter.Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[string(iter.Path())] = common.CopyBytes(blob)
+	}
+
+	paths, blobs = trie.tracer.prevList()
+	if len(paths) != len(seen) || len(blobs) != len(seen) {
+		t.Fatalf("Unexpected tracked values")
+	}
+	for i, path := range paths {
+		blob := blobs[i]
+		prev, ok := seen[string(path)]
+		if !ok {
+			t.Fatalf("Missing node %v", path)
+		}
+		if !bytes.Equal(blob, prev) {
+			t.Fatalf("Unexpected value path: %v, want: %v, got: %v", path, prev, blob)
+		}
+	}
+
+	// Re-open the trie and iterate the trie, ensure nothing will be tracked.
+	// Iterator will not link any loaded nodes to trie.
+	trie, _ = New(TrieID(root), db)
+	trie.tracer = newTracer()
+
+	iter = trie.NodeIterator(nil)
+	for iter.Next(true) {
+	}
+	paths, blobs = trie.tracer.prevList()
+	if len(paths) != 0 || len(blobs) != 0 {
+		t.Fatalf("Nothing should be tracked")
+	}
+
+	// Re-open the trie and generate proof for entries, ensure nothing will
+	// be tracked. Prover will not link any loaded nodes to trie.
+	trie, _ = New(TrieID(root), db)
+	trie.tracer = newTracer()
+	for _, val := range vals {
+		trie.Prove([]byte(val.k), 0, rawdb.NewMemoryDatabase())
+	}
+	paths, blobs = trie.tracer.prevList()
+	if len(paths) != 0 || len(blobs) != 0 {
+		t.Fatalf("Nothing should be tracked")
+	}
+
+	// Delete entries from trie, ensure all previous values are correct.
+	trie, _ = New(TrieID(root), db)
+	trie.tracer = newTracer()
+	trie.resolveAndTrack(root.Bytes(), nil)
+
+	for _, val := range vals {
+		trie.TryDelete([]byte(val.k))
+	}
+	paths, blobs = trie.tracer.prevList()
+	if len(paths) != len(seen) || len(blobs) != len(seen) {
+		t.Fatalf("Unexpected tracked values")
+	}
+	for i, path := range paths {
+		blob := blobs[i]
+		prev, ok := seen[string(path)]
+		if !ok {
+			t.Fatalf("Missing node %v", path)
+		}
+		if !bytes.Equal(blob, prev) {
+			t.Fatalf("Unexpected value path: %v, want: %v, got: %v", path, prev, blob)
+		}
 	}
 }


### PR DESCRIPTION
Reference: https://github.com/ethereum/go-ethereum/pull/25757

Important changes:

- A storage trie is now identified by StateRoot (root of state/account trie), Owner, Root. The state/account trie is identified with StateRoot = Root. Those params are now needed for init a trie.

- Separate list of dirty nodes to updated nodes and deleted node. Also separate the updating/deleting operations.

- Track previous value of each node (before committing).

- Apply delete tracking logics to committer.

- Add `trie_reader.go`, interface for reaching database layer(s) from trie. Support backward compatibility: can use `hash_reader` for old hash based scheme, and can use `diffLayer` for path based scheme in the future PRs.

- Add metrics for tracking trie commits.