### PR TITLE
eth/protocols/snap: fix batch writer when resuming an aborted sync (#…

### DIFF
--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -714,6 +714,8 @@ func (s *Syncer) loadSyncStatus() {
 			}
 			s.tasks = progress.Tasks
 			for _, task := range s.tasks {
+				task := task // closure for task.genBatch in the stacktrie writer callback
+
 				task.genBatch = ethdb.HookedBatch{
 					Batch: s.db.NewBatch(),
 					OnPut: func(key []byte, value []byte) {
@@ -726,6 +728,8 @@ func (s *Syncer) loadSyncStatus() {
 
 				for accountHash, subtasks := range task.SubTasks {
 					for _, subtask := range subtasks {
+						subtask := subtask // closure for subtask.genBatch in the stacktrie writer callback
+
 						subtask.genBatch = ethdb.HookedBatch{
 							Batch: s.db.NewBatch(),
 							OnPut: func(key []byte, value []byte) {


### PR DESCRIPTION
https://go.dev/blog/loopvar-preview, in path-base-implementing, we will use the callback function when generating a trie for per task which triggers this issue 
```
	task.genTrie = trie.NewStackTrie(func(owner common.Hash, path []byte, hash common.Hash, val []byte) {
					rawdb.WriteTrieNode(task.genBatch, owner, path, hash, val, s.scheme)
				})
```