### PR TITLE
accounts/abi: fix bigInt topic encoding

### DIFF
--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -42,7 +42,7 @@ func MakeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 			case common.Address:
 				copy(topic[common.HashLength-common.AddressLength:], rule[:])
 			case *big.Int:
-				copy(topic[:], math.U256Bytes(rule))
+				copy(topic[:], math.U256Bytes(new(big.Int).Set(rule)))
 			case bool:
 				if rule {
 					topic[common.HashLength-1] = 1

--- a/accounts/abi/topics.go
+++ b/accounts/abi/topics.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -41,8 +42,7 @@ func MakeTopics(query ...[]interface{}) ([][]common.Hash, error) {
 			case common.Address:
 				copy(topic[common.HashLength-common.AddressLength:], rule[:])
 			case *big.Int:
-				blob := rule.Bytes()
-				copy(topic[common.HashLength-len(blob):], blob)
+				copy(topic[:], math.U256Bytes(rule))
 			case bool:
 				if rule {
 					topic[common.HashLength-1] = 1

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -17,6 +17,7 @@
 package abi
 
 import (
+	"math"
 	"math/big"
 	"reflect"
 	"testing"
@@ -54,9 +55,27 @@ func TestMakeTopics(t *testing.T) {
 			false,
 		},
 		{
-			"support *big.Int types in topics",
-			args{[][]interface{}{{big.NewInt(1).Lsh(big.NewInt(2), 254)}}},
-			[][]common.Hash{{common.Hash{128}}},
+			"support positive *big.Int types in topics",
+			args{[][]interface{}{
+				{big.NewInt(1)},
+				{big.NewInt(1).Lsh(big.NewInt(2), 254)},
+			}},
+			[][]common.Hash{
+				{common.HexToHash("0000000000000000000000000000000000000000000000000000000000000001")},
+				{common.Hash{128}},
+			},
+			false,
+		},
+		{
+			"support negative *big.Int types in topics",
+			args{[][]interface{}{
+				{big.NewInt(-1)},
+				{big.NewInt(math.MinInt64)},
+			}},
+			[][]common.Hash{
+				{common.HexToHash("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")},
+				{common.HexToHash("ffffffffffffffffffffffffffffffffffffffffffffffff8000000000000000")},
+			},
 			false,
 		},
 		{

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -147,6 +147,23 @@ func TestMakeTopics(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("does not mutate big.Int", func(t *testing.T) {
+		t.Parallel()
+		want := [][]common.Hash{{common.HexToHash("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")}}
+
+		in := big.NewInt(-1)
+		got, err := MakeTopics([]interface{}{in})
+		if err != nil {
+			t.Fatalf("makeTopics() error = %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("makeTopics() = %v, want %v", got, want)
+		}
+		if orig := big.NewInt(-1); in.Cmp(orig) != 0 {
+			t.Fatalf("makeTopics() mutated an input parameter from %v to %v", orig, in)
+		}
+	})
 }
 
 type args struct {


### PR DESCRIPTION
- accounts/abi: fix bigInt topic encoding (#28764)

commit https://github.com/ethereum/go-ethereum/commit/d0edc5af4a2f4e8e9961c5da4d710579ff19681f.

Currectly encode the negative bigInt. Currently, bigInt(-1) is encoded as
0000000000...000000000001, while it should be ffffffffff...ffff instead.

- accounts/abi: fix MakeTopics mutation of big.Int inputs (#30785)

commit https://github.com/ethereum/go-ethereum/commit/3c754e2a09d112cd62f4d51f221637f9a147dcc6.

also changed the behavior of the function from just _reading_ the input
`*big.Int` via `Bytes()`, to leveraging `big.U256Bytes` which is documented as
being _destructive_:

This change updates `MakeTopics` to not mutate the original.

Reported-by: eugenioclrc \<eugenioclrc@gmail.com\>