### PR TITLE
v2/consortium_test: fix: do not insert inserted blocks

### DIFF
--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -2219,7 +2219,7 @@ func testSystemTransactionOrder(t *testing.T, scheme string) {
 }
 
 func TestIsPeriodBlock(t *testing.T) {
-	//testIsPeriodBlock(t, rawdb.PathScheme)
+	testIsPeriodBlock(t, rawdb.PathScheme)
 	testIsPeriodBlock(t, rawdb.HashScheme)
 }
 
@@ -2292,17 +2292,25 @@ func testIsPeriodBlock(t *testing.T, scheme string) {
 	if c.IsPeriodBlock(chain, header, nil) {
 		t.Error("wrong period block")
 	}
-
+	newBs := make(types.Blocks, 0)
 	for i := 0; i < 210; i++ {
 		callback := func(i int, bg *core.BlockGen) {
 			if i == 0 {
 				bg.OffsetTime(int64(dayInSeconds))
 			}
 		}
-		block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
-		bs = append(bs, block...)
+		if i == 0 {
+			block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
+			newBs = append(newBs, block...)
+			bs = append(bs, block...)
+		} else {
+			block, _ := core.GenerateChain(&chainConfig, newBs[len(newBs)-1], ethash.NewFaker(), db, 1, callback, true)
+			newBs = append(newBs, block...)
+			bs = append(bs, block...)
+		}
 	}
-	if _, err := chain.InsertChain(bs[:], nil); err != nil {
+	// only insert newly generated blocks
+	if _, err := chain.InsertChain(newBs[:], nil); err != nil {
 		panic(err)
 	}
 
@@ -2330,8 +2338,7 @@ Will disable this test firstly for further investigation.
 */
 func TestIsTrippEffective(t *testing.T) {
 	testIsTrippEffective(t, rawdb.HashScheme)
-	// testIsTrippEffective(t, rawdb.PathScheme)
-
+	testIsTrippEffective(t, rawdb.PathScheme)
 }
 
 func testIsTrippEffective(t *testing.T, scheme string) {
@@ -2408,16 +2415,25 @@ func testIsTrippEffective(t *testing.T, scheme string) {
 		t.Error("fail test Tripp effective")
 	}
 
+	newBs := make(types.Blocks, 0)
 	for i := 0; i < 210; i++ {
 		callback := func(i int, bg *core.BlockGen) {
 			if i == 0 {
 				bg.OffsetTime(int64(dayInSeconds))
 			}
 		}
-		block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
-		bs = append(bs, block...)
+		if i == 0 {
+			block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
+			newBs = append(newBs, block...)
+			bs = append(bs, block...)
+		} else {
+			block, _ := core.GenerateChain(&chainConfig, newBs[len(newBs)-1], ethash.NewFaker(), db, 1, callback, true)
+			newBs = append(newBs, block...)
+			bs = append(bs, block...)
+		}
 	}
-	if _, err := chain.InsertChain(bs[:], nil); err != nil {
+	// only insert newly generated blocks
+	if _, err := chain.InsertChain(newBs[:], nil); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
Before this PR, in `TestIsPeriodBlock` and `TestIsTrippEffective`, the chain of blocks is inserted while it still includes some previously inserted blocks, potentially cause the following error when running on path scheme:
```
--- FAIL: TestIsTrippEffective (0.19s)
panic: triedb parent [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421] layer missing [recovered]
        panic: triedb parent [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421] layer missing

goroutine 4016 [running]:
testing.tRunner.func1.2({0x105c97d20, 0x140002d1770})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1634 +0x33c
panic({0x105c97d20?, 0x140002d1770?})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/panic.go:770 +0x124
github.com/ethereum/go-ethereum/consensus/consortium/v2.testIsTrippEffective(0x140000c3a00, {0x10592235d, 0x4})
        /Users/long.nguyen/Documents/GitHub/ronin/consensus/consortium/v2/consortium_test.go:2437 +0xe5c
github.com/ethereum/go-ethereum/consensus/consortium/v2.TestIsTrippEffective(0x140000c3a00)
        /Users/long.nguyen/Documents/GitHub/ronin/consensus/consortium/v2/consortium_test.go:2341 +0x40
testing.tRunner(0x140000c3a00, 0x105df9818)
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1742 +0x318
exit status 2
FAIL    github.com/ethereum/go-ethereum/consensus/consortium/v2 1.631s
```
This PR is to fix it by creating a new list of blocks that only contains newly created blocks.
Run test after fixing:
```
PASS
ok      github.com/ethereum/go-ethereum/consensus/consortium/v2 1.530s
```