### PR TITLE
v2/consortium_test: fix for pbss: do not insert inserted blocks

### DIFF
--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -2219,7 +2219,7 @@ func testSystemTransactionOrder(t *testing.T, scheme string) {
 }
 
 func TestIsPeriodBlock(t *testing.T) {
-	//testIsPeriodBlock(t, rawdb.PathScheme)
+	testIsPeriodBlock(t, rawdb.PathScheme)
 	testIsPeriodBlock(t, rawdb.HashScheme)
 }
 
@@ -2302,7 +2302,7 @@ func testIsPeriodBlock(t *testing.T, scheme string) {
 		block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
 		bs = append(bs, block...)
 	}
-	if _, err := chain.InsertChain(bs[:], nil); err != nil {
+	if _, err := chain.InsertChain(bs[399:], nil); err != nil {
 		panic(err)
 	}
 
@@ -2322,15 +2322,9 @@ func testIsPeriodBlock(t *testing.T, scheme string) {
 	}
 }
 
-/*
-Got issues related to parent layer missing in the test
-panic: triedb parent [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421] layer missing [recovered]
-panic: triedb parent [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421] layer missing
-Will disable this test firstly for further investigation.
-*/
 func TestIsTrippEffective(t *testing.T) {
 	testIsTrippEffective(t, rawdb.HashScheme)
-	// testIsTrippEffective(t, rawdb.PathScheme)
+	testIsTrippEffective(t, rawdb.PathScheme)
 
 }
 
@@ -2417,7 +2411,7 @@ func testIsTrippEffective(t *testing.T, scheme string) {
 		block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
 		bs = append(bs, block...)
 	}
-	if _, err := chain.InsertChain(bs[:], nil); err != nil {
+	if _, err := chain.InsertChain(bs[399:], nil); err != nil {
 		panic(err)
 	}
 

--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -2302,6 +2302,10 @@ func testIsPeriodBlock(t *testing.T, scheme string) {
 		block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
 		bs = append(bs, block...)
 	}
+	// Only the new blocks are inserted here
+	// For path scheme, the number of db diff layers corresponding to blocks are limited to 128
+	// So just the newest 128 blocks can be retrieved from the db
+	// Therefore, the handling of the inserted blocks can result in error since the older blocks can not be retrieved for checking
 	if _, err := chain.InsertChain(bs[399:], nil); err != nil {
 		panic(err)
 	}
@@ -2411,6 +2415,10 @@ func testIsTrippEffective(t *testing.T, scheme string) {
 		block, _ := core.GenerateChain(&chainConfig, bs[len(bs)-1], ethash.NewFaker(), db, 1, callback, true)
 		bs = append(bs, block...)
 	}
+	// Only the new blocks are inserted here
+	// For path scheme, the number of db diff layers corresponding to blocks are limited to 128
+	// So just the newest 128 blocks can be retrieved from the db
+	// Therefore, the handling of the inserted blocks can result in error since the older blocks can not be retrieved for checking
 	if _, err := chain.InsertChain(bs[399:], nil); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR is an alternative for https://github.com/axieinfinity/ronin/pull/612

Before this PR, in `TestIsPeriodBlock` and `TestIsTrippEffective`, the chain of blocks is inserted while it still includes some previously inserted blocks, causing the below error when running on path scheme.

Potential reason:

- There are still logics for correctly handle inserting inserted blocks.
- However, in pathdb, the blocks older than 128 blocks are not directly retrievable from the layer tree, which are already capped to the disk layer. (there are 128 diff layers) => the parent of the being-inserted block cannot be retrieved for processing.
- In hashdb, the old blocks can still be retrieved from disk.
- Therefore, in this 2 tests, the number of blocks inserted are too large to be retrieve, causing the error.

This PR is to fix it by only inserting newly created blocks.

Run test before this PR
```
--- FAIL: TestIsTrippEffective (0.19s)
panic: triedb parent [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421] layer missing [recovered]
        panic: triedb parent [0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421] layer missing

goroutine 4016 [running]:
testing.tRunner.func1.2({0x105c97d20, 0x140002d1770})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1634 +0x33c
panic({0x105c97d20?, 0x140002d1770?})
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/runtime/panic.go:770 +0x124
github.com/ethereum/go-ethereum/consensus/consortium/v2.testIsTrippEffective(0x140000c3a00, {0x10592235d, 0x4})
        /Users/long.nguyen/Documents/GitHub/ronin/consensus/consortium/v2/consortium_test.go:2437 +0xe5c
github.com/ethereum/go-ethereum/consensus/consortium/v2.TestIsTrippEffective(0x140000c3a00)
        /Users/long.nguyen/Documents/GitHub/ronin/consensus/consortium/v2/consortium_test.go:2341 +0x40
testing.tRunner(0x140000c3a00, 0x105df9818)
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.22.3/libexec/src/testing/testing.go:1742 +0x318
exit status 2
FAIL    github.com/ethereum/go-ethereum/consensus/consortium/v2 1.631s
```
Run test after this PR
```
PASS
ok      github.com/ethereum/go-ethereum/consensus/consortium/v2 1.530s
```