### PR TITLE
txpool, evm: skip blacklist and whitelist deployer check after Venoki

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -163,7 +163,8 @@ func applyTransaction(
 
 	// Check if sender and recipient are blacklisted
 	payer := msg.Payer()
-	if config.Consortium != nil && config.IsOdysseus(blockNumber) {
+	// After the Venoki hardfork, all addresses now can submit transaction
+	if config.Consortium != nil && config.IsOdysseus(blockNumber) && !config.IsVenoki(blockNumber) {
 		contractAddr := config.BlacklistContractAddress
 		if state.IsAddressBlacklisted(statedb, contractAddr, &from) ||
 			state.IsAddressBlacklisted(statedb, contractAddr, msg.To()) ||

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -383,7 +383,8 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		}
 
 		// Check if sender, payer and recipient are blacklisted
-		if opts.Config.Consortium != nil && opts.Config.IsOdysseus(opts.Head.Number) {
+		// This is only affective from Odysseus to Venoki to prevent blacklisted address/contract
+		if opts.Config.Consortium != nil && opts.Config.IsOdysseus(opts.Head.Number) && !opts.Config.IsVenoki(opts.Head.Number) {
 			contractAddr := opts.Config.BlacklistContractAddress
 			if state.IsAddressBlacklisted(opts.State, contractAddr, &from) ||
 				state.IsAddressBlacklisted(opts.State, contractAddr, tx.To()) ||

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -365,9 +365,12 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 	}
 
 	if opts.Config != nil {
+		// The whitelisted deployer logic is not affective after Venoki
 		if tx.To() == nil && opts.Config.Consortium != nil {
 			var whitelisted bool
-			if opts.Config.IsAntenna(opts.Head.Number) {
+			if opts.Config.IsVenoki(opts.Head.Number) {
+				whitelisted = true
+			} else if opts.Config.IsAntenna(opts.Head.Number) {
 				whitelisted = state.IsWhitelistedDeployerV2(
 					opts.State,
 					from,

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -528,16 +528,18 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 		}
 	}
 
-	// Handle latest hardfork firstly.
-	if evm.chainRules.IsAntenna {
-		if !evm.StateDB.ValidDeployerV2(caller.Address(), evm.Context.Time, evm.ChainConfig().WhiteListDeployerContractV2Address) {
-			captureTraceEarly(ErrExecutionReverted)
-			return nil, common.Address{}, gas, ErrExecutionReverted
-		}
-	} else if evm.chainRules.IsOdysseusFork {
-		if !evm.StateDB.ValidDeployer(caller.Address()) {
-			captureTraceEarly(ErrExecutionReverted)
-			return nil, common.Address{}, gas, ErrExecutionReverted
+	// After Venoki, no need to check for whitelisted deployer anymore
+	if !evm.chainRules.IsVenoki {
+		if evm.chainRules.IsAntenna {
+			if !evm.StateDB.ValidDeployerV2(caller.Address(), evm.Context.Time, evm.ChainConfig().WhiteListDeployerContractV2Address) {
+				captureTraceEarly(ErrExecutionReverted)
+				return nil, common.Address{}, gas, ErrExecutionReverted
+			}
+		} else if evm.chainRules.IsOdysseusFork {
+			if !evm.StateDB.ValidDeployer(caller.Address()) {
+				captureTraceEarly(ErrExecutionReverted)
+				return nil, common.Address{}, gas, ErrExecutionReverted
+			}
 		}
 	}
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -63,8 +63,11 @@ func (evm *EVM) precompile(caller ContractRef, addr common.Address) (Precompiled
 			return contract, isPrecompile
 		}
 	}
-	if c := evm.ChainConfig().BlacklistContractAddress; evm.chainRules.IsOdysseusFork && evm.StateDB.Blacklisted(c, &addr) {
-		return &blacklistedAddress{}, true
+	// Blacklisted contract is only effective from Odysseus to Venoki
+	if evm.chainRules.IsOdysseusFork && !evm.chainRules.IsVenoki {
+		if c := evm.ChainConfig().BlacklistContractAddress; evm.StateDB.Blacklisted(c, &addr) {
+			return &blacklistedAddress{}, true
+		}
 	}
 
 	var precompiles map[common.Address]PrecompiledContract


### PR DESCRIPTION
After Venoki, we don't have to check for whitelisted and blacklisted contract deployers anymore.
This help boost performance by not access to state for checking.