### PR TITLE
cmd/ronin/chaincmd: open ancient freezer when init genesis

### DIFF
--- a/cmd/ronin/chaincmd.go
+++ b/cmd/ronin/chaincmd.go
@@ -53,6 +53,7 @@ var (
 			utils.ForceOverrideChainConfigFlag,
 			utils.CachePreimagesFlag,
 			utils.StateSchemeFlag,
+			utils.AncientFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
@@ -226,7 +227,7 @@ func initGenesis(ctx *cli.Context) error {
 	defer stack.Close()
 
 	for _, name := range []string{"chaindata", "lightchaindata"} {
-		chaindb, err := stack.OpenDatabase(name, 0, 0, "", false)
+		chaindb, err := stack.OpenDatabaseWithFreezer(name, 0, 0, ctx.String(utils.AncientFlag.Name), "", false)
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)
 		}

--- a/docker/chainnode/entrypoint.sh
+++ b/docker/chainnode/entrypoint.sh
@@ -92,6 +92,7 @@ elif [[ "$FORCE_INIT" = "true" && "$INIT_FORCE_OVERRIDE_CHAIN_CONFIG" = "true" ]
 elif [ "$FORCE_INIT" = "true" ]; then
   echo "Forcing update chain config with $genesisPath, state_scheme $state_scheme ..."
   ronin init $dbEngine --datadir $datadir --state.scheme $state_scheme $genesisPath
+fi
 
 # password file
 if [[ ! -f $PASSWORD_FILE ]]; then


### PR DESCRIPTION
Before this PR, when initializing genesis, the ancient db is not opened for writing the genesis state, results in data inconsistency in the ancient db. Therefore, when processing the next blocks, the following error occurred
```
CRIT [10-30|04:53:29.422] Failed to truncate state history freezer err="out of range, tail: 0, head: 0, target: 90000"
```
This PR simply open the ancient db for writing genesis state when initializing it.