### PR TITLE
core/vm, go.mod: update uint256 and use faster method to write to memory (#30868)

### DIFF
--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -56,49 +56,7 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
 		panic("invalid memory: store empty")
 	}
 	// Fill in relevant bits
-	fastWriteToArray32((*[32]byte)(m.store[offset:offset+32]), val)
-}
-
-// fastWriteToArray32 is the same as WriteToArray32 in uint256 package
-// but with the loop unrolling manually for reducing branch instructions
-func fastWriteToArray32(dest *[32]byte, val *uint256.Int) {
-	// Unroll this loop manually
-	//
-	// for i := 0; i < 32; i++ {
-	//     dest[31-i] = byte(val[i/8] >> uint64(8*(i%8)))
-	// }
-	dest[31] = byte(val[0] >> uint64(0))
-	dest[30] = byte(val[0] >> uint64(8))
-	dest[29] = byte(val[0] >> uint64(16))
-	dest[28] = byte(val[0] >> uint64(24))
-	dest[27] = byte(val[0] >> uint64(32))
-	dest[26] = byte(val[0] >> uint64(40))
-	dest[25] = byte(val[0] >> uint64(48))
-	dest[24] = byte(val[0] >> uint64(56))
-	dest[23] = byte(val[1] >> uint64(0))
-	dest[22] = byte(val[1] >> uint64(8))
-	dest[21] = byte(val[1] >> uint64(16))
-	dest[20] = byte(val[1] >> uint64(24))
-	dest[19] = byte(val[1] >> uint64(32))
-	dest[18] = byte(val[1] >> uint64(40))
-	dest[17] = byte(val[1] >> uint64(48))
-	dest[16] = byte(val[1] >> uint64(56))
-	dest[15] = byte(val[2] >> uint64(0))
-	dest[14] = byte(val[2] >> uint64(8))
-	dest[13] = byte(val[2] >> uint64(16))
-	dest[12] = byte(val[2] >> uint64(24))
-	dest[11] = byte(val[2] >> uint64(32))
-	dest[10] = byte(val[2] >> uint64(40))
-	dest[9] = byte(val[2] >> uint64(48))
-	dest[8] = byte(val[2] >> uint64(56))
-	dest[7] = byte(val[3] >> uint64(0))
-	dest[6] = byte(val[3] >> uint64(8))
-	dest[5] = byte(val[3] >> uint64(16))
-	dest[4] = byte(val[3] >> uint64(24))
-	dest[3] = byte(val[3] >> uint64(32))
-	dest[2] = byte(val[3] >> uint64(40))
-	dest[1] = byte(val[3] >> uint64(48))
-	dest[0] = byte(val[3] >> uint64(56))
+	val.PutUint256(m.store[offset:])
 }
 
 // Resize resizes the memory to size

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/graph-gophers/graphql-go v1.3.0
 	github.com/hashicorp/go-bexpr v0.1.10
 	github.com/holiman/bloomfilter/v2 v2.0.3
-	github.com/holiman/uint256 v1.3.0
+	github.com/holiman/uint256 v1.3.2
 	github.com/huin/goupnp v1.1.0
 	github.com/influxdata/influxdb v1.8.3
 	github.com/influxdata/influxdb-client-go/v2 v2.8.0
@@ -76,6 +76,7 @@ require (
 	github.com/grafana/pyroscope-go v1.1.2
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/holiman/billy v0.0.0-20240322075458-72a4e81ec6da
 	github.com/klauspost/compress v1.17.8
 	github.com/pkg/errors v0.9.1
 	github.com/supranational/blst v0.3.11
@@ -112,7 +113,6 @@ require (
 	github.com/google/pprof v0.0.0-20230405160723-4a4c7d95572b // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/herumi/bls-eth-go-binary v1.31.0 // indirect
-	github.com/holiman/billy v0.0.0-20240322075458-72a4e81ec6da // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-ieproxy v0.0.0-20190702010315-6dee0af9227d // indirect

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/holiman/billy v0.0.0-20240322075458-72a4e81ec6da h1:8qEhdMGSUx67L2s5a
 github.com/holiman/billy v0.0.0-20240322075458-72a4e81ec6da/go.mod h1:5GuXa7vkL8u9FkFuWdVvfR5ix8hRB7DbOAaYULamFpc=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
-github.com/holiman/uint256 v1.3.0 h1:4wdcm/tnd0xXdu7iS3ruNvxkWwrb4aeBQv19ayYn8F4=
-github.com/holiman/uint256 v1.3.0/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
+github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
+github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/huin/goupnp v1.1.0 h1:gEe0Dp/lZmPZiDFzJJaOfUpOvv2MKUkoBX8lDrn9vKU=


### PR DESCRIPTION
commit https://github.com/ethereum/go-ethereum/commit/5c58612e12a5131233be5efc9aa9ff55aac4538a.

Updates geth to use the uint256 v1.3.2, and use faster memory-writer to speed up MSTORE.
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
           │   old.txt   │               new.txt               │
           │   sec/op    │   sec/op     vs base                │
OpMstore-8   18.18n ± 8%   12.58n ± 8%  -30.76% (p=0.000 n=10)
```
Link: https://github.com/holiman/uint256/pull/190