### PR TITLE
trie, core: track state changes in statedb

### DIFF
--- a/core/state/dump.go
+++ b/core/state/dump.go
@@ -162,7 +162,7 @@ func (s *StateDB) DumpToCollector(c DumpCollector, conf *DumpConfig) (nextKey []
 			account.SecureKey = it.Key
 		}
 		addr := common.BytesToAddress(addrBytes)
-		obj := newObject(s, addr, data)
+		obj := newObject(s, addr, &data)
 		if !conf.SkipCode {
 			account.Code = obj.Code(s.db)
 		}

--- a/core/state/metrics.go
+++ b/core/state/metrics.go
@@ -27,4 +27,11 @@ var (
 	storageTriesUpdatedMeter = metrics.NewRegisteredMeter("state/update/storagenodes", nil)
 	accountTrieDeletedMeter  = metrics.NewRegisteredMeter("state/delete/accountnodes", nil)
 	storageTriesDeletedMeter = metrics.NewRegisteredMeter("state/delete/storagenodes", nil)
+
+	slotDeletionMaxCount = metrics.NewRegisteredGauge("state/delete/storage/max/slot", nil)
+	slotDeletionMaxSize  = metrics.NewRegisteredGauge("state/delete/storage/max/size", nil)
+	slotDeletionTimer    = metrics.NewRegisteredResettingTimer("state/delete/storage/timer", nil)
+	slotDeletionCount    = metrics.NewRegisteredMeter("state/delete/storage/slot", nil)
+	slotDeletionSize     = metrics.NewRegisteredMeter("state/delete/storage/size", nil)
+	slotDeletionSkip     = metrics.NewRegisteredGauge("state/delete/storage/skip", nil)
 )

--- a/core/state/snapshot/generate.go
+++ b/core/state/snapshot/generate.go
@@ -440,7 +440,7 @@ func (dl *diskLayer) generateRange(trieID *trie.ID, prefix []byte, kind string, 
 		}
 		root, nodes, _ := snapTrie.Commit(false)
 		if nodes != nil {
-			snapTrieDb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+			snapTrieDb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 		}
 		snapTrieDb.Commit(root, false)
 	}

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -198,7 +198,7 @@ func (t *testHelper) Commit() common.Hash {
 	if nodes != nil {
 		t.nodes.Merge(nodes)
 	}
-	t.triedb.Update(root, types.EmptyRootHash, t.nodes)
+	t.triedb.Update(root, types.EmptyRootHash, t.nodes, nil)
 	t.triedb.Commit(root, false)
 	return root
 }

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -28,21 +28,21 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-type stateTest struct {
+type stateEnv struct {
 	db    ethdb.Database
 	state *StateDB
 }
 
-func newStateTest() *stateTest {
+func newStateEnv() *stateEnv {
 	db := rawdb.NewMemoryDatabase()
 	sdb, _ := New(common.Hash{}, NewDatabase(db), nil)
-	return &stateTest{db: db, state: sdb}
+	return &stateEnv{db: db, state: sdb}
 }
 
 func TestDump(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
 	sdb, _ := New(common.Hash{}, NewDatabaseWithConfig(db, &trie.Config{Preimages: true}), nil)
-	s := &stateTest{db: db, state: sdb}
+	s := &stateEnv{db: db, state: sdb}
 
 	// generate a few entries
 	obj1 := s.state.GetOrNewStateObject(common.BytesToAddress([]byte{0x01}))
@@ -92,7 +92,7 @@ func TestDump(t *testing.T) {
 }
 
 func TestNull(t *testing.T) {
-	s := newStateTest()
+	s := newStateEnv()
 	address := common.HexToAddress("0x823140710bf13990e4500136726d8b55")
 	s.state.CreateAccount(address)
 	//value := common.FromHex("0x823140710bf13990e4500136726d8b55")
@@ -114,7 +114,7 @@ func TestSnapshot(t *testing.T) {
 	var storageaddr common.Hash
 	data1 := common.BytesToHash([]byte{42})
 	data2 := common.BytesToHash([]byte{43})
-	s := newStateTest()
+	s := newStateEnv()
 
 	// snapshot the genesis state
 	genesis := s.state.Snapshot()
@@ -145,7 +145,7 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestSnapshotEmpty(t *testing.T) {
-	s := newStateTest()
+	s := newStateEnv()
 	s.state.RevertToSnapshot(s.state.Snapshot())
 }
 

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -1,0 +1,362 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package state
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/quick"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/trie/triestate"
+)
+
+// A stateTest checks that the state changes are correctly captured. Instances
+// of this test with pseudorandom content are created by Generate.
+//
+// The test works as follows:
+//
+// A list of states are created by applying actions. The state changes between
+// each state instance are tracked and be verified.
+type stateTest struct {
+	addrs   []common.Address // all account addresses
+	actions [][]testAction   // modifications to the state, grouped by block
+	chunk   int              // The number of actions per chunk
+	err     error            // failure details are reported through this field
+}
+
+// newStateTestAction creates a random action that changes state.
+func newStateTestAction(addr common.Address, r *rand.Rand, index int) testAction {
+	actions := []testAction{
+		{
+			name: "SetBalance",
+			fn: func(a testAction, s *StateDB) {
+				s.SetBalance(addr, big.NewInt(a.args[0]))
+			},
+			args: make([]int64, 1),
+		},
+		{
+			name: "SetNonce",
+			fn: func(a testAction, s *StateDB) {
+				s.SetNonce(addr, uint64(a.args[0]))
+			},
+			args: make([]int64, 1),
+		},
+		{
+			name: "SetState",
+			fn: func(a testAction, s *StateDB) {
+				var key, val common.Hash
+				binary.BigEndian.PutUint16(key[:], uint16(a.args[0]))
+				binary.BigEndian.PutUint16(val[:], uint16(a.args[1]))
+				s.SetState(addr, key, val)
+			},
+			args: make([]int64, 2),
+		},
+		{
+			name: "SetCode",
+			fn: func(a testAction, s *StateDB) {
+				code := make([]byte, 16)
+				binary.BigEndian.PutUint64(code, uint64(a.args[0]))
+				binary.BigEndian.PutUint64(code[8:], uint64(a.args[1]))
+				s.SetCode(addr, code)
+			},
+			args: make([]int64, 2),
+		},
+		{
+			name: "CreateAccount",
+			fn: func(a testAction, s *StateDB) {
+				s.CreateAccount(addr)
+			},
+		},
+		{
+			name: "Suicide",
+			fn: func(a testAction, s *StateDB) {
+				s.SelfDestruct(addr)
+			},
+		},
+	}
+	var nonRandom = index != -1
+	if index == -1 {
+		index = r.Intn(len(actions))
+	}
+	action := actions[index]
+	var names []string
+	if !action.noAddr {
+		names = append(names, addr.Hex())
+	}
+	for i := range action.args {
+		if nonRandom {
+			action.args[i] = rand.Int63n(10000) + 1 // set balance to non-zero
+		} else {
+			action.args[i] = rand.Int63n(10000)
+		}
+		names = append(names, fmt.Sprint(action.args[i]))
+	}
+	action.name += " " + strings.Join(names, ", ")
+	return action
+}
+
+// Generate returns a new snapshot test of the given size. All randomness is
+// derived from r.
+func (*stateTest) Generate(r *rand.Rand, size int) reflect.Value {
+	addrs := make([]common.Address, 5)
+	for i := range addrs {
+		addrs[i][0] = byte(i)
+	}
+	actions := make([][]testAction, rand.Intn(5)+1)
+
+	for i := 0; i < len(actions); i++ {
+		actions[i] = make([]testAction, size)
+		for j := range actions[i] {
+			if j == 0 {
+				// Always include a set balance action to make sure
+				// the state changes are not empty.
+				actions[i][j] = newStateTestAction(common.HexToAddress("0xdeadbeef"), r, 0)
+				continue
+			}
+			actions[i][j] = newStateTestAction(addrs[r.Intn(len(addrs))], r, -1)
+		}
+	}
+	chunk := int(math.Sqrt(float64(size)))
+	if size > 0 && chunk == 0 {
+		chunk = 1
+	}
+	return reflect.ValueOf(&stateTest{
+		addrs:   addrs,
+		actions: actions,
+		chunk:   chunk,
+	})
+}
+
+func (test *stateTest) String() string {
+	out := new(bytes.Buffer)
+	for i, actions := range test.actions {
+		fmt.Fprintf(out, "---- block %d ----\n", i)
+		for j, action := range actions {
+			if j%test.chunk == 0 {
+				fmt.Fprintf(out, "---- transaction %d ----\n", j/test.chunk)
+			}
+			fmt.Fprintf(out, "%4d: %s\n", j%test.chunk, action.name)
+		}
+	}
+	return out.String()
+}
+
+func (test *stateTest) run() bool {
+	var (
+		roots       []common.Hash
+		accountList []map[common.Hash][]byte
+		storageList []map[common.Hash]map[common.Hash][]byte
+		onCommit    = func(states *triestate.Set) {
+			accountList = append(accountList, copySet(states.Accounts))
+			storageList = append(storageList, copy2DSet(states.Storages))
+		}
+		disk      = rawdb.NewMemoryDatabase()
+		tdb       = trie.NewDatabaseWithConfig(disk, &trie.Config{OnCommit: onCommit})
+		sdb       = NewDatabaseWithNodeDB(disk, tdb)
+		byzantium = rand.Intn(2) == 0
+	)
+	for i, actions := range test.actions {
+		root := types.EmptyRootHash
+		if i != 0 {
+			root = roots[len(roots)-1]
+		}
+		state, err := New(root, sdb, nil)
+		if err != nil {
+			panic(err)
+		}
+		for i, action := range actions {
+			if i%test.chunk == 0 && i != 0 {
+				if byzantium {
+					state.Finalise(true) // call finalise at the transaction boundary
+				} else {
+					state.IntermediateRoot(true) // call intermediateRoot at the transaction boundary
+				}
+			}
+			action.fn(action, state)
+		}
+		if byzantium {
+			state.Finalise(true) // call finalise at the transaction boundary
+		} else {
+			state.IntermediateRoot(true) // call intermediateRoot at the transaction boundary
+		}
+		nroot, err := state.Commit(true) // call commit at the block boundary
+		if err != nil {
+			panic(err)
+		}
+		if nroot == root {
+			return true // filter out non-change state transition
+		}
+		roots = append(roots, nroot)
+	}
+	for i := 0; i < len(test.actions); i++ {
+		root := types.EmptyRootHash
+		if i != 0 {
+			root = roots[i-1]
+		}
+		test.err = test.verify(root, roots[i], tdb, accountList[i], storageList[i])
+		if test.err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// verifyAccountCreation this function is called once the state diff says that
+// specific account was not present. A serial of checks will be performed to
+// ensure the state diff is correct, includes:
+//
+// - the account was indeed not present in trie
+// - the account is present in new trie, nil->nil is regarded as invalid
+// - the slots transition is correct
+func (test *stateTest) verifyAccountCreation(next common.Hash, db *trie.Database, otr, ntr *trie.Trie, addrHash common.Hash, slots map[common.Hash][]byte) error {
+	// Verify account change
+	oBlob := otr.Get(addrHash.Bytes())
+	nBlob := ntr.Get(addrHash.Bytes())
+	if len(oBlob) != 0 {
+		return fmt.Errorf("unexpected account in old trie, %x", addrHash)
+	}
+	if len(nBlob) == 0 {
+		return fmt.Errorf("missing account in new trie, %x", addrHash)
+	}
+
+	// Verify storage changes
+	var nAcct types.StateAccount
+	if err := rlp.DecodeBytes(nBlob, &nAcct); err != nil {
+		return err
+	}
+	// Account has no slot, empty slot set is expected
+	if nAcct.Root == types.EmptyRootHash {
+		if len(slots) != 0 {
+			return fmt.Errorf("unexpected slot changes %x", addrHash)
+		}
+		return nil
+	}
+	// Account has slots, ensure all new slots are contained
+	st, err := trie.New(trie.StorageTrieID(next, addrHash, nAcct.Root), db)
+	if err != nil {
+		return err
+	}
+	for key, val := range slots {
+		st.Update(key.Bytes(), val)
+	}
+	if st.Hash() != types.EmptyRootHash {
+		return errors.New("invalid slot changes")
+	}
+	return nil
+}
+
+// verifyAccountUpdate this function is called once the state diff says that
+// specific account was present. A serial of checks will be performed to
+// ensure the state diff is correct, includes:
+//
+// - the account was indeed present in trie
+// - the account in old trie matches the provided value
+// - the slots transition is correct
+func (test *stateTest) verifyAccountUpdate(next common.Hash, db *trie.Database, otr, ntr *trie.Trie, addrHash common.Hash, origin []byte, slots map[common.Hash][]byte) error {
+	// Verify account change
+	oBlob := otr.Get(addrHash.Bytes())
+	nBlob := ntr.Get(addrHash.Bytes())
+	if len(oBlob) == 0 {
+		return fmt.Errorf("missing account in old trie, %x", addrHash)
+	}
+	full, err := snapshot.FullAccountRLP(origin)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(full, oBlob) {
+		return fmt.Errorf("account value is not matched, %x", addrHash)
+	}
+
+	// Decode accounts
+	var (
+		oAcct types.StateAccount
+		nAcct types.StateAccount
+		nRoot common.Hash
+	)
+	if err := rlp.DecodeBytes(oBlob, &oAcct); err != nil {
+		return err
+	}
+	if len(nBlob) == 0 {
+		nRoot = types.EmptyRootHash
+	} else {
+		if err := rlp.DecodeBytes(nBlob, &nAcct); err != nil {
+			return err
+		}
+		nRoot = nAcct.Root
+	}
+
+	// Verify storage
+	st, err := trie.New(trie.StorageTrieID(next, addrHash, nRoot), db)
+	if err != nil {
+		return err
+	}
+	for key, val := range slots {
+		st.Update(key.Bytes(), val)
+	}
+	if st.Hash() != oAcct.Root {
+		return errors.New("invalid slot changes")
+	}
+	return nil
+}
+
+func (test *stateTest) verify(root common.Hash, next common.Hash, db *trie.Database, accountsOrigin map[common.Hash][]byte, storagesOrigin map[common.Hash]map[common.Hash][]byte) error {
+	otr, err := trie.New(trie.StateTrieID(root), db)
+	if err != nil {
+		return err
+	}
+	ntr, err := trie.New(trie.StateTrieID(next), db)
+	if err != nil {
+		return err
+	}
+	for addrHash, account := range accountsOrigin {
+		var err error
+		if len(account) == 0 {
+			err = test.verifyAccountCreation(next, db, otr, ntr, addrHash, storagesOrigin[addrHash])
+		} else {
+			err = test.verifyAccountUpdate(next, db, otr, ntr, addrHash, accountsOrigin[addrHash], storagesOrigin[addrHash])
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestStateChanges(t *testing.T) {
+	config := &quick.Config{MaxCount: 1000}
+	err := quick.Check((*stateTest).run, config)
+	if cerr, ok := err.(*quick.CheckError); ok {
+		test := cerr.In[0].(*stateTest)
+		t.Errorf("%v:\n%s", test.err, test)
+	} else if err != nil {
+		t.Error(err)
+	}
+}

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -481,7 +481,7 @@ func (test *snapshotTest) checkEqual(state, checkstate *StateDB) error {
 }
 
 func TestTouchDelete(t *testing.T) {
-	s := newStateTest()
+	s := newStateEnv()
 	s.state.GetOrNewStateObject(common.Address{})
 	root, _ := s.state.Commit(false)
 	s.state, _ = New(root, s.state.db, s.state.snaps)

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -20,7 +20,10 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
+
+var emptyCodeHash = crypto.Keccak256(nil)
 
 // StateAccount is the Ethereum consensus representation of accounts.
 // These objects are stored in the main account trie.
@@ -29,6 +32,29 @@ type StateAccount struct {
 	Balance  *big.Int
 	Root     common.Hash // merkle root of the storage trie
 	CodeHash []byte
+}
+
+// NewEmptyStateAccount constructs an empty state account.
+func NewEmptyStateAccount() *StateAccount {
+	return &StateAccount{
+		Balance:  new(big.Int),
+		Root:     EmptyRootHash,
+		CodeHash: emptyCodeHash,
+	}
+}
+
+// Copy returns a deep-copied state account object.
+func (acct *StateAccount) Copy() *StateAccount {
+	var balance *big.Int
+	if acct.Balance != nil {
+		balance = new(big.Int).Set(acct.Balance)
+	}
+	return &StateAccount{
+		Nonce:    acct.Nonce,
+		Balance:  balance,
+		Root:     acct.Root,
+		CodeHash: common.CopyBytes(acct.CodeHash),
+	}
 }
 
 type DirtyStateAccount struct {

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -1382,7 +1382,7 @@ func makeAccountTrieNoStorage(n int) (string, *trie.Trie, entrySlice) {
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
 	root, nodes, _ := accTrie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
 	return db.Scheme(), accTrie, entries
@@ -1443,7 +1443,7 @@ func makeBoundaryAccountTrie(n int) (string, *trie.Trie, entrySlice) {
 	// Commit the state changes into db and re-create the trie
 	// for accessing later.
 	root, nodes, _ := accTrie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
 	return db.Scheme(), accTrie, entries
@@ -1491,7 +1491,7 @@ func makeAccountTrieWithStorageWithUniqueStorage(accounts, slots int, code bool)
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
-	db.Update(root, types.EmptyRootHash, nodes)
+	db.Update(root, types.EmptyRootHash, nodes, nil)
 
 	// Re-create tries with new root
 	accTrie, _ = trie.New(trie.StateTrieID(root), db)
@@ -1553,7 +1553,7 @@ func makeAccountTrieWithStorage(accounts, slots int, code, boundary bool) (strin
 	nodes.Merge(set)
 
 	// Commit gathered dirty nodes into database
-	db.Update(root, types.EmptyRootHash, nodes)
+	db.Update(root, types.EmptyRootHash, nodes, nil)
 
 	// Re-create tries with new root
 	accTrie, err := trie.New(trie.StateTrieID(root), db)

--- a/light/postprocess.go
+++ b/light/postprocess.go
@@ -226,7 +226,7 @@ func (c *ChtIndexerBackend) Commit() error {
 	}
 	// Commite trie changes into trie database in case it's not nil.
 	if nodes != nil {
-		if err := c.triedb.Update(root, c.originRoot, trienode.NewWithNodeSet(nodes)); err != nil {
+		if err := c.triedb.Update(root, c.originRoot, trienode.NewWithNodeSet(nodes), nil); err != nil {
 			return err
 		}
 	}
@@ -474,7 +474,7 @@ func (b *BloomTrieIndexerBackend) Commit() error {
 	}
 
 	if nodes != nil {
-		if err := b.triedb.Update(root, b.originRoot, trienode.NewWithNodeSet(nodes)); err != nil {
+		if err := b.triedb.Update(root, b.originRoot, trienode.NewWithNodeSet(nodes), nil); err != nil {
 			return err
 		}
 	}

--- a/tests/fuzzers/stacktrie/trie_fuzzer.go
+++ b/tests/fuzzers/stacktrie/trie_fuzzer.go
@@ -189,7 +189,7 @@ func (f *fuzzer) fuzz() int {
 		panic(err)
 	}
 	if nodes != nil {
-		dbA.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+		dbA.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	}
 	// Flush memdb -> disk (sponge)
 	dbA.Commit(rootA, false)

--- a/tests/fuzzers/trie/trie-fuzzer.go
+++ b/tests/fuzzers/trie/trie-fuzzer.go
@@ -173,7 +173,7 @@ func runRandTest(rt randTest) error {
 				return err
 			}
 			if nodes != nil {
-				if err := triedb.Update(hash, origin, trienode.NewWithNodeSet(nodes)); err != nil {
+				if err := triedb.Update(hash, origin, trienode.NewWithNodeSet(nodes), nil); err != nil {
 					return err
 				}
 			}

--- a/trie/database.go
+++ b/trie/database.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/trie/triedb/hashdb"
 	"github.com/ethereum/go-ethereum/trie/trienode"
+	"github.com/ethereum/go-ethereum/trie/triestate"
 )
 
 // Config defines all necessary options for database.
@@ -34,6 +35,9 @@ type Config struct {
 	Cache     int    // Memory allowance (MB) to use for caching trie nodes in memory
 	Journal   string // Journal of clean cache to survive node restarts
 	Preimages bool   // Flag whether the preimage of trie key is recorded
+
+	// Testing hooks
+	OnCommit func(states *triestate.Set) // Hook invoked when commit is performed
 }
 
 // backend defines the methods needed to access/update trie nodes in different
@@ -130,7 +134,10 @@ func (db *Database) Reader(blockRoot common.Hash) Reader {
 // given set in order to update state from the specified parent to the specified
 // root. The held pre-images accumulated up to this point will be flushed in case
 // the size exceeds the threshold.
-func (db *Database) Update(root common.Hash, parent common.Hash, nodes *trienode.MergedNodeSet) error {
+func (db *Database) Update(root common.Hash, parent common.Hash, nodes *trienode.MergedNodeSet, states *triestate.Set) error {
+	if db.config != nil && db.config.OnCommit != nil {
+		db.config.OnCommit(states)
+	}
 	if db.preimages != nil {
 		db.preimages.commit(false)
 	}

--- a/trie/iterator_test.go
+++ b/trie/iterator_test.go
@@ -66,7 +66,7 @@ func TestIterator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to commit trie %v", err)
 	}
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	trie, _ = New(TrieID(root), db)
 	found := make(map[string]string)
 	it := NewIterator(trie.NodeIterator(nil))
@@ -249,7 +249,7 @@ func TestDifferenceIterator(t *testing.T) {
 		triea.Update([]byte(val.k), []byte(val.v))
 	}
 	rootA, nodesA, _ := triea.Commit(false)
-	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA))
+	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA), nil)
 	triea, _ = New(TrieID(rootA), dba)
 
 	dbb := NewDatabase(rawdb.NewMemoryDatabase())
@@ -258,7 +258,7 @@ func TestDifferenceIterator(t *testing.T) {
 		trieb.Update([]byte(val.k), []byte(val.v))
 	}
 	rootB, nodesB, _ := trieb.Commit(false)
-	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB))
+	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB), nil)
 	trieb, _ = New(TrieID(rootB), dbb)
 
 	found := make(map[string]string)
@@ -291,7 +291,7 @@ func TestUnionIterator(t *testing.T) {
 		triea.Update([]byte(val.k), []byte(val.v))
 	}
 	rootA, nodesA, _ := triea.Commit(false)
-	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA))
+	dba.Update(rootA, types.EmptyRootHash, trienode.NewWithNodeSet(nodesA), nil)
 	triea, _ = New(TrieID(rootA), dba)
 
 	dbb := NewDatabase(rawdb.NewMemoryDatabase())
@@ -300,7 +300,7 @@ func TestUnionIterator(t *testing.T) {
 		trieb.Update([]byte(val.k), []byte(val.v))
 	}
 	rootB, nodesB, _ := trieb.Commit(false)
-	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB))
+	dbb.Update(rootB, types.EmptyRootHash, trienode.NewWithNodeSet(nodesB), nil)
 	trieb, _ = New(TrieID(rootB), dbb)
 
 	di, _ := NewUnionIterator([]NodeIterator{triea.NodeIterator(nil), trieb.NodeIterator(nil)})
@@ -362,7 +362,7 @@ func testIteratorContinueAfterError(t *testing.T, memonly bool, scheme string) {
 		tr.Update([]byte(val.k), []byte(val.v))
 	}
 	root, nodes, _ := tr.Commit(false)
-	tdb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	tdb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	if !memonly {
 		tdb.Commit(root, false)
 	}
@@ -478,7 +478,7 @@ func testIteratorContinueAfterSeekError(t *testing.T, memonly bool, scheme strin
 			break
 		}
 	}
-	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	if !memonly {
 		triedb.Commit(root, false)
 	}
@@ -599,7 +599,7 @@ func makeLargeTestTrie() (*Database, *SecureTrie, *loggingDb) {
 		trie.Update(key, val)
 	}
 	root, nodes, _ := trie.Commit(false)
-	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	// Return the generated trie
 	return triedb, trie, logDb
 }
@@ -639,7 +639,7 @@ func testIteratorNodeBlob(t *testing.T, scheme string) {
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
 	root, nodes, _ := trie.Commit(false)
-	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	triedb.Commit(root, false)
 
 	var found = make(map[common.Hash][]byte)

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -61,7 +61,7 @@ func makeTestTrie(scheme string) (ethdb.Database, *Database, *SecureTrie, map[st
 	if err != nil {
 		panic(fmt.Errorf("failed to commit trie: %v", err))
 	}
-	if err := triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes)); err != nil {
+	if err := triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(fmt.Errorf("failed to commit db %v", err))
 	}
 	if err := triedb.Commit(root, false); err != nil {
@@ -713,7 +713,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		diff[string(key)] = val
 	}
 	root, nodes, _ := srcTrie.Commit(false)
-	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes)); err != nil {
+	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(err)
 	}
 	if err := srcDb.Commit(root, false); err != nil {
@@ -738,7 +738,7 @@ func testSyncMovingTarget(t *testing.T, scheme string) {
 		reverted[k] = val
 	}
 	root, nodes, _ = srcTrie.Commit(false)
-	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes)); err != nil {
+	if err := srcDb.Update(root, preRoot, trienode.NewWithNodeSet(nodes), nil); err != nil {
 		panic(err)
 	}
 	if err := srcDb.Commit(root, false); err != nil {

--- a/trie/tracer_test.go
+++ b/trie/tracer_test.go
@@ -71,7 +71,7 @@ func testTrieTracer(t *testing.T, vals []struct{ k, v string }) {
 	insertSet := copySet(trie.tracer.inserts) // copy before commit
 	deleteSet := copySet(trie.tracer.deletes) // copy before commit
 	root, nodes, _ := trie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 
 	seen := setKeys(iterNodes(db, root))
 	if !compareSet(insertSet, seen) {
@@ -137,7 +137,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
 	root, nodes, _ := trie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
 	if err := verifyAccessList(orig, trie, nodes); err != nil {
@@ -152,7 +152,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		trie.Update([]byte(val.k), randBytes(32))
 	}
 	root, nodes, _ = trie.Commit(false)
-	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
+	db.Update(root, parent, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
 	if err := verifyAccessList(orig, trie, nodes); err != nil {
@@ -170,7 +170,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		trie.Update(key, randBytes(32))
 	}
 	root, nodes, _ = trie.Commit(false)
-	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
+	db.Update(root, parent, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
 	if err := verifyAccessList(orig, trie, nodes); err != nil {
@@ -185,7 +185,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		trie.Update([]byte(key), nil)
 	}
 	root, nodes, _ = trie.Commit(false)
-	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
+	db.Update(root, parent, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
 	if err := verifyAccessList(orig, trie, nodes); err != nil {
@@ -200,7 +200,7 @@ func testAccessList(t *testing.T, vals []struct{ k, v string }) {
 		trie.Update([]byte(val.k), nil)
 	}
 	root, nodes, _ = trie.Commit(false)
-	db.Update(root, parent, trienode.NewWithNodeSet(nodes))
+	db.Update(root, parent, trienode.NewWithNodeSet(nodes), nil)
 
 	trie, _ = New(TrieID(root), db)
 	if err := verifyAccessList(orig, trie, nodes); err != nil {
@@ -219,7 +219,7 @@ func TestAccessListLeak(t *testing.T) {
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
 	root, nodes, _ := trie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 
 	var cases = []struct {
 		op func(tr *Trie)
@@ -269,7 +269,7 @@ func TestTinyTree(t *testing.T) {
 		trie.Update([]byte(val.k), randBytes(32))
 	}
 	root, set, _ := trie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(set))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(set), nil)
 
 	parent := root
 	trie, _ = New(TrieID(root), db)
@@ -278,7 +278,7 @@ func TestTinyTree(t *testing.T) {
 		trie.Update([]byte(val.k), []byte(val.v))
 	}
 	root, set, _ = trie.Commit(false)
-	db.Update(root, parent, trienode.NewWithNodeSet(set))
+	db.Update(root, parent, trienode.NewWithNodeSet(set), nil)
 
 	trie, _ = New(TrieID(root), db)
 	if err := verifyAccessList(orig, trie, set); err != nil {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -96,7 +96,7 @@ func testMissingNode(t *testing.T, memonly bool, scheme string) {
 	updateString(trie, "120000", "qwerqwerqwerqwerqwerqwerqwerqwer")
 	updateString(trie, "123456", "asdfasdfasdfasdfasdfasdfasdfasdf")
 	root, nodes, _ := trie.Commit(false)
-	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	if !memonly {
 		triedb.Commit(root, true)
 	}
@@ -214,7 +214,7 @@ func TestGet(t *testing.T) {
 			return
 		}
 		root, nodes, _ := trie.Commit(false)
-		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 		trie, _ = New(TrieID(root), db)
 	}
 }
@@ -289,7 +289,7 @@ func TestReplication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit error: %v", err)
 	}
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 
 	// create a new trie on top of the database and check that lookups work.
 	trie2, err := New(TrieID(root), db)
@@ -310,7 +310,7 @@ func TestReplication(t *testing.T) {
 	}
 	// recreate the trie after commit
 	if nodes != nil {
-		db.Update(hash, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+		db.Update(hash, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	}
 	trie2, err = New(TrieID(hash), db)
 	if err != nil {
@@ -527,7 +527,7 @@ func runRandTest(rt randTest) bool {
 				return false
 			}
 			if nodes != nil {
-				triedb.Update(root, origin, trienode.NewWithNodeSet(nodes))
+				triedb.Update(root, origin, trienode.NewWithNodeSet(nodes), nil)
 			}
 			newtr, err := New(TrieID(root), triedb)
 			if err != nil {
@@ -821,7 +821,7 @@ func TestCommitSequence(t *testing.T) {
 		}
 		// Flush trie -> database
 		root, nodes, _ := trie.Commit(false)
-		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
 		if got, exp := s.sponge.Sum(nil), tc.expWriteSeqHash; !bytes.Equal(got, exp) {
@@ -862,7 +862,7 @@ func TestCommitSequenceRandomBlobs(t *testing.T) {
 		}
 		// Flush trie -> database
 		root, nodes, _ := trie.Commit(false)
-		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
 		if got, exp := s.sponge.Sum(nil), tc.expWriteSeqHash; !bytes.Equal(got, exp) {
@@ -902,7 +902,7 @@ func TestCommitSequenceStackTrie(t *testing.T) {
 		}
 		// Flush trie -> database
 		root, nodes, _ := trie.Commit(false)
-		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+		db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 		// Flush memdb -> disk (sponge)
 		db.Commit(root, false)
 		// And flush stacktrie -> disk
@@ -951,7 +951,7 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	stTrie.TryUpdate(key, []byte{0x1})
 	// Flush trie -> database
 	root, nodes, _ := trie.Commit(false)
-	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	db.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	// Flush memdb -> disk (sponge)
 	db.Commit(root, false)
 	// And flush stacktrie -> disk
@@ -1123,7 +1123,7 @@ func benchmarkDerefRootFixedSize(b *testing.B, addresses [][20]byte, accounts []
 	}
 	h := trie.Hash()
 	root, nodes, _ := trie.Commit(false)
-	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes))
+	triedb.Update(root, types.EmptyRootHash, trienode.NewWithNodeSet(nodes), nil)
 	b.StartTimer()
 	triedb.Dereference(h)
 	b.StopTimer()

--- a/trie/triestate/state.go
+++ b/trie/triestate/state.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package triestate
+
+import "github.com/ethereum/go-ethereum/common"
+
+// Set represents a collection of mutated states during a state transition.
+// The value refers to the original content of state before the transition
+// is made. Nil means that the state was not present previously.
+type Set struct {
+	Accounts   map[common.Hash][]byte                 // Mutated account set, nil means the account was not present
+	Storages   map[common.Hash]map[common.Hash][]byte // Mutated storage set, nil means the slot was not present
+	Incomplete map[common.Hash]struct{}               // Indicator whether the storage slot is incomplete due to large deletion
+}


### PR DESCRIPTION
Reference: https://github.com/ethereum/go-ethereum/pull/27349

This PR is for tracking state changes in stateDB. The tracked changes will later be used in PBSS to generate the history data.

Changes:
- trie/triestate/state.go: create struct `Set` representing the state changes that will be tracked. There will be pairs of values before and after being changed.
- trie/database_wrap: change name to database; `database.Update()` now take in the tracked state changes, which will later be used in PBSS.
- core/state_object: `stateObject` represents an account being updated. Now, `origin`, which represents the account before changes, is added for keeping track of changes. This `origin` will be updated to the current account only after committing.
- core/statedb: 
- - accounts/storages origins and changes are always tracked now (previously they are tracked only if snap is enabled).
- - `stateObjectsDestruct` that store destructed objects will be stored along with their previous values.
- - Add `handleDestruction` to track the destructed objects
- - All the changes (updates and deletes) will be stored to `Set` and passed to `s.db.TrieDB().Update()` when committing.