### PR TITLE
miner/worker: speculatively apply next transaction in parallel

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -142,6 +142,7 @@ var (
 		utils.MinerNoVerifyFlag,
 		utils.MinerBlockProduceLeftoverFlag,
 		utils.MinerBlockSizeReserveFlag,
+		utils.MinerNoSpeculation,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -597,6 +597,11 @@ var (
 		Value:    ethconfig.Defaults.Miner.BlockSizeReserve,
 		Category: flags.MinerCategory,
 	}
+	MinerNoSpeculation = &cli.BoolFlag{
+		Name:     "miner.nospeculation",
+		Usage:    "Disable speculatively committing next transaction",
+		Category: flags.MinerCategory,
+	}
 	// Account settings
 	UnlockedAccountFlag = &cli.StringFlag{
 		Name:     "unlock",
@@ -1775,6 +1780,7 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	if ctx.IsSet(LegacyMinerGasTargetFlag.Name) {
 		log.Warn("The generic --miner.gastarget flag is deprecated and will be removed in the future!")
 	}
+	cfg.NoSpeculation = ctx.Bool(MinerNoSpeculation.Name)
 }
 
 func setWhitelist(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -631,6 +631,36 @@ func NewMessage(
 	}
 }
 
+func NewMessageWithExpiredTimeAndPayer(
+	from common.Address,
+	to *common.Address,
+	nonce uint64,
+	amount *big.Int,
+	gasLimit uint64,
+	gasPrice, gasFeeCap, gasTipCap *big.Int,
+	data []byte,
+	accessList AccessList,
+	isFake bool,
+	expiredTime uint64,
+	payer common.Address,
+) Message {
+	return Message{
+		from:        from,
+		to:          to,
+		nonce:       nonce,
+		amount:      amount,
+		gasLimit:    gasLimit,
+		gasPrice:    gasPrice,
+		gasFeeCap:   gasFeeCap,
+		gasTipCap:   gasTipCap,
+		data:        data,
+		accessList:  accessList,
+		isFake:      isFake,
+		expiredTime: expiredTime,
+		payer:       payer,
+	}
+}
+
 // AsMessage returns the transaction as a core.Message.
 func (tx *Transaction) AsMessage(s Signer, baseFee *big.Int) (Message, error) {
 	msg := Message{

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -55,6 +55,7 @@ type Config struct {
 	Noverify             bool           // Disable remote mining solution verification(only useful in ethash).
 	BlockProduceLeftOver time.Duration
 	BlockSizeReserve     uint64
+	NoSpeculation        bool
 }
 
 // Miner creates blocks and searches for proof-of-work values.


### PR DESCRIPTION
On mining node, when executing the current transaction, we try to speculatively apply the next transaction in parallel to prefetch the storage. As a result, it can help to reduce the execution time of the next actual execution.