### PR TITLE
accounts/abi: context info on unpack-errors (#28529)

### DIFF
--- a/accounts/abi/error.go
+++ b/accounts/abi/error.go
@@ -18,7 +18,6 @@ package abi
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -82,10 +81,10 @@ func (e *Error) String() string {
 
 func (e *Error) Unpack(data []byte) (interface{}, error) {
 	if len(data) < 4 {
-		return "", errors.New("invalid data for unpacking")
+		return "", fmt.Errorf("insufficient data for unpacking: have %d, want at least 4", len(data))
 	}
 	if !bytes.Equal(data[:4], e.ID[:4]) {
-		return "", errors.New("invalid data for unpacking")
+		return "", fmt.Errorf("invalid identifier, have %#x want %#x", data[:4], e.ID[:4])
 	}
 	return e.Inputs.Unpack(data[4:])
 }


### PR DESCRIPTION
Adds contextual information to errors returned by unpack
Cherry-pick: https://github.com/ethereum/go-ethereum/pull/28529 