### PR TITLE
consortium-v2: add parent list parameter to IsTrippEffective

### DIFF
--- a/consensus/consortium/v2/consortium_test.go
+++ b/consensus/consortium/v2/consortium_test.go
@@ -2587,28 +2587,28 @@ func TestIsTrippEffective(t *testing.T) {
 	// header of block 30
 	header = bs[29].Header()
 	// this header must not be Tripp effective
-	if c.IsTrippEffective(chain, header) {
+	if c.IsTrippEffective(chain, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 
 	// header of block 201
 	// this header must not be Tripp effective
 	header = bs[201].Header()
-	if c.IsTrippEffective(chain, header) {
+	if c.IsTrippEffective(chain, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 
 	// header of block 200
 	// this header must not be Tripp effective
 	header = bs[200].Header()
-	if c.IsTrippEffective(chain, header) {
+	if c.IsTrippEffective(chain, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 
 	// header of block 399
 	// this header must not be Tripp effective
 	header = bs[398].Header()
-	if c.IsTrippEffective(chain, header) {
+	if c.IsTrippEffective(chain, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 
@@ -2628,20 +2628,20 @@ func TestIsTrippEffective(t *testing.T) {
 	// header of block 400
 	// this header must be Tripp effective
 	header = bs[399].Header()
-	if !c.IsTrippEffective(nil, header) {
+	if !c.IsTrippEffective(nil, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 
 	// header of block 402
 	// this header must be Tripp effective
 	header = bs[401].Header()
-	if !c.IsTrippEffective(chain, header) {
+	if !c.IsTrippEffective(chain, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 
 	header = bs[599].Header()
 	// this header must be Tripp effective
-	if !c.IsTrippEffective(chain, header) {
+	if !c.IsTrippEffective(chain, header, nil) {
 		t.Error("fail test Tripp effective")
 	}
 }


### PR DESCRIPTION
This is the same as commit b718105228d9 ("consortium-v2: add parent list parameter to IsPeriodBlock") but with the IsTrippEffective function. The parent list is passed to this function when it is called in the VerifyHeader path.