### PR TITLE
cmd, rawdb: Fix db inspect command when overwriting the tail method in chainfreezer.

### DIFF
--- a/core/rawdb/ancient_utils.go
+++ b/core/rawdb/ancient_utils.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type tableSize struct {
@@ -89,6 +90,10 @@ func inspectFreezers(db ethdb.Database) ([]freezerInfo, error) {
 			infos = append(infos, info)
 
 		case stateFreezerName:
+			if ReadStateScheme(db) != PathScheme {
+				log.Info("Skip inspecting state freezer", "reason", "state freezer is supported for PathScheme only")
+				continue
+			}
 			datadir, err := db.AncientDatadir()
 			if err != nil {
 				return nil, err

--- a/core/rawdb/chain_freezer.go
+++ b/core/rawdb/chain_freezer.go
@@ -73,11 +73,6 @@ func (f *chainFreezer) Close() error {
 	return err
 }
 
-// Tail returns an error as we don't have a backing chain freezer.
-func (f *chainFreezer) Tail() (uint64, error) {
-	return 0, errNotSupported
-}
-
 // freeze is a background thread that periodically checks the blockchain for any
 // import progress and moves ancient data from the fast database into the freezer.
 //


### PR DESCRIPTION
Before 
```
Attaching to node
node    | INFO [11-06|17:14:43.375] Maximum peer count                       ETH=50 LES=0 total=50
node    | INFO [11-06|17:14:43.377] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
node    | INFO [11-06|17:14:43.386] Using pebble as the backing database
node    | INFO [11-06|17:14:43.387] Allocated cache and file handles         database=/ronin/data/ronin/chaindata cache=512.00MiB handles=524,288
node    | INFO [11-06|17:14:43.950] Opened ancient database                  database=/ronin/data/ronin/chaindata/ancient/chain readonly=true
node    | INFO [11-06|17:14:43.952] State scheme set to already existing     scheme=path
node    | INFO [11-06|17:14:43.954] Set global gas cap                       cap=50,000,000
node    | INFO [11-06|17:14:43.955] Initializing the KZG library             backend=gokzg
node    | INFO [11-06|17:14:44.104] Using pebble as the backing database
node    | INFO [11-06|17:14:44.104] Allocated cache and file handles         database=/ronin/data/ronin/chaindata cache=512.00MiB handles=524,288
node    | INFO [11-06|17:14:44.552] Opened ancient database                  database=/ronin/data/ronin/chaindata/ancient/chain readonly=true
node    | INFO [11-06|17:14:52.555] Inspecting database                      count=7,208,000 elapsed=8.000s
node    | INFO [11-06|17:15:00.556] Inspecting database                      count=18,947,000 elapsed=16.000s
node    | INFO [11-06|17:15:08.556] Inspecting database                      count=32,577,000 elapsed=24.001s
node    | INFO [11-06|17:15:16.557] Inspecting database                      count=48,566,000 elapsed=32.001s
node    | INFO [11-06|17:15:24.558] Inspecting database                      count=59,841,000 elapsed=40.003s
node    | INFO [11-06|17:15:32.560] Inspecting database                      count=68,976,000 elapsed=48.005s
node    | INFO [11-06|17:15:40.561] Inspecting database                      count=77,935,000 elapsed=56.006s
node    | INFO [11-06|17:15:48.562] Inspecting database                      count=87,145,000 elapsed=1m4.006s
node    | INFO [11-06|17:15:56.562] Inspecting database                      count=103,938,000 elapsed=1m12.007s
node    | this operation is not supported
node exited with code 1
```

After
```
Attaching to node
node    | INFO [11-07|04:01:29.160] Maximum peer count                       ETH=50 LES=0 total=50
node    | INFO [11-07|04:01:29.163] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
node    | INFO [11-07|04:01:29.169] Using pebble as the backing database
node    | INFO [11-07|04:01:29.169] Allocated cache and file handles         database=/ronin/data/ronin/chaindata cache=512.00MiB handles=524,288
node    | INFO [11-07|04:01:29.884] Opened ancient database                  database=/ronin/data/ronin/chaindata/ancient/chain readonly=true
node    | INFO [11-07|04:01:29.885] State scheme set to already existing     scheme=path
node    | INFO [11-07|04:01:29.888] Set global gas cap                       cap=50,000,000
node    | INFO [11-07|04:01:29.889] Initializing the KZG library             backend=gokzg
node    | INFO [11-07|04:01:30.037] Using pebble as the backing database
node    | INFO [11-07|04:01:30.037] Allocated cache and file handles         database=/ronin/data/ronin/chaindata cache=512.00MiB handles=524,288
node    | INFO [11-07|04:01:30.707] Opened ancient database                  database=/ronin/data/ronin/chaindata/ancient/chain readonly=true
node    | INFO [11-07|04:01:38.735] Inspecting database                      count=16,161,000 elapsed=8.000s
node    | INFO [11-07|04:01:46.735] Inspecting database                      count=38,694,000 elapsed=16.000s
node    | INFO [11-07|04:01:54.736] Inspecting database                      count=60,370,000 elapsed=24.000s
node    | INFO [11-07|04:02:02.736] Inspecting database                      count=79,176,000 elapsed=32.001s
node    | INFO [11-07|04:02:10.736] Inspecting database                      count=93,216,000 elapsed=40.001s
node    | INFO [11-07|04:02:17.710] Opened ancient database                  database=/ronin/data/ronin/chaindata/ancient/state readonly=true
node    | +-----------------------+-------------------------+------------+----------+
node    | |       DATABASE        |        CATEGORY         |    SIZE    |  ITEMS   |
node    | +-----------------------+-------------------------+------------+----------+
node    | | Key-Value store       | Headers                 | 62.16 MiB  |    90015 |
node    | | Key-Value store       | Bodies                  | 93.70 MiB  |    90015 |
node    | | Key-Value store       | Receipt lists           | 46.03 MiB  |    90015 |
node    | | Key-Value store       | Difficulties            | 4.03 MiB   |    90015 |
node    | | Key-Value store       | Block number->hash      | 3.61 MiB   |    90012 |
node    | | Key-Value store       | Block hash->number      | 1.24 GiB   | 32403042 |
node    | | Key-Value store       | Transaction index       | 179.91 MiB |  5098734 |
node    | | Key-Value store       | Bloombit index          | 986.47 MiB | 16207591 |
node    | | Key-Value store       | Contract codes          | 65.02 MiB  |     6609 |
node    | | Key-Value store       | Hash trie nodes         | 0.00 B     |        0 |
node    | | Key-Value store       | Path trie state lookups | 3.52 MiB   |    90003 |
node    | | Key-Value store       | Path trie account nodes | 371.55 MiB |  3185086 |
node    | | Key-Value store       | Path trie storage nodes | 2.91 GiB   | 28248198 |
node    | | Key-Value store       | Trie preimages          | 0.00 B     |        0 |
node    | | Key-Value store       | Account snapshot        | 131.28 MiB |  2291139 |
node    | | Key-Value store       | Storage snapshot        | 1.55 GiB   | 20906095 |
node    | | Key-Value store       | Clique snapshots        | 0.00 B     |        0 |
node    | | Key-Value store       | Consortium snapshots    | 496.77 MiB |   493688 |
node    | | Key-Value store       | Singleton metadata      | 10.11 MiB  |       18 |
node    | | Light client          | CHT trie nodes          | 0.00 B     |        0 |
node    | | Light client          | Bloom trie nodes        | 0.00 B     |        0 |
node    | | Ancient store (Chain) | Receipts                | 5.94 GiB   | 32313028 |
node    | | Ancient store (Chain) | Diffs                   | 336.50 MiB | 32313028 |
node    | | Ancient store (Chain) | Headers                 | 12.93 GiB  | 32313028 |
node    | | Ancient store (Chain) | Hashes                  | 1.14 GiB   | 32313028 |
node    | | Ancient store (Chain) | Bodies                  | 9.93 GiB   | 32313028 |
node    | | Ancient store (State) | Storage.Index           | 220.54 MiB |    90000 |
node    | | Ancient store (State) | Account.Data            | 44.22 MiB  |    90000 |
node    | | Ancient store (State) | Storage.Data            | 34.30 MiB  |    90000 |
node    | | Ancient store (State) | History.Meta            | 13.79 MiB  |    90000 |
node    | | Ancient store (State) | Account.Index           | 24.81 MiB  |    90000 |
node    | +-----------------------+-------------------------+------------+----------+
node    | |                                  TOTAL          | 38.69 GIB  |          |
node    | +-----------------------+-------------------------+-----------
```