### PR TITLE
consortium-v2: move the block timestamp calculation before IsPeriodBlock

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -872,6 +872,14 @@ func (c *Consortium) Prepare(chain consensus.ChainHeaderReader, header *types.He
 		return err
 	}
 
+	// Ensure the timestamp has the correct delay
+	parent := chain.GetHeader(header.ParentHash, number-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+
+	header.Time = c.computeHeaderTime(header, parent, snap)
+
 	// Set the correct difficulty
 	header.Difficulty = CalcDifficulty(snap, coinbase)
 
@@ -926,13 +934,6 @@ func (c *Consortium) Prepare(chain consensus.ChainHeaderReader, header *types.He
 	// Mix digest is reserved for now, set to empty
 	header.MixDigest = common.Hash{}
 
-	// Ensure the timestamp has the correct delay
-	parent := chain.GetHeader(header.ParentHash, number-1)
-	if parent == nil {
-		return consensus.ErrUnknownAncestor
-	}
-
-	header.Time = c.computeHeaderTime(header, parent, snap)
 	return nil
 }
 


### PR DESCRIPTION
IsPeriodBlock uses the block header's timestamp to determine if the block is in new period. So we need to move the block header's timestamp calculation before the logic that calls IsPeriodBlock.