### PR TITLE
core/vm: remove consortiumLog precompiled contract after Cancun

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1963,8 +1963,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(VMEnableDebugFlag.Name) {
 		// TODO(fjl): force-enable this in --dev mode
 		cfg.EnablePreimageRecording = ctx.Bool(VMEnableDebugFlag.Name)
-		// set debug environment to true
-		os.Setenv("DEBUG", "true")
 	}
 
 	if ctx.IsSet(RPCGlobalGasCapFlag.Name) {

--- a/core/vm/consortium_precompiled_contracts.go
+++ b/core/vm/consortium_precompiled_contracts.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -102,22 +101,6 @@ func (c *consortiumLog) RequiredGas(_ []byte) uint64 {
 }
 
 func (c *consortiumLog) Run(input []byte) ([]byte, error) {
-	if os.Getenv("DEBUG") != "true" {
-		return input, nil
-	}
-	_, method, args, err := loadMethodAndArgs(LogContract, input)
-	if err != nil {
-		return nil, err
-	}
-	switch method.Name {
-	case logMethod:
-		if len(args) == 0 {
-			return input, nil
-		}
-		if _, ok := args[0].(string); ok {
-			log.Info("[consortiumLog] log message from smart contract", "message", args[0].(string))
-		}
-	}
 	return input, nil
 }
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -141,6 +141,8 @@ func init() {
 
 	PrecompiledContractsCancun = copyPrecompiledContract(PrecompiledContractsBerlin)
 	PrecompiledContractsCancun[common.BytesToAddress([]byte{10})] = &kzgPointEvaluation{}
+	// Remove consortiumLog precompiled contract after Cancun
+	delete(PrecompiledContractsCancun, common.BytesToAddress([]byte{101}))
 
 	for k := range PrecompiledContractsHomestead {
 		PrecompiledAddressesHomestead = append(PrecompiledAddressesHomestead, k)

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -620,6 +620,19 @@ func TestConsortiumPrecompileQuery(t *testing.T) {
 	if _, ok := precompiledContract.(*kzgPointEvaluation); !ok {
 		t.Fatal("Wrong kzg point evaluation contract")
 	}
+
+	// consortiumLog is removed after Cancun
+	consortiumLogAddr := common.BytesToAddress([]byte{101})
+	_, ok = evm.precompile(caller, consortiumLogAddr)
+	if ok {
+		t.Fatal("consortiumLog is still available after Cancun")
+	}
+	addrs := ActivePrecompiles(evm.chainRules)
+	for _, addr := range addrs {
+		if addr == consortiumLogAddr {
+			t.Fatal("consortiumLog is still available after Cancun")
+		}
+	}
 }
 
 func BenchmarkConsortiumPrecompileQuery(b *testing.B) {


### PR DESCRIPTION
This precompiled contract is unused and may cause the node with environment variable DEBUG=true to halt. So we decide to remove this precompiled contract after Cancun and remove the logic when DEBUG=true, make this precompiled contract always return (input, nil).

Reported-by: Dontonka