### PR TITLE
eth: disable transaction broadcast based on originated peer

### DIFF
--- a/cmd/ronin/main.go
+++ b/cmd/ronin/main.go
@@ -150,6 +150,7 @@ var (
 		utils.NodeKeyFileFlag,
 		utils.NodeKeyHexFlag,
 		utils.DNSDiscoveryFlag,
+		utils.DisableTxBroadcastFromFlag,
 		utils.MainnetFlag,
 		utils.DeveloperFlag,
 		utils.DeveloperPeriodFlag,

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -60,6 +60,8 @@ type Transaction struct {
 	size  atomic.Value
 	from  atomic.Value
 	payer atomic.Value
+
+	noBroadcast bool
 }
 
 // NewTx creates a new transaction.
@@ -530,6 +532,14 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 	cpy := tx.inner.copy()
 	cpy.setSignatureValues(signer.ChainID(), v, r, s)
 	return &Transaction{inner: cpy, time: tx.time}, nil
+}
+
+func (tx *Transaction) IsNoBroadcast() bool {
+	return tx.noBroadcast
+}
+
+func (tx *Transaction) SetNoBroadcast() {
+	tx.noBroadcast = true
 }
 
 // Transactions implements DerivableList for transactions.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -279,18 +279,19 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 	}
 	if eth.handler, err = newHandler(&handlerConfig{
-		NodeID:               eth.p2pServer.Self().ID(),
-		Database:             chainDb,
-		Chain:                eth.blockchain,
-		TxPool:               eth.txPool,
-		Network:              config.NetworkId,
-		Sync:                 config.SyncMode,
-		BloomCache:           uint64(cacheLimit),
-		EventMux:             eth.eventMux,
-		Checkpoint:           checkpoint,
-		Whitelist:            config.Whitelist,
-		DisableRoninProtocol: config.DisableRoninProtocol,
-		VotePool:             votePool,
+		NodeID:                 eth.p2pServer.Self().ID(),
+		Database:               chainDb,
+		Chain:                  eth.blockchain,
+		TxPool:                 eth.txPool,
+		Network:                config.NetworkId,
+		Sync:                   config.SyncMode,
+		BloomCache:             uint64(cacheLimit),
+		EventMux:               eth.eventMux,
+		Checkpoint:             checkpoint,
+		Whitelist:              config.Whitelist,
+		DisableRoninProtocol:   config.DisableRoninProtocol,
+		VotePool:               votePool,
+		DisableTxBroadcastFrom: config.DisableTxBroadcastFrom,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -230,6 +230,9 @@ type Config struct {
 
 	// Send additional chain event
 	EnableAdditionalChainEvent bool
+
+	// Don't broadcast transactions that are originated from these peer ids
+	DisableTxBroadcastFrom []string
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -112,6 +112,11 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 		return h.txFetcher.Enqueue(peer.ID(), *packet, false)
 
 	case *eth.PooledTransactionsPacket:
+		if _, ok := h.disableTxBroadcastFrom[peer.ID()]; ok {
+			for _, tx := range *packet {
+				tx.SetNoBroadcast()
+			}
+		}
 		return h.txFetcher.Enqueue(peer.ID(), *packet, true)
 
 	default:

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -455,7 +455,7 @@ func answerGetPooledTransactions(backend Backend, query GetPooledTransactionsPac
 		}
 		// Retrieve the requested transaction, skipping if unknown to us
 		tx := backend.TxPool().Get(hash)
-		if tx == nil {
+		if tx == nil || tx.IsNoBroadcast() {
 			continue
 		}
 		// If known, encode and queue for response packet

--- a/p2p/enode/urlv4.go
+++ b/p2p/enode/urlv4.go
@@ -71,7 +71,7 @@ func MustParseV4(rawurl string) *Node {
 //    enode://<hex node id>@10.3.58.6:30303?discport=30301
 func ParseV4(rawurl string) (*Node, error) {
 	if m := incompleteNodeURL.FindStringSubmatch(rawurl); m != nil {
-		id, err := parsePubkey(m[1])
+		id, err := ParsePubkey(m[1])
 		if err != nil {
 			return nil, fmt.Errorf("invalid public key (%v)", err)
 		}
@@ -123,7 +123,7 @@ func parseComplete(rawurl string) (*Node, error) {
 	if u.User == nil {
 		return nil, errors.New("does not contain node ID")
 	}
-	if id, err = parsePubkey(u.User.String()); err != nil {
+	if id, err = ParsePubkey(u.User.String()); err != nil {
 		return nil, fmt.Errorf("invalid public key (%v)", err)
 	}
 	// Parse the IP address.
@@ -154,8 +154,8 @@ func parseComplete(rawurl string) (*Node, error) {
 	return NewV4(id, ip, int(tcpPort), int(udpPort)), nil
 }
 
-// parsePubkey parses a hex-encoded secp256k1 public key.
-func parsePubkey(in string) (*ecdsa.PublicKey, error) {
+// ParsePubkey parses a hex-encoded secp256k1 public key.
+func ParsePubkey(in string) (*ecdsa.PublicKey, error) {
 	b, err := hex.DecodeString(in)
 	if err != nil {
 		return nil, err

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -158,7 +158,7 @@ var parseNodeTests = []struct {
 }
 
 func hexPubkey(h string) *ecdsa.PublicKey {
-	k, err := parsePubkey(h)
+	k, err := ParsePubkey(h)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This commit adds a flag --disable-tx-broadcast.from so that node operator can provide enode ids (e.g. --disable-tx-broadcast.from cfa5f00c55eba79f359c9d95f5c0b2bb8e173867ffbb6e212c6799a52918502519e56650970e34caf1cd17418d4da46c3243588578886c3b4f8c42d1934bf108). Transaction originated from the peers have those enode ids will not be broadcasted to any other peers.