### PR TITLE
consortium-v2: only return when failing to verify extraData

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -1304,11 +1304,15 @@ func (c *Consortium) Finalize(chain consensus.ChainHeaderReader, header *types.H
 				}
 			}
 			if c.IsPeriodBlock(chain, header, nil) {
-				return verifyValidatorExtraDataWithContract(checkpointValidators, extraData, true, true)
+				if err := verifyValidatorExtraDataWithContract(checkpointValidators, extraData, true, true); err != nil {
+					return err
+				}
 			}
 		} else {
 			isShillin := c.chainConfig.IsShillin(header.Number)
-			return verifyValidatorExtraDataWithContract(checkpointValidators, extraData, isShillin, false)
+			if err := verifyValidatorExtraDataWithContract(checkpointValidators, extraData, isShillin, false); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
In commit 584db0f668 ("consortium-v2: move extraData check with contract into a function"), we refactor the code and mistakenly return even if we successfully verify extraData. Fix it by checking the error and only return if there is an error when verifying extraData.