### PR TITLE
all: convert time.After to time.NewTimer to avoid leak

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -204,11 +204,14 @@ func (ks *KeyStore) Subscribe(sink chan<- accounts.WalletEvent) event.Subscripti
 // forces a manual refresh (only triggers for systems where the filesystem notifier
 // is not running).
 func (ks *KeyStore) updater() {
+	timer := time.NewTimer(walletRefreshCycle)
+	defer timer.Stop()
 	for {
+		timer.Reset(walletRefreshCycle)
 		// Wait for an account update or a refresh timeout
 		select {
 		case <-ks.changes:
-		case <-time.After(walletRefreshCycle):
+		case <-timer.C:
 		}
 		// Run the wallet refresher
 		ks.refreshWallets()

--- a/consensus/consortium/v1/consortium.go
+++ b/consensus/consortium/v1/consortium.go
@@ -679,10 +679,12 @@ func (c *Consortium) Seal(chain consensus.ChainHeaderReader, block *types.Block,
 	// Wait until sealing is terminated or delay timeout.
 	log.Trace("Waiting for slot to sign and propagate", "delay", common.PrettyDuration(delay))
 	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
 		select {
 		case <-stop:
 			return
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 
 		select {

--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -596,6 +596,9 @@ func (s *MatcherSession) deliverSections(bit uint, sections []uint64, bitsets []
 // of the session, any request in-flight need to be responded to! Empty responses
 // are fine though in that case.
 func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan *Retrieval) {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
 	for {
 		// Allocate a new bloom bit index to retrieve data for, stopping when done
 		bit, ok := s.allocateRetrieval()
@@ -604,6 +607,7 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 		}
 		// Bit allocated, throttle a bit if we're below our batch limit
 		if s.pendingSections(bit) < batch {
+			timer.Reset(wait)
 			select {
 			case <-s.quit:
 				// Session terminating, we can't meaningfully service, abort
@@ -611,7 +615,7 @@ func (s *MatcherSession) Multiplex(batch int, wait time.Duration, mux chan chan 
 				s.deliverSections(bit, []uint64{}, [][]byte{})
 				return
 
-			case <-time.After(wait):
+			case <-timer.C:
 				// Throttling up, fetch whatever's available
 			}
 		}

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -544,10 +544,12 @@ func (s *Service) reportLatency(conn *connWrapper) error {
 		return err
 	}
 	// Wait for the pong request to arrive back
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
 	select {
 	case <-s.pongCh:
 		// Pong delivered, report the latency
-	case <-time.After(5 * time.Second):
+	case <-timer.C:
 		// Ping timeout, abort
 		return errors.New("ping timed out")
 	}

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -207,7 +207,8 @@ func (tab *Table) getNode(id enode.ID) *enode.Node {
 func (tab *Table) closeWorkerTask() {
 	waitTicker := time.NewTicker(1 * time.Millisecond)
 	defer waitTicker.Stop()
-	timeoutChan := time.After(timeoutWorkerTaskClose)
+	timer := time.NewTimer(timeoutWorkerTaskClose)
+	defer timer.Stop()
 	for {
 		select {
 		case <-waitTicker.C:
@@ -216,7 +217,7 @@ func (tab *Table) closeWorkerTask() {
 				return
 			}
 
-		case <-timeoutChan:
+		case <-timer.C:
 			log.Warn("Timeout waiting for workerPoolTask is refill full , force exit it.")
 			return
 		}


### PR DESCRIPTION
In Go before 1.23, we need to call timer.Stop on the timer to allow it to be collected by garbage collector. So using the pattern like <-time.After(...) can lead to memory leak. Convert this pattern to time.NewTimer so that we can call Stop on created timer. This commit does not fix the pattern in tests and unused code (e.g. light, clique, ...)

Reported-by: eugenioclrc \<eugenioclrc@gmail.com\>