### PR TITLE
consortium-v2: move extraData check with contract into a function

### DIFF
--- a/consensus/consortium/v2/finality/consortium_header.go
+++ b/consensus/consortium/v2/finality/consortium_header.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -122,6 +123,16 @@ func (validator ValidatorWithBlsPub) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&savedValidator)
+}
+
+func (validator ValidatorWithBlsPub) String() string {
+	var blsPublicKey string
+	if validator.BlsPublicKey != nil {
+		blsPublicKey = hex.EncodeToString(validator.BlsPublicKey.Marshal())
+	}
+
+	return fmt.Sprintf("Address: %v, BlsPublicKey: %s, Weight: %d",
+		validator.Address, blsPublicKey, validator.Weight)
 }
 
 // CheckpointValidatorAscending implements the sort interface to allow sorting a list


### PR DESCRIPTION
This commit refactors the logic that checks extraData's validator information with contract data into a separate function. It also adds more information in the error cases.