### PR TITLE
github/workflows: correct the argument provided to benchstat

### DIFF
--- a/.github/workflows/evm-benchmark.yml
+++ b/.github/workflows/evm-benchmark.yml
@@ -44,9 +44,9 @@ jobs:
           go install golang.org/x/perf/cmd/benchstat@v0.0.0-20240604174448-3b48cf0e0164
           cd core/vm
           if [[ ${{ github.event_name }} = "pull_request" ]]; then
-            ../../script/benchstat.sh -c "-test.v -test.run=^$ -test.bench=BenchmarkEvm" \
+            ../../script/benchstat.sh -f "-test.v -test.run=^$ -test.bench=BenchmarkEvm" \
               -o $(git rev-parse --short origin/master) -n ${{ github.sha }} -c 10 -i
           else
-            ../../script/benchstat.sh -c "-test.v -test.run=^$ -test.bench=BenchmarkEvm" \
+            ../../script/benchstat.sh -f "-test.v -test.run=^$ -test.bench=BenchmarkEvm" \
               -o "$OLD_COMMIT" -n "$NEW_COMMIT" -c 10 -i
           fi


### PR DESCRIPTION
In 0eb8e918e ("script/benchstat: introduce interleave mode when running benchmark"), we change the benchstat script's argument. This commit makes the workflow use the new argument.