### PR TITLE
core/vm: make all opcodes proper type (#30925)

### DIFF
--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -166,7 +166,7 @@ const (
 
 // 0x80 range - dups.
 const (
-	DUP1 = 0x80 + iota
+	DUP1 OpCode = 0x80 + iota
 	DUP2
 	DUP3
 	DUP4
@@ -186,7 +186,7 @@ const (
 
 // 0x90 range - swaps.
 const (
-	SWAP1 = 0x90 + iota
+	SWAP1 OpCode = 0x90 + iota
 	SWAP2
 	SWAP3
 	SWAP4


### PR DESCRIPTION
commit https://github.com/ethereum/go-ethereum/commit/5b9a3ea9d2930eb2228c5203d1afe40776e70af3.

Noticed this omission while doing some work on goevmlab. We don't properly type some of the opcodes, but apparently implicit casting works in all the internal usecases.

This makes the debugger show the name of those missing type opcodes instead of just hexadecimal value.