### PR TITLE
core/state: lock update seen in prefetcher to prevent data race

### DIFF
--- a/consensus/consortium/v2/consortium.go
+++ b/consensus/consortium/v2/consortium.go
@@ -872,6 +872,14 @@ func (c *Consortium) Prepare(chain consensus.ChainHeaderReader, header *types.He
 		return err
 	}
 
+	// Ensure the timestamp has the correct delay
+	parent := chain.GetHeader(header.ParentHash, number-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+
+	header.Time = c.computeHeaderTime(header, parent, snap)
+
 	// Set the correct difficulty
 	header.Difficulty = CalcDifficulty(snap, coinbase)
 
@@ -926,13 +934,6 @@ func (c *Consortium) Prepare(chain consensus.ChainHeaderReader, header *types.He
 	// Mix digest is reserved for now, set to empty
 	header.MixDigest = common.Hash{}
 
-	// Ensure the timestamp has the correct delay
-	parent := chain.GetHeader(header.ParentHash, number-1)
-	if parent == nil {
-		return consensus.ErrUnknownAncestor
-	}
-
-	header.Time = c.computeHeaderTime(header, parent, snap)
 	return nil
 }
 

--- a/core/state/trie_prefetcher.go
+++ b/core/state/trie_prefetcher.go
@@ -314,6 +314,8 @@ func (sf *subfetcher) loop() {
 					ch <- sf.db.CopyTrie(sf.trie)
 
 				default:
+					// Lock the mutex to prevent race condition within the prefetcher
+					sf.lock.Lock()
 					// No termination request yet, prefetch the next entry
 					if _, ok := sf.seen[string(task)]; ok {
 						sf.dups++
@@ -321,6 +323,7 @@ func (sf *subfetcher) loop() {
 						sf.trie.TryGet(task)
 						sf.seen[string(task)] = struct{}{}
 					}
+					sf.lock.Unlock()
 				}
 			}
 


### PR DESCRIPTION
Lock when update the seen in state pre-fetcher to prevent concurrent map read/write to it