### PR TITLE
core/vm: use uint256.Bytes32 and builtin copy to make MSTORE faster

### DIFF
--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -56,49 +56,8 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 		panic("invalid memory: store empty")
 	}
 	// Fill in relevant bits
-	fastWriteToArray32((*[32]byte)(m.store[offset:offset+32]), val)
-}
-
-// fastWriteToArray32 is the same as WriteToArray32 in uint256 package
-// but with the loop unrolling manually for reducing branch instructions
-func fastWriteToArray32(dest *[32]byte, val *uint256.Int) {
-	// Unroll this loop manually
-	//
-	// for i := 0; i < 32; i++ {
-	//     dest[31-i] = byte(val[i/8] >> uint64(8*(i%8)))
-	// }
-	dest[31] = byte(val[0] >> uint64(0))
-	dest[30] = byte(val[0] >> uint64(8))
-	dest[29] = byte(val[0] >> uint64(16))
-	dest[28] = byte(val[0] >> uint64(24))
-	dest[27] = byte(val[0] >> uint64(32))
-	dest[26] = byte(val[0] >> uint64(40))
-	dest[25] = byte(val[0] >> uint64(48))
-	dest[24] = byte(val[0] >> uint64(56))
-	dest[23] = byte(val[1] >> uint64(0))
-	dest[22] = byte(val[1] >> uint64(8))
-	dest[21] = byte(val[1] >> uint64(16))
-	dest[20] = byte(val[1] >> uint64(24))
-	dest[19] = byte(val[1] >> uint64(32))
-	dest[18] = byte(val[1] >> uint64(40))
-	dest[17] = byte(val[1] >> uint64(48))
-	dest[16] = byte(val[1] >> uint64(56))
-	dest[15] = byte(val[2] >> uint64(0))
-	dest[14] = byte(val[2] >> uint64(8))
-	dest[13] = byte(val[2] >> uint64(16))
-	dest[12] = byte(val[2] >> uint64(24))
-	dest[11] = byte(val[2] >> uint64(32))
-	dest[10] = byte(val[2] >> uint64(40))
-	dest[9] = byte(val[2] >> uint64(48))
-	dest[8] = byte(val[2] >> uint64(56))
-	dest[7] = byte(val[3] >> uint64(0))
-	dest[6] = byte(val[3] >> uint64(8))
-	dest[5] = byte(val[3] >> uint64(16))
-	dest[4] = byte(val[3] >> uint64(24))
-	dest[3] = byte(val[3] >> uint64(32))
-	dest[2] = byte(val[3] >> uint64(40))
-	dest[1] = byte(val[3] >> uint64(48))
-	dest[0] = byte(val[3] >> uint64(56))
+	b32 := val.Bytes32()
+	copy(m.store[offset:], b32[:])
 }
 
 // Resize resizes the memory to size


### PR DESCRIPTION
In commit f791124611 ("core/vm: optimize the mstore opcode with loop unrolling"), we optimize the loop that copies each byte by manually unrolling the loop as it seems like Go cannot do that at this time. This makes the code quite ugly and might increase the number of unique instructions executed, creates more pressure to the instruction cache.

This commit instead follows the go-ethereum commit e0a1fd5fdc ("core/vm: optimize Memory.Set32") by using uint256.Bytes32 and builtin copy. The uint256.Bytes32 is inlined and is compiled into fewer instructions 4x (load, bswap, store). The builtin copy can copy 32 bytes by just 2 load-store pairs using 128-bit (16-byte) xmm register.
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
                          │   old.txt    │               new.txt                │
                          │    sec/op    │    sec/op     vs base                │
EvmInsertionSort-8          108.7m ±  6%   104.6m ± 26%        ~ (p=0.631 n=10)
EvmQuickSort-8              6.848m ± 14%   6.633m ±  3%        ~ (p=0.089 n=10)
EvmSignatureValidation-8    15.96µ ±  3%   15.48µ ±  3%        ~ (p=0.052 n=10)
EvmMulticallErcTransfer-8   6.503m ± 15%   6.562m ±  6%        ~ (p=0.912 n=10)
EvmRedBlackTree-8           302.5m ±  4%   305.0m ±  2%        ~ (p=0.684 n=10)
OpMstore-8                  33.47n ± 10%   30.09n ±  6%  -10.07% (p=0.000 n=10)
geomean                     959.9µ         930.0µ         -3.11%
```