### PR TITLE
core: don't prune blob sidecar in archive node

### DIFF
--- a/cmd/ronin/chaincmd.go
+++ b/cmd/ronin/chaincmd.go
@@ -87,6 +87,7 @@ The dumpgenesis command dumps the genesis block configuration in JSON format to 
 			utils.CacheFlag,
 			utils.SyncModeFlag,
 			utils.GCModeFlag,
+			utils.NoPruningSideCarFlag,
 			utils.SnapshotFlag,
 			utils.CacheDatabaseFlag,
 			utils.CacheGCFlag,

--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -100,6 +100,7 @@ var (
 		utils.SyncModeFlag,
 		utils.ExitWhenSyncedFlag,
 		utils.GCModeFlag,
+		utils.NoPruningSideCarFlag,
 		utils.SnapshotFlag,
 		utils.TxLookupLimitFlag,
 		utils.TriesInMemoryFlag,

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -139,6 +139,7 @@ type CacheConfig struct {
 	SnapshotLimit       int           // Memory allowance (MB) to use for caching snapshot entries in memory
 	Preimages           bool          // Whether to store preimage of trie key to the disk
 	TriesInMemory       int           // The number of tries is kept in memory before pruning
+	NoPruningSideCar    bool          // Whether to disable blob sidecar pruning
 
 	SnapshotWait bool // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 }
@@ -1486,7 +1487,7 @@ func (bc *BlockChain) reorgNeeded(localBlock *types.Block, localTd *big.Int, ext
 
 // pruneBlockSidecars prunes the sidecars of blocks that are older than the keep period
 func (bc *BlockChain) pruneBlockSidecars(db ethdb.KeyValueWriter, curBlock *types.Block) {
-	if curBlock.NumberU64() < uint64(bc.blobPrunePeriod) {
+	if bc.cacheConfig.NoPruningSideCar || curBlock.NumberU64() < uint64(bc.blobPrunePeriod) {
 		return
 	}
 	pruneBlockNumber := curBlock.NumberU64() - uint64(bc.blobPrunePeriod)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -202,6 +202,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			SnapshotLimit:       config.SnapshotCache,
 			Preimages:           config.Preimages,
 			TriesInMemory:       config.TriesInMemory,
+			NoPruningSideCar:    config.NoPruningSideCar,
 		}
 	)
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -143,6 +143,8 @@ type Config struct {
 	NoPruning  bool // Whether to disable pruning and flush everything to disk
 	NoPrefetch bool // Whether to disable prefetching and only load state on demand
 
+	NoPruningSideCar bool // Whether to disable blob sidecar pruning
+
 	TxLookupLimit uint64 `toml:",omitempty"` // The maximum number of blocks from head whose tx indices are reserved.
 
 	// Whitelist of required block number -> hash values to accept


### PR DESCRIPTION
This commit adds a flag --no-pruning-sidecar (default: true) to disable blob sidecar pruning in archive node. Blob sidecar is meant to be pruned, but in the early state where the offchain storage is not available, it might be better to keep it in archive node for debugging.