### PR TITLE
core/txpool/blobpool: avoid possible zero index panic (#30430)

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -555,7 +555,7 @@ func (p *BlobPool) recheck(addr common.Address, inclusions map[common.Hash]uint6
 			ids    []uint64
 			nonces []uint64
 		)
-		for txs[0].nonce < next {
+		for len(txs) > 0 && txs[0].nonce < next {
 			ids = append(ids, txs[0].id)
 			nonces = append(nonces, txs[0].nonce)
 


### PR DESCRIPTION
commit https://github.com/ethereum/go-ethereum/commit/0dd7e82c0aef3c27303b4a7b30016790dda949d4.

This situation(`len(txs) == 0`) rarely occurs, but if it does, it will panic.