### PR TITLE
ethclient: support dynamic gas fee, access list, blob transaction in callArg

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -576,6 +576,9 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasTipCap != nil {
 		arg["maxPriorityFeePerGas"] = (*hexutil.Big)(msg.GasTipCap)
 	}
+	if msg.AccessList != nil {
+		arg["accessList"] = msg.AccessList
+	}
 	return arg
 }
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -579,6 +579,12 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.AccessList != nil {
 		arg["accessList"] = msg.AccessList
 	}
+	if msg.BlobGasFeeCap != nil {
+		arg["maxFeePerBlobGas"] = (*hexutil.Big)(msg.BlobGasFeeCap)
+	}
+	if msg.BlobHashes != nil {
+		arg["blobVersionedHashes"] = msg.BlobHashes
+	}
 	return arg
 }
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -570,6 +570,12 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasPrice != nil {
 		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
 	}
+	if msg.GasFeeCap != nil {
+		arg["maxFeePerGas"] = (*hexutil.Big)(msg.GasFeeCap)
+	}
+	if msg.GasTipCap != nil {
+		arg["maxPriorityFeePerGas"] = (*hexutil.Big)(msg.GasTipCap)
+	}
 	return arg
 }
 

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -221,6 +221,15 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	if msg.GasPrice != nil {
 		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
 	}
+	if msg.GasFeeCap != nil {
+		arg["maxFeePerGas"] = (*hexutil.Big)(msg.GasFeeCap)
+	}
+	if msg.GasTipCap != nil {
+		arg["maxPriorityFeePerGas"] = (*hexutil.Big)(msg.GasTipCap)
+	}
+	if msg.AccessList != nil {
+		arg["accessList"] = msg.AccessList
+	}
 	return arg
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -123,6 +123,10 @@ type CallMsg struct {
 	Data      []byte          // input data, usually an ABI-encoded contract method invocation
 
 	AccessList types.AccessList // EIP-2930 access list.
+
+	// For BlobTxType
+	BlobGasFeeCap *big.Int
+	BlobHashes    []common.Hash
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by


### PR DESCRIPTION
- ethclient: fix forwarding 1559 gas fields (#28462)

commit https://github.com/ethereum/go-ethereum/commit/e91cdb49beb4b2a3872b5f2548bf2d6559e4f561.

- ethclient: apply accessList field in toCallArg (#28832)

commit https://github.com/ethereum/go-ethereum/commit/1c488298c807f4daa3cbe260efb88b81902a903d.

- ethereum, ethclient: add blob transaction fields in CallMsg (#28989) 

commit https://github.com/ethereum/go-ethereum/commit/9d537f543990d9013d73433dc58fd0e985d9b2b6.
